### PR TITLE
Implement a simple log wrapper, plumb it into the parsers, and produce a JSON report

### DIFF
--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>picocli</artifactId>
             <version>4.6.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>3.7.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tool/src/main/java/org/datacommons/tool/GenMcf.java
+++ b/tool/src/main/java/org/datacommons/tool/GenMcf.java
@@ -83,9 +83,10 @@ class GenMcf implements Callable<Integer> {
     BufferedWriter writer = new BufferedWriter(new FileWriter(outPath.toString()));
 
     LogWrapper logCtx = new LogWrapper(Debug.Log.newBuilder(), parent.outputDir.toPath());
+    Processor processor = new Processor(logCtx);
     Integer retVal = 0;
     try {
-      Processor.processTables(tmcfFiles.get(0), csvFiles, delimiter, writer, logCtx);
+      processor.processTables(tmcfFiles.get(0), csvFiles, delimiter, writer);
     } catch (DCTooManyFailuresException ex) {
       // Regardless of the failures, we will dump the logCtx and exit.
       retVal = -1;

--- a/tool/src/main/java/org/datacommons/tool/GenMcf.java
+++ b/tool/src/main/java/org/datacommons/tool/GenMcf.java
@@ -79,7 +79,7 @@ class GenMcf implements Callable<Integer> {
     }
 
     Path outPath = Paths.get(parent.outputDir.getPath(), "generated.mcf");
-    logger.info("Writing to {}", outPath.toAbsolutePath().normalize().toString());
+    logger.info("Writing generated MCF to {}", outPath.toAbsolutePath().normalize().toString());
     BufferedWriter writer = new BufferedWriter(new FileWriter(outPath.toString()));
 
     LogWrapper logCtx = new LogWrapper(Debug.Log.newBuilder(), parent.outputDir.toPath());
@@ -91,7 +91,7 @@ class GenMcf implements Callable<Integer> {
       retVal = -1;
     }
     writer.close();
-    logCtx.writeLog(false);
+    logCtx.persistLog(false);
     return retVal;
   }
 }

--- a/tool/src/main/java/org/datacommons/tool/GenMcf.java
+++ b/tool/src/main/java/org/datacommons/tool/GenMcf.java
@@ -81,7 +81,7 @@ class GenMcf implements Callable<Integer> {
     String directory = parent.outputDir == null ? "." : parent.outputDir.getPath();
     Debug.Log.Builder logCtx = Debug.Log.newBuilder();
     Path outPath = Paths.get(directory, "generated.mcf");
-    logger.info("Writing to {}", outPath.toString());
+    logger.info("Writing to {}", outPath.toAbsolutePath().toString());
     BufferedWriter writer = new BufferedWriter(new FileWriter(outPath.toString()));
     Integer retVal = 0;
     try {

--- a/tool/src/main/java/org/datacommons/tool/GenMcf.java
+++ b/tool/src/main/java/org/datacommons/tool/GenMcf.java
@@ -85,7 +85,7 @@ class GenMcf implements Callable<Integer> {
     Integer retVal = 0;
     try {
       Processor.processTables(tmcfFiles.get(0), csvFiles, delimiter, writer, logCtx);
-    } catch (TooManyFailuresException ex) {
+    } catch (DCTooManyFailuresException ex) {
       // Regardless of the failures, we will dump the logCtx and exit.
       retVal = -1;
     }

--- a/tool/src/main/java/org/datacommons/tool/GenMcf.java
+++ b/tool/src/main/java/org/datacommons/tool/GenMcf.java
@@ -78,11 +78,11 @@ class GenMcf implements Callable<Integer> {
       delimiter = nTsv > 0 ? '\t' : ',';
     }
 
-    String directory = parent.outputDir == null ? "." : parent.outputDir.getPath();
-    Debug.Log.Builder logCtx = Debug.Log.newBuilder();
-    Path outPath = Paths.get(directory, "generated.mcf");
-    logger.info("Writing to {}", outPath.toAbsolutePath().toString());
+    Path outPath = Paths.get(parent.outputDir.getPath(), "generated.mcf");
+    logger.info("Writing to {}", outPath.toAbsolutePath().normalize().toString());
     BufferedWriter writer = new BufferedWriter(new FileWriter(outPath.toString()));
+
+    LogWrapper logCtx = new LogWrapper(Debug.Log.newBuilder(), parent.outputDir.toPath());
     Integer retVal = 0;
     try {
       Processor.processTables(tmcfFiles.get(0), csvFiles, delimiter, writer, logCtx);
@@ -91,8 +91,7 @@ class GenMcf implements Callable<Integer> {
       retVal = -1;
     }
     writer.close();
-
-    LogWrapper.writeLog(logCtx, Paths.get(directory, "report.json"));
+    logCtx.writeLog(false);
     return retVal;
   }
 }

--- a/tool/src/main/java/org/datacommons/tool/GenMcf.java
+++ b/tool/src/main/java/org/datacommons/tool/GenMcf.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Callable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.datacommons.proto.Debug;
+import org.datacommons.util.LogWrapper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "genmcf", description = "Generate Instance MCF from TMCF/CSV files")
@@ -91,7 +92,7 @@ class GenMcf implements Callable<Integer> {
     }
     writer.close();
 
-    Processor.writeLog(logCtx, Paths.get(directory, "report.json"));
+    LogWrapper.writeLog(logCtx, Paths.get(directory, "report.json"));
     return retVal;
   }
 }

--- a/tool/src/main/java/org/datacommons/tool/GenMcf.java
+++ b/tool/src/main/java/org/datacommons/tool/GenMcf.java
@@ -84,14 +84,14 @@ class GenMcf implements Callable<Integer> {
     BufferedWriter writer = new BufferedWriter(new FileWriter(outPath.toString()));
     Integer retVal = 0;
     try {
-      Processor.processTables(tmcfFiles.get(0), csvFiles, delimiter, writer, logCtx, logger);
+      Processor.processTables(tmcfFiles.get(0), csvFiles, delimiter, writer, logCtx);
     } catch (TooManyFailuresException ex) {
       // Regardless of the failures, we will dump the logCtx and exit.
       retVal = -1;
     }
     writer.close();
 
-    Processor.writeLog(logCtx, Paths.get(directory, "report.json"), logger);
+    Processor.writeLog(logCtx, Paths.get(directory, "report.json"));
     return retVal;
   }
 }

--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -94,7 +94,7 @@ class Lint implements Callable<Integer> {
       // Regardless of the failures, we will dump the logCtx and exit.
       retVal = -1;
     }
-    logCtx.writeLog(false);
+    logCtx.persistLog(false);
     return retVal;
   }
 }

--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -81,13 +81,13 @@ class Lint implements Callable<Integer> {
     Integer retVal = 0;
     try {
       for (File f : mcfFiles) {
-        Processor.processNodes(Mcf.McfType.INSTANCE_MCF, f, logCtx, logger);
+        Processor.processNodes(Mcf.McfType.INSTANCE_MCF, f, logCtx);
       }
       if (!csvFiles.isEmpty()) {
-        Processor.processTables(tmcfFiles.get(0), csvFiles, delimiter, null, logCtx, logger);
+        Processor.processTables(tmcfFiles.get(0), csvFiles, delimiter, null, logCtx);
       } else {
         for (File f : tmcfFiles) {
-          Processor.processNodes(Mcf.McfType.TEMPLATE_MCF, f, logCtx, logger);
+          Processor.processNodes(Mcf.McfType.TEMPLATE_MCF, f, logCtx);
         }
       }
     } catch (TooManyFailuresException ex) {
@@ -95,8 +95,9 @@ class Lint implements Callable<Integer> {
       retVal = -1;
     }
 
+    logger.error(logCtx.toString());
     String directory = parent.outputDir == null ? "." : parent.outputDir.getPath();
-    Processor.writeLog(logCtx, Paths.get(directory, "report.json"), logger);
+    Processor.writeLog(logCtx, Paths.get(directory, "report.json"));
     return retVal;
   }
 }

--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -95,7 +95,6 @@ class Lint implements Callable<Integer> {
       retVal = -1;
     }
 
-    logger.error(logCtx.toString());
     String directory = parent.outputDir == null ? "." : parent.outputDir.getPath();
     Processor.writeLog(logCtx, Paths.get(directory, "report.json"));
     return retVal;

--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.datacommons.proto.Debug;
 import org.datacommons.proto.Mcf;
+import org.datacommons.util.LogWrapper;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "lint", description = "Run various checks on input MCF/TMCF/CSV files")
@@ -96,7 +97,7 @@ class Lint implements Callable<Integer> {
     }
 
     String directory = parent.outputDir == null ? "." : parent.outputDir.getPath();
-    Processor.writeLog(logCtx, Paths.get(directory, "report.json"));
+    LogWrapper.writeLog(logCtx, Paths.get(directory, "report.json"));
     return retVal;
   }
 }

--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -90,7 +90,7 @@ class Lint implements Callable<Integer> {
           Processor.processNodes(Mcf.McfType.TEMPLATE_MCF, f, logCtx);
         }
       }
-    } catch (TooManyFailuresException ex) {
+    } catch (DCTooManyFailuresException ex) {
       // Regardless of the failures, we will dump the logCtx and exit.
       retVal = -1;
     }

--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -78,16 +78,17 @@ class Lint implements Callable<Integer> {
           spec.commandLine(), "Please provide one .tmcf file with CSV/TSV files");
     }
     LogWrapper logCtx = new LogWrapper(Debug.Log.newBuilder(), parent.outputDir.toPath());
+    Processor processor = new Processor(logCtx);
     Integer retVal = 0;
     try {
       for (File f : mcfFiles) {
-        Processor.processNodes(Mcf.McfType.INSTANCE_MCF, f, logCtx);
+        processor.processNodes(Mcf.McfType.INSTANCE_MCF, f);
       }
       if (!csvFiles.isEmpty()) {
-        Processor.processTables(tmcfFiles.get(0), csvFiles, delimiter, null, logCtx);
+        processor.processTables(tmcfFiles.get(0), csvFiles, delimiter, null);
       } else {
         for (File f : tmcfFiles) {
-          Processor.processNodes(Mcf.McfType.TEMPLATE_MCF, f, logCtx);
+          processor.processNodes(Mcf.McfType.TEMPLATE_MCF, f);
         }
       }
     } catch (DCTooManyFailuresException ex) {

--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -3,7 +3,6 @@ package org.datacommons.tool;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -78,7 +77,7 @@ class Lint implements Callable<Integer> {
       throw new CommandLine.ParameterException(
           spec.commandLine(), "Please provide one .tmcf file with CSV/TSV files");
     }
-    Debug.Log.Builder logCtx = Debug.Log.newBuilder();
+    LogWrapper logCtx = new LogWrapper(Debug.Log.newBuilder(), parent.outputDir.toPath());
     Integer retVal = 0;
     try {
       for (File f : mcfFiles) {
@@ -95,9 +94,7 @@ class Lint implements Callable<Integer> {
       // Regardless of the failures, we will dump the logCtx and exit.
       retVal = -1;
     }
-
-    String directory = parent.outputDir == null ? "." : parent.outputDir.getPath();
-    LogWrapper.writeLog(logCtx, Paths.get(directory, "report.json"));
+    logCtx.writeLog(false);
     return retVal;
   }
 }

--- a/tool/src/main/java/org/datacommons/tool/Main.java
+++ b/tool/src/main/java/org/datacommons/tool/Main.java
@@ -14,6 +14,7 @@ class Main {
   @CommandLine.Option(
       names = {"-o", "--output-dir"},
       description = "Directory to write output files. Default is current working directory.",
+      defaultValue = ".",
       scope = CommandLine.ScopeType.INHERIT)
   public File outputDir;
 

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -1,9 +1,14 @@
 package org.datacommons.tool;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.List;
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Logger;
 import org.datacommons.proto.Debug;
 import org.datacommons.proto.Mcf;
@@ -11,16 +16,31 @@ import org.datacommons.util.McfParser;
 import org.datacommons.util.McfUtil;
 import org.datacommons.util.TmcfCsvParser;
 
+class TooManyFailuresException extends Exception {
+  public TooManyFailuresException() {}
+
+  public TooManyFailuresException(String message) {
+    super(message);
+  }
+}
+
 public class Processor {
+  private static final int MAX_ERROR_LIMIT = 10;
+
   public static void processNodes(
-      Mcf.McfType type, File file, Debug.Log.Builder logCtx, Logger logger) throws IOException {
+      Mcf.McfType type, File file, Debug.Log.Builder logCtx, Logger logger)
+      throws IOException, TooManyFailuresException {
     int numNodesProcessed = 0;
     logger.debug("Checking {}", file.getName());
     // TODO: isResolved is more allowing, be stricter.
     McfParser parser = McfParser.init(type, file.getPath(), false, logCtx);
     Mcf.McfGraph n;
+    boolean hasError = false;
     while ((n = parser.parseNextNode()) != null) {
       numNodesProcessed++;
+      if (shouldBail(logCtx, logger)) {
+        throw new TooManyFailuresException("processNodes encountered too many failures");
+      }
     }
     logger.info("Checked {} with {} nodes", file.getName(), numNodesProcessed);
   }
@@ -32,8 +52,9 @@ public class Processor {
       BufferedWriter writer,
       Debug.Log.Builder logCtx,
       Logger logger)
-      throws IOException {
+      throws IOException, TooManyFailuresException {
     logger.debug("TMCF " + tmcfFile.getName());
+    boolean hasError = false;
     for (File csvFile : csvFiles) {
       logger.debug("Checking CSV " + csvFile.getPath());
       TmcfCsvParser parser =
@@ -46,6 +67,9 @@ public class Processor {
         if (writer != null) {
           writer.write(McfUtil.serializeMcfGraph(g, false));
         }
+        if (shouldBail(logCtx, logger)) {
+          throw new TooManyFailuresException("processTables encountered too many failures");
+        }
       }
       logger.info(
           "Checked CSV {} ({} rows, {} nodes)",
@@ -53,5 +77,25 @@ public class Processor {
           numRowsProcessed,
           numNodesProcessed);
     }
+  }
+
+  public static void writeLog(Debug.Log.Builder logCtx, Path logPath, Logger logger)
+      throws InvalidProtocolBufferException, IOException {
+    logger.info("Writing log to {}", logPath.toString());
+    File logFile = new File(logPath.toString());
+    FileUtils.writeStringToFile(
+        logFile, JsonFormat.printer().print(logCtx), StandardCharsets.UTF_8);
+  }
+
+  private static boolean shouldBail(Debug.Log.Builder logCtx, Logger logger) {
+    if (logCtx.getLevelSummaryOrDefault("LEVEL_FATAL", 0) > 0) {
+      logger.error("Found a fatal log error");
+      return true;
+    }
+    if (logCtx.getLevelSummaryOrDefault("LEVEL_ERROR", 0) > MAX_ERROR_LIMIT) {
+      logger.error("Exceeded over {} errors!", MAX_ERROR_LIMIT);
+      return true;
+    }
+    return false;
   }
 }

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -1,18 +1,14 @@
 package org.datacommons.tool;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.util.JsonFormat;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.List;
-import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.datacommons.proto.Debug;
 import org.datacommons.proto.Mcf;
+import org.datacommons.util.LogWrapper;
 import org.datacommons.util.McfParser;
 import org.datacommons.util.McfUtil;
 import org.datacommons.util.TmcfCsvParser;
@@ -28,11 +24,9 @@ class DCTooManyFailuresException extends Exception {
 public class Processor {
   private static final Logger logger = LogManager.getLogger(Processor.class);
 
-  private static final int MAX_ERROR_LIMIT = 50;
-
   public static void processNodes(Mcf.McfType type, File file, Debug.Log.Builder logCtx)
       throws IOException, DCTooManyFailuresException {
-    int numNodesProcessed = 0;
+    long numNodesProcessed = 0;
     logger.debug("Checking {}", file.getName());
     // TODO: isResolved is more allowing, be stricter.
     McfParser parser = McfParser.init(type, file.getPath(), false, logCtx);
@@ -40,9 +34,10 @@ public class Processor {
     boolean hasError = false;
     while ((n = parser.parseNextNode()) != null) {
       numNodesProcessed++;
-      if (shouldBail(logCtx, logger)) {
+      if (LogWrapper.loggedTooManyFailures(logCtx)) {
         throw new DCTooManyFailuresException("processNodes encountered too many failures");
       }
+      maybePrintStatus(numNodesProcessed, "nodes", file.getName(), logCtx);
     }
     logger.info("Checked {} with {} nodes", file.getName(), numNodesProcessed);
   }
@@ -61,16 +56,17 @@ public class Processor {
       TmcfCsvParser parser =
           TmcfCsvParser.init(tmcfFile.getPath(), csvFile.getPath(), delimiter, logCtx);
       Mcf.McfGraph g;
-      int numNodesProcessed = 0, numRowsProcessed = 0;
+      long numNodesProcessed = 0, numRowsProcessed = 0;
       while ((g = parser.parseNextRow()) != null) {
         numNodesProcessed += g.getNodesCount();
         numRowsProcessed++;
         if (writer != null) {
           writer.write(McfUtil.serializeMcfGraph(g, false));
         }
-        if (shouldBail(logCtx, logger)) {
+        if (LogWrapper.loggedTooManyFailures(logCtx)) {
           throw new DCTooManyFailuresException("processTables encountered too many failures");
         }
+        maybePrintStatus(numRowsProcessed, "rows", csvFile.getName(), logCtx);
       }
       logger.info(
           "Checked CSV {} ({} rows, {} nodes)",
@@ -80,36 +76,11 @@ public class Processor {
     }
   }
 
-  public static void writeLog(Debug.Log.Builder logCtx, Path logPath)
-      throws InvalidProtocolBufferException, IOException {
-    if (logCtx.getLevelSummaryMap().isEmpty()) {
-      logger.info("Found no warnings or errors!");
-      return;
+  private static void maybePrintStatus(
+      long count, String thing, String fileName, Debug.Log.Builder logCtx) {
+    if (count > 0 && count % 100000 == 0) {
+      logger.info(
+          "Processed {} {} of {}.  {}.", count, thing, fileName, LogWrapper.logSummary(logCtx));
     }
-    logger.info("Failures: {}.  Writing details to {}", logSummary(logCtx), logPath.toString());
-    File logFile = new File(logPath.toString());
-    FileUtils.writeStringToFile(
-        logFile, JsonFormat.printer().print(logCtx), StandardCharsets.UTF_8);
-  }
-
-  private static String logSummary(Debug.Log.Builder logCtx) {
-    return logCtx.getLevelSummaryMap().getOrDefault("LEVEL_FATAL", 0L)
-        + " fatal, "
-        + logCtx.getLevelSummaryMap().getOrDefault("LEVEL_ERROR", 0L)
-        + " error(s), "
-        + logCtx.getLevelSummaryMap().getOrDefault("LEVEL_WARNING", 0L)
-        + " warning(s)";
-  }
-
-  private static boolean shouldBail(Debug.Log.Builder logCtx, Logger logger) {
-    if (logCtx.getLevelSummaryOrDefault("LEVEL_FATAL", 0) > 0) {
-      logger.error("Found a fatal failure. Quitting!");
-      return true;
-    }
-    if (logCtx.getLevelSummaryOrDefault("LEVEL_ERROR", 0) > MAX_ERROR_LIMIT) {
-      logger.error("Found too many failures. Quitting!");
-      return true;
-    }
-    return false;
   }
 }

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -82,10 +82,23 @@ public class Processor {
 
   public static void writeLog(Debug.Log.Builder logCtx, Path logPath)
       throws InvalidProtocolBufferException, IOException {
-    logger.info("Writing log to {}", logPath.toString());
+    if (logCtx.getLevelSummaryMap().isEmpty()) {
+      logger.info("Found no warnings or errors!");
+      return;
+    }
+    logger.info("Failures: {}.  Writing details to {}", logSummary(logCtx), logPath.toString());
     File logFile = new File(logPath.toString());
     FileUtils.writeStringToFile(
         logFile, JsonFormat.printer().print(logCtx), StandardCharsets.UTF_8);
+  }
+
+  private static String logSummary(Debug.Log.Builder logCtx) {
+    return logCtx.getLevelSummaryMap().getOrDefault("LEVEL_FATAL", 0L)
+        + " fatal, "
+        + logCtx.getLevelSummaryMap().getOrDefault("LEVEL_ERROR", 0L)
+        + " error(s), "
+        + logCtx.getLevelSummaryMap().getOrDefault("LEVEL_WARNING", 0L)
+        + " warning(s)";
   }
 
   private static boolean shouldBail(Debug.Log.Builder logCtx, Logger logger) {

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -22,8 +22,13 @@ class DCTooManyFailuresException extends Exception {
 
 public class Processor {
   private static final Logger logger = LogManager.getLogger(Processor.class);
+  private LogWrapper logCtx;
 
-  public static void processNodes(Mcf.McfType type, File file, LogWrapper logCtx)
+  public Processor(LogWrapper logCtx) {
+    this.logCtx = logCtx;
+  }
+
+  public void processNodes(Mcf.McfType type, File file)
       throws IOException, DCTooManyFailuresException {
     long numNodesProcessed = 0;
     logger.debug("Checking {}", file.getName());
@@ -41,8 +46,8 @@ public class Processor {
     logger.info("Checked {} with {} nodes", file.getName(), numNodesProcessed);
   }
 
-  public static void processTables(
-      File tmcfFile, List<File> csvFiles, char delimiter, BufferedWriter writer, LogWrapper logCtx)
+  public void processTables(
+      File tmcfFile, List<File> csvFiles, char delimiter, BufferedWriter writer)
       throws IOException, DCTooManyFailuresException {
     logger.debug("TMCF " + tmcfFile.getName());
     for (File csvFile : csvFiles) {

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -17,7 +17,7 @@ public class Processor {
     int numNodesProcessed = 0;
     logger.debug("Checking {}", file.getName());
     // TODO: isResolved is more allowing, be stricter.
-    McfParser parser = McfParser.init(type, file.getPath(), false);
+    McfParser parser = McfParser.init(type, file.getPath(), false, logCtx);
     Mcf.McfGraph n;
     while ((n = parser.parseNextNode()) != null) {
       numNodesProcessed++;

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -50,7 +50,6 @@ public class Processor {
       Debug.Log.Builder logCtx)
       throws IOException, DCTooManyFailuresException {
     logger.debug("TMCF " + tmcfFile.getName());
-    boolean hasError = false;
     for (File csvFile : csvFiles) {
       logger.debug("Checking CSV " + csvFile.getPath());
       TmcfCsvParser parser =

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.datacommons.proto.Debug;
 import org.datacommons.proto.Mcf;
@@ -25,10 +26,11 @@ class TooManyFailuresException extends Exception {
 }
 
 public class Processor {
+  private static final Logger logger = LogManager.getLogger(Processor.class);
+
   private static final int MAX_ERROR_LIMIT = 10;
 
-  public static void processNodes(
-      Mcf.McfType type, File file, Debug.Log.Builder logCtx, Logger logger)
+  public static void processNodes(Mcf.McfType type, File file, Debug.Log.Builder logCtx)
       throws IOException, TooManyFailuresException {
     int numNodesProcessed = 0;
     logger.debug("Checking {}", file.getName());
@@ -50,8 +52,7 @@ public class Processor {
       List<File> csvFiles,
       char delimiter,
       BufferedWriter writer,
-      Debug.Log.Builder logCtx,
-      Logger logger)
+      Debug.Log.Builder logCtx)
       throws IOException, TooManyFailuresException {
     logger.debug("TMCF " + tmcfFile.getName());
     boolean hasError = false;
@@ -79,7 +80,7 @@ public class Processor {
     }
   }
 
-  public static void writeLog(Debug.Log.Builder logCtx, Path logPath, Logger logger)
+  public static void writeLog(Debug.Log.Builder logCtx, Path logPath)
       throws InvalidProtocolBufferException, IOException {
     logger.info("Writing log to {}", logPath.toString());
     File logFile = new File(logPath.toString());

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -68,6 +68,12 @@
             <version>2.14.1</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>3.7.1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -33,6 +33,11 @@
             <version>1.6</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.9</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>[1.6, 1.8)</version>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -62,6 +62,12 @@
             <version>0.46</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.14.1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -37,16 +37,6 @@
             <artifactId>commons-text</artifactId>
             <version>1.9</version>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>[1.6, 1.8)</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>[1.6, 1.8)</version>
-        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/util/src/main/java/org/datacommons/proto/Debug.java
+++ b/util/src/main/java/org/datacommons/proto/Debug.java
@@ -43,6 +43,60 @@ public final class Debug {
     org.datacommons.proto.Debug.Log.CounterSet getCounterSet();
     /** <code>optional .org.datacommons.proto.Log.CounterSet counter_set = 2;</code> */
     org.datacommons.proto.Debug.Log.CounterSetOrBuilder getCounterSetOrBuilder();
+
+    /**
+     *
+     *
+     * <pre>
+     * Key: Level.name()
+     * </pre>
+     *
+     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+     */
+    int getLevelSummaryCount();
+    /**
+     *
+     *
+     * <pre>
+     * Key: Level.name()
+     * </pre>
+     *
+     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+     */
+    boolean containsLevelSummary(java.lang.String key);
+    /** Use {@link #getLevelSummaryMap()} instead. */
+    @java.lang.Deprecated
+    java.util.Map<java.lang.String, java.lang.Long> getLevelSummary();
+    /**
+     *
+     *
+     * <pre>
+     * Key: Level.name()
+     * </pre>
+     *
+     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+     */
+    java.util.Map<java.lang.String, java.lang.Long> getLevelSummaryMap();
+    /**
+     *
+     *
+     * <pre>
+     * Key: Level.name()
+     * </pre>
+     *
+     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+     */
+    long getLevelSummaryOrDefault(java.lang.String key, long defaultValue);
+    /**
+     *
+     *
+     * <pre>
+     * Key: Level.name()
+     * </pre>
+     *
+     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+     */
+    long getLevelSummaryOrThrow(java.lang.String key);
   }
   /**
    *
@@ -124,6 +178,23 @@ public final class Debug {
                 bitField0_ |= 0x00000001;
                 break;
               }
+            case 26:
+              {
+                if (!((mutable_bitField0_ & 0x00000004) != 0)) {
+                  levelSummary_ =
+                      com.google.protobuf.MapField.newMapField(
+                          LevelSummaryDefaultEntryHolder.defaultEntry);
+                  mutable_bitField0_ |= 0x00000004;
+                }
+                com.google.protobuf.MapEntry<java.lang.String, java.lang.Long> levelSummary__ =
+                    input.readMessage(
+                        LevelSummaryDefaultEntryHolder.defaultEntry.getParserForType(),
+                        extensionRegistry);
+                levelSummary_
+                    .getMutableMap()
+                    .put(levelSummary__.getKey(), levelSummary__.getValue());
+                break;
+              }
             default:
               {
                 if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
@@ -148,6 +219,17 @@ public final class Debug {
 
     public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
       return org.datacommons.proto.Debug.internal_static_org_datacommons_proto_Log_descriptor;
+    }
+
+    @SuppressWarnings({"rawtypes"})
+    @java.lang.Override
+    protected com.google.protobuf.MapField internalGetMapField(int number) {
+      switch (number) {
+        case 3:
+          return internalGetLevelSummary();
+        default:
+          throw new RuntimeException("Invalid map field number: " + number);
+      }
     }
 
     @java.lang.Override
@@ -3683,6 +3765,101 @@ public final class Debug {
           : counterSet_;
     }
 
+    public static final int LEVEL_SUMMARY_FIELD_NUMBER = 3;
+
+    private static final class LevelSummaryDefaultEntryHolder {
+      static final com.google.protobuf.MapEntry<java.lang.String, java.lang.Long> defaultEntry =
+          com.google.protobuf.MapEntry.<java.lang.String, java.lang.Long>newDefaultInstance(
+              org.datacommons.proto.Debug
+                  .internal_static_org_datacommons_proto_Log_LevelSummaryEntry_descriptor,
+              com.google.protobuf.WireFormat.FieldType.STRING,
+              "",
+              com.google.protobuf.WireFormat.FieldType.INT64,
+              0L);
+    }
+
+    private com.google.protobuf.MapField<java.lang.String, java.lang.Long> levelSummary_;
+
+    private com.google.protobuf.MapField<java.lang.String, java.lang.Long>
+        internalGetLevelSummary() {
+      if (levelSummary_ == null) {
+        return com.google.protobuf.MapField.emptyMapField(
+            LevelSummaryDefaultEntryHolder.defaultEntry);
+      }
+      return levelSummary_;
+    }
+
+    public int getLevelSummaryCount() {
+      return internalGetLevelSummary().getMap().size();
+    }
+    /**
+     *
+     *
+     * <pre>
+     * Key: Level.name()
+     * </pre>
+     *
+     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+     */
+    public boolean containsLevelSummary(java.lang.String key) {
+      if (key == null) {
+        throw new java.lang.NullPointerException();
+      }
+      return internalGetLevelSummary().getMap().containsKey(key);
+    }
+    /** Use {@link #getLevelSummaryMap()} instead. */
+    @java.lang.Deprecated
+    public java.util.Map<java.lang.String, java.lang.Long> getLevelSummary() {
+      return getLevelSummaryMap();
+    }
+    /**
+     *
+     *
+     * <pre>
+     * Key: Level.name()
+     * </pre>
+     *
+     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+     */
+    public java.util.Map<java.lang.String, java.lang.Long> getLevelSummaryMap() {
+      return internalGetLevelSummary().getMap();
+    }
+    /**
+     *
+     *
+     * <pre>
+     * Key: Level.name()
+     * </pre>
+     *
+     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+     */
+    public long getLevelSummaryOrDefault(java.lang.String key, long defaultValue) {
+      if (key == null) {
+        throw new java.lang.NullPointerException();
+      }
+      java.util.Map<java.lang.String, java.lang.Long> map = internalGetLevelSummary().getMap();
+      return map.containsKey(key) ? map.get(key) : defaultValue;
+    }
+    /**
+     *
+     *
+     * <pre>
+     * Key: Level.name()
+     * </pre>
+     *
+     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+     */
+    public long getLevelSummaryOrThrow(java.lang.String key) {
+      if (key == null) {
+        throw new java.lang.NullPointerException();
+      }
+      java.util.Map<java.lang.String, java.lang.Long> map = internalGetLevelSummary().getMap();
+      if (!map.containsKey(key)) {
+        throw new java.lang.IllegalArgumentException();
+      }
+      return map.get(key);
+    }
+
     private byte memoizedIsInitialized = -1;
 
     @java.lang.Override
@@ -3703,6 +3880,8 @@ public final class Debug {
       if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(2, getCounterSet());
       }
+      com.google.protobuf.GeneratedMessageV3.serializeStringMapTo(
+          output, internalGetLevelSummary(), LevelSummaryDefaultEntryHolder.defaultEntry, 3);
       unknownFields.writeTo(output);
     }
 
@@ -3717,6 +3896,16 @@ public final class Debug {
       }
       if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream.computeMessageSize(2, getCounterSet());
+      }
+      for (java.util.Map.Entry<java.lang.String, java.lang.Long> entry :
+          internalGetLevelSummary().getMap().entrySet()) {
+        com.google.protobuf.MapEntry<java.lang.String, java.lang.Long> levelSummary__ =
+            LevelSummaryDefaultEntryHolder.defaultEntry
+                .newBuilderForType()
+                .setKey(entry.getKey())
+                .setValue(entry.getValue())
+                .build();
+        size += com.google.protobuf.CodedOutputStream.computeMessageSize(3, levelSummary__);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -3738,6 +3927,7 @@ public final class Debug {
       if (hasCounterSet()) {
         if (!getCounterSet().equals(other.getCounterSet())) return false;
       }
+      if (!internalGetLevelSummary().equals(other.internalGetLevelSummary())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -3756,6 +3946,10 @@ public final class Debug {
       if (hasCounterSet()) {
         hash = (37 * hash) + COUNTER_SET_FIELD_NUMBER;
         hash = (53 * hash) + getCounterSet().hashCode();
+      }
+      if (!internalGetLevelSummary().getMap().isEmpty()) {
+        hash = (37 * hash) + LEVEL_SUMMARY_FIELD_NUMBER;
+        hash = (53 * hash) + internalGetLevelSummary().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -3875,6 +4069,26 @@ public final class Debug {
         return org.datacommons.proto.Debug.internal_static_org_datacommons_proto_Log_descriptor;
       }
 
+      @SuppressWarnings({"rawtypes"})
+      protected com.google.protobuf.MapField internalGetMapField(int number) {
+        switch (number) {
+          case 3:
+            return internalGetLevelSummary();
+          default:
+            throw new RuntimeException("Invalid map field number: " + number);
+        }
+      }
+
+      @SuppressWarnings({"rawtypes"})
+      protected com.google.protobuf.MapField internalGetMutableMapField(int number) {
+        switch (number) {
+          case 3:
+            return internalGetMutableLevelSummary();
+          default:
+            throw new RuntimeException("Invalid map field number: " + number);
+        }
+      }
+
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
@@ -3917,6 +4131,7 @@ public final class Debug {
           counterSetBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000002);
+        internalGetMutableLevelSummary().clear();
         return this;
       }
 
@@ -3961,6 +4176,8 @@ public final class Debug {
           }
           to_bitField0_ |= 0x00000001;
         }
+        result.levelSummary_ = internalGetLevelSummary();
+        result.levelSummary_.makeImmutable();
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -4043,6 +4260,7 @@ public final class Debug {
         if (other.hasCounterSet()) {
           mergeCounterSet(other.getCounterSet());
         }
+        internalGetMutableLevelSummary().mergeFrom(other.internalGetLevelSummary());
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -4397,6 +4615,158 @@ public final class Debug {
         return counterSetBuilder_;
       }
 
+      private com.google.protobuf.MapField<java.lang.String, java.lang.Long> levelSummary_;
+
+      private com.google.protobuf.MapField<java.lang.String, java.lang.Long>
+          internalGetLevelSummary() {
+        if (levelSummary_ == null) {
+          return com.google.protobuf.MapField.emptyMapField(
+              LevelSummaryDefaultEntryHolder.defaultEntry);
+        }
+        return levelSummary_;
+      }
+
+      private com.google.protobuf.MapField<java.lang.String, java.lang.Long>
+          internalGetMutableLevelSummary() {
+        onChanged();
+        ;
+        if (levelSummary_ == null) {
+          levelSummary_ =
+              com.google.protobuf.MapField.newMapField(LevelSummaryDefaultEntryHolder.defaultEntry);
+        }
+        if (!levelSummary_.isMutable()) {
+          levelSummary_ = levelSummary_.copy();
+        }
+        return levelSummary_;
+      }
+
+      public int getLevelSummaryCount() {
+        return internalGetLevelSummary().getMap().size();
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Key: Level.name()
+       * </pre>
+       *
+       * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+       */
+      public boolean containsLevelSummary(java.lang.String key) {
+        if (key == null) {
+          throw new java.lang.NullPointerException();
+        }
+        return internalGetLevelSummary().getMap().containsKey(key);
+      }
+      /** Use {@link #getLevelSummaryMap()} instead. */
+      @java.lang.Deprecated
+      public java.util.Map<java.lang.String, java.lang.Long> getLevelSummary() {
+        return getLevelSummaryMap();
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Key: Level.name()
+       * </pre>
+       *
+       * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+       */
+      public java.util.Map<java.lang.String, java.lang.Long> getLevelSummaryMap() {
+        return internalGetLevelSummary().getMap();
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Key: Level.name()
+       * </pre>
+       *
+       * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+       */
+      public long getLevelSummaryOrDefault(java.lang.String key, long defaultValue) {
+        if (key == null) {
+          throw new java.lang.NullPointerException();
+        }
+        java.util.Map<java.lang.String, java.lang.Long> map = internalGetLevelSummary().getMap();
+        return map.containsKey(key) ? map.get(key) : defaultValue;
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Key: Level.name()
+       * </pre>
+       *
+       * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+       */
+      public long getLevelSummaryOrThrow(java.lang.String key) {
+        if (key == null) {
+          throw new java.lang.NullPointerException();
+        }
+        java.util.Map<java.lang.String, java.lang.Long> map = internalGetLevelSummary().getMap();
+        if (!map.containsKey(key)) {
+          throw new java.lang.IllegalArgumentException();
+        }
+        return map.get(key);
+      }
+
+      public Builder clearLevelSummary() {
+        internalGetMutableLevelSummary().getMutableMap().clear();
+        return this;
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Key: Level.name()
+       * </pre>
+       *
+       * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+       */
+      public Builder removeLevelSummary(java.lang.String key) {
+        if (key == null) {
+          throw new java.lang.NullPointerException();
+        }
+        internalGetMutableLevelSummary().getMutableMap().remove(key);
+        return this;
+      }
+      /** Use alternate mutation accessors instead. */
+      @java.lang.Deprecated
+      public java.util.Map<java.lang.String, java.lang.Long> getMutableLevelSummary() {
+        return internalGetMutableLevelSummary().getMutableMap();
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Key: Level.name()
+       * </pre>
+       *
+       * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+       */
+      public Builder putLevelSummary(java.lang.String key, long value) {
+        if (key == null) {
+          throw new java.lang.NullPointerException();
+        }
+
+        internalGetMutableLevelSummary().getMutableMap().put(key, value);
+        return this;
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Key: Level.name()
+       * </pre>
+       *
+       * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+       */
+      public Builder putAllLevelSummary(java.util.Map<java.lang.String, java.lang.Long> values) {
+        internalGetMutableLevelSummary().getMutableMap().putAll(values);
+        return this;
+      }
+
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -4470,6 +4840,10 @@ public final class Debug {
       internal_static_org_datacommons_proto_Log_Entry_descriptor;
   private static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_org_datacommons_proto_Log_Entry_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+      internal_static_org_datacommons_proto_Log_LevelSummaryEntry_descriptor;
+  private static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_org_datacommons_proto_Log_LevelSummaryEntry_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor getDescriptor() {
     return descriptor;
@@ -4479,22 +4853,26 @@ public final class Debug {
 
   static {
     java.lang.String[] descriptorData = {
-      "\n\013Debug.proto\022\025org.datacommons.proto\"\330\004\n"
+      "\n\013Debug.proto\022\025org.datacommons.proto\"\322\005\n"
           + "\003Log\0221\n\007entries\030\001 \003(\0132 .org.datacommons."
           + "proto.Log.Entry\022:\n\013counter_set\030\002 \001(\0132%.o"
-          + "rg.datacommons.proto.Log.CounterSet\032Y\n\010L"
-          + "ocation\022\014\n\004file\030\001 \001(\t\022\023\n\013line_number\030\002 \001"
-          + "(\003\022\025\n\rcolumn_number\030\003 \001(\003\022\023\n\013column_name"
-          + "\030\004 \001(\t\032\204\001\n\nCounterSet\022E\n\010counters\030\001 \003(\0132"
-          + "3.org.datacommons.proto.Log.CounterSet.C"
-          + "ountersEntry\032/\n\rCountersEntry\022\013\n\003key\030\001 \001"
-          + "(\t\022\r\n\005value\030\002 \001(\003:\0028\001\032\232\001\n\005Entry\022/\n\005level"
-          + "\030\001 \001(\0162 .org.datacommons.proto.Log.Level"
-          + "\0225\n\010location\030\002 \001(\0132#.org.datacommons.pro"
-          + "to.Log.Location\022\024\n\014user_message\030\003 \001(\t\022\023\n"
-          + "\013counter_key\030\004 \001(\t\"c\n\005Level\022\025\n\021LEVEL_UNS"
-          + "PECIFIED\020\000\022\016\n\nLEVEL_INFO\020\001\022\021\n\rLEVEL_WARN"
-          + "ING\020\002\022\017\n\013LEVEL_ERROR\020\003\022\017\n\013LEVEL_FATAL\020\004"
+          + "rg.datacommons.proto.Log.CounterSet\022C\n\rl"
+          + "evel_summary\030\003 \003(\0132,.org.datacommons.pro"
+          + "to.Log.LevelSummaryEntry\032Y\n\010Location\022\014\n\004"
+          + "file\030\001 \001(\t\022\023\n\013line_number\030\002 \001(\003\022\025\n\rcolum"
+          + "n_number\030\003 \001(\003\022\023\n\013column_name\030\004 \001(\t\032\204\001\n\n"
+          + "CounterSet\022E\n\010counters\030\001 \003(\01323.org.datac"
+          + "ommons.proto.Log.CounterSet.CountersEntr"
+          + "y\032/\n\rCountersEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value"
+          + "\030\002 \001(\003:\0028\001\032\232\001\n\005Entry\022/\n\005level\030\001 \001(\0162 .or"
+          + "g.datacommons.proto.Log.Level\0225\n\010locatio"
+          + "n\030\002 \001(\0132#.org.datacommons.proto.Log.Loca"
+          + "tion\022\024\n\014user_message\030\003 \001(\t\022\023\n\013counter_ke"
+          + "y\030\004 \001(\t\0323\n\021LevelSummaryEntry\022\013\n\003key\030\001 \001("
+          + "\t\022\r\n\005value\030\002 \001(\003:\0028\001\"c\n\005Level\022\025\n\021LEVEL_U"
+          + "NSPECIFIED\020\000\022\016\n\nLEVEL_INFO\020\001\022\021\n\rLEVEL_WA"
+          + "RNING\020\002\022\017\n\013LEVEL_ERROR\020\003\022\017\n\013LEVEL_FATAL\020"
+          + "\004"
     };
     descriptor =
         com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
@@ -4504,7 +4882,7 @@ public final class Debug {
         new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
             internal_static_org_datacommons_proto_Log_descriptor,
             new java.lang.String[] {
-              "Entries", "CounterSet",
+              "Entries", "CounterSet", "LevelSummary",
             });
     internal_static_org_datacommons_proto_Log_Location_descriptor =
         internal_static_org_datacommons_proto_Log_descriptor.getNestedTypes().get(0);
@@ -4537,6 +4915,14 @@ public final class Debug {
             internal_static_org_datacommons_proto_Log_Entry_descriptor,
             new java.lang.String[] {
               "Level", "Location", "UserMessage", "CounterKey",
+            });
+    internal_static_org_datacommons_proto_Log_LevelSummaryEntry_descriptor =
+        internal_static_org_datacommons_proto_Log_descriptor.getNestedTypes().get(3);
+    internal_static_org_datacommons_proto_Log_LevelSummaryEntry_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_org_datacommons_proto_Log_LevelSummaryEntry_descriptor,
+            new java.lang.String[] {
+              "Key", "Value",
             });
   }
 

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -28,14 +28,16 @@ public class LogWrapper {
   private Path logPath;
   private String locationFile;
   private Instant lastStatusAt;
+  private long countAtLastStatus;
 
   public LogWrapper(Debug.Log.Builder log, Path outputDir) {
     this.log = log;
     logPath = Paths.get(outputDir.toString(), REPORT_JSON);
     logger.info(
         "Report written periodically to {}", logPath.toAbsolutePath().normalize().toString());
-    lastStatusAt = Instant.now();
     locationFile = "FileNotSet.idk";
+    lastStatusAt = Instant.now();
+    countAtLastStatus = 0;
   }
 
   public void updateLocationFile(String locationFile) {
@@ -59,7 +61,12 @@ public class LogWrapper {
       throws InvalidProtocolBufferException, IOException {
     Instant now = Instant.now();
     if (Duration.between(lastStatusAt, now).getSeconds() >= SECONDS_BETWEEN_STATUS) {
-      logger.info("Processed {} {} of {};  {}.", count, thing, locationFile, summaryString());
+      logger.info(
+          "Processed {} {} of {};  {}.",
+          count - countAtLastStatus,
+          thing,
+          locationFile,
+          summaryString());
       persistLog(true);
       lastStatusAt = now;
     }

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -11,31 +11,41 @@ class LogWrapper {
     fileName = fileName;
   }
 
-  public void AddLog(Debug.Log.Level level, String counter, String message, long lno) {
+  public void addLog(Debug.Log.Level level, String counter, String message, long lno) {
     if (logCtx == null) return;
-    AddLog(level, counter, message, lno, -1 , null);
+    addLog(level, counter, message, lno, -1, null);
   }
 
-  public void AddLog(Debug.Log.Level level, String counter, String message, long lno, long cno) {
+  public void addLog(Debug.Log.Level level, String counter, String message, long lno, long cno) {
     if (logCtx == null) return;
-    AddLog(level, counter, message, lno, cno, null);
+    addLog(level, counter, message, lno, cno, null);
   }
 
-  public void AddLog(Debug.Log.Level level, String counter, String message, long lno,
-                     String cname) {
+  public void addLog(
+      Debug.Log.Level level, String counter, String message, long lno, String cname) {
     if (logCtx == null) return;
-    AddLog(level, counter, message, lno, -1, cname);
+    addLog(level, counter, message, lno, -1, cname);
   }
 
-  private void AddLog(Debug.Log.Level level, String counter, String message, long lno, long cno,
-                      String cname) {
+  public void incrementCounterBy(String counter, int incr) {
+    Long c = Long.valueOf(incr);
+    if (logCtx.getCounterSet().getCountersMap().containsKey(counter)) {
+      c = logCtx.getCounterSet().getCountersMap().get(counter) + Long.valueOf(incr);
+    }
+    logCtx.getCounterSetBuilder().putCounters(counter, c);
+  }
+
+  private void addLog(
+      Debug.Log.Level level, String counter, String message, long lno, long cno, String cname) {
     Debug.Log.Entry.Builder e = logCtx.addEntriesBuilder();
     e.setLevel(level);
     e.setUserMessage(message);
     if (counter != null && !counter.isEmpty()) {
       e.setCounterKey(counter);
-      logCtx.getCounterSetBuilder().getCountersMap().put(counter,
-              logCtx.getCounterSet().getCountersOrDefault(counter, 0) + 1);
+      logCtx
+          .getCounterSetBuilder()
+          .getCountersMap()
+          .put(counter, logCtx.getCounterSet().getCountersOrDefault(counter, 0) + 1);
     }
     Debug.Log.Location.Builder l = e.getLocationBuilder();
     l.setFile(fileName);

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -2,14 +2,14 @@ package org.datacommons.util;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.datacommons.proto.Debug;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 
 public class LogWrapper {
   private static final Logger logger = LogManager.getLogger(McfParser.class);
@@ -45,8 +45,7 @@ public class LogWrapper {
     }
     logger.info("Failures: {}.  Writing details to {}", logSummary(logCtx), logPath.toString());
     File logFile = new File(logPath.toString());
-    FileUtils.writeStringToFile(
-        logFile, JsonFormat.printer().print(logCtx), StandardCharsets.UTF_8);
+    FileUtils.writeStringToFile(logFile, JsonFormat.printer().print(logCtx));
   }
 
   public static String logSummary(Debug.Log.Builder logCtx) {
@@ -80,7 +79,7 @@ public class LogWrapper {
     logCtx.getCounterSetBuilder().putCounters(counterName, counterValue + 1);
     logCtx.putLevelSummary(level.name(), logCtx.getLevelSummaryOrDefault(level.name(), 0) + 1);
 
-    if (counterValue > MAX_MESSAGES_PER_COUNTER) {
+    if (counterValue <= MAX_MESSAGES_PER_COUNTER) {
       // Log only up to certain full messages per counter. This can spam the log for WARNING msgs.
       Debug.Log.Entry.Builder e = logCtx.addEntriesBuilder();
       e.setLevel(level);

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -1,14 +1,18 @@
 package org.datacommons.util;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.datacommons.proto.Debug;
 
 class LogWrapper {
+  private static final Logger logger = LogManager.getLogger(McfParser.class);
+
   private Debug.Log.Builder logCtx;
   private String fileName;
 
   public LogWrapper(Debug.Log.Builder logCtx, String fileName) {
-    logCtx = logCtx;
-    fileName = fileName;
+    this.logCtx = logCtx;
+    this.fileName = fileName;
   }
 
   public void addLog(Debug.Log.Level level, String counter, String message, long lno) {
@@ -26,6 +30,9 @@ class LogWrapper {
 
   private void addLog(
       Debug.Log.Level level, String counter, String message, long lno, long cno, String cname) {
+    if (level == Debug.Log.Level.LEVEL_ERROR || level == Debug.Log.Level.LEVEL_FATAL) {
+      logger.error("{} - @{}:{} - {} - {}", level.name(), fileName, lno, counter, message);
+    }
     Debug.Log.Entry.Builder e = logCtx.addEntriesBuilder();
     e.setLevel(level);
     e.setUserMessage(message);
@@ -40,11 +47,10 @@ class LogWrapper {
       e.setCounterKey(counter);
       logCtx
           .getCounterSetBuilder()
-          .getCountersMap()
-          .put(counter, logCtx.getCounterSet().getCountersOrDefault(counter, 0) + 1);
+          .putCounters(counter, logCtx.getCounterSet().getCountersOrDefault(counter, 0) + 1);
     }
 
     // Update level summary.
-    logCtx.getLevelSummaryMap().put(level.name(), logCtx.getLevelSummaryOrDefault(level.name(), 0));
+    logCtx.putLevelSummary(level.name(), logCtx.getLevelSummaryOrDefault(level.name(), 0));
   }
 }

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -1,0 +1,46 @@
+package org.datacommons.util;
+
+import org.datacommons.proto.Debug;
+
+class LogWrapper {
+  private Debug.Log.Builder logCtx;
+  private String fileName;
+
+  public LogWrapper(Debug.Log.Builder logCtx, String fileName) {
+    logCtx = logCtx;
+    fileName = fileName;
+  }
+
+  public void AddLog(Debug.Log.Level level, String counter, String message, long lno) {
+    if (logCtx == null) return;
+    AddLog(level, counter, message, lno, -1 , null);
+  }
+
+  public void AddLog(Debug.Log.Level level, String counter, String message, long lno, long cno) {
+    if (logCtx == null) return;
+    AddLog(level, counter, message, lno, cno, null);
+  }
+
+  public void AddLog(Debug.Log.Level level, String counter, String message, long lno,
+                     String cname) {
+    if (logCtx == null) return;
+    AddLog(level, counter, message, lno, -1, cname);
+  }
+
+  private void AddLog(Debug.Log.Level level, String counter, String message, long lno, long cno,
+                      String cname) {
+    Debug.Log.Entry.Builder e = logCtx.addEntriesBuilder();
+    e.setLevel(level);
+    e.setUserMessage(message);
+    if (counter != null && !counter.isEmpty()) {
+      e.setCounterKey(counter);
+      logCtx.getCounterSetBuilder().getCountersMap().put(counter,
+              logCtx.getCounterSet().getCountersOrDefault(counter, 0) + 1);
+    }
+    Debug.Log.Location.Builder l = e.getLocationBuilder();
+    l.setFile(fileName);
+    l.setLineNumber(lno);
+    if (cno > 0) l.setColumnNumber(cno);
+    if (cname != null && !cname.isEmpty()) l.setColumnName(cname);
+  }
+}

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -2,12 +2,6 @@ package org.datacommons.util;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.text.StringEscapeUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.datacommons.proto.Debug;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -15,6 +9,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.datacommons.proto.Debug;
 
 // The class that provides logging functionality.
 public class LogWrapper {

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -31,7 +31,7 @@ class LogWrapper {
   private void addLog(
       Debug.Log.Level level, String counter, String message, long lno, long cno, String cname) {
     if (level == Debug.Log.Level.LEVEL_ERROR || level == Debug.Log.Level.LEVEL_FATAL) {
-      logger.error("{} - @{}:{} - {} - {}", level.name(), fileName, lno, counter, message);
+      logger.error("{}:{} - {} - {}", level.name(), fileName, lno, counter, message);
     }
     Debug.Log.Entry.Builder e = logCtx.addEntriesBuilder();
     e.setLevel(level);

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -2,6 +2,12 @@ package org.datacommons.util;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.datacommons.proto.Debug;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -9,11 +15,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.text.StringEscapeUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.datacommons.proto.Debug;
 
 // The class that provides logging functionality.
 public class LogWrapper {
@@ -32,7 +33,8 @@ public class LogWrapper {
   public LogWrapper(Debug.Log.Builder log, Path outputDir) {
     this.log = log;
     logPath = Paths.get(outputDir.toString(), REPORT_JSON);
-    logger.info("Writing log to {}", logPath.toAbsolutePath().normalize().toString());
+    logger.info(
+        "Report written periodically to {}", logPath.toAbsolutePath().normalize().toString());
     lastStatusAt = Instant.now();
     locationFile = "FileNotSet.idk";
   }

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -51,6 +51,6 @@ class LogWrapper {
     }
 
     // Update level summary.
-    logCtx.putLevelSummary(level.name(), logCtx.getLevelSummaryOrDefault(level.name(), 0));
+    logCtx.putLevelSummary(level.name(), logCtx.getLevelSummaryOrDefault(level.name(), 0) + 1);
   }
 }

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -44,7 +44,10 @@ public class LogWrapper {
       logger.info("Found no warnings or errors!");
       return;
     }
-    logger.info("Failures: {}.  Writing details to {}", logSummary(logCtx), logPath.toString());
+    logger.info(
+        "Failures: {}.  Writing details to {}",
+        logSummary(logCtx),
+        logPath.toAbsolutePath().toString());
     File logFile = new File(logPath.toString());
     // Without the unescaping something like 'Node' shows up as \u0027Node\u0027
     String jsonStr = StringEscapeUtils.unescapeJson(JsonFormat.printer().print(logCtx.build()));

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -16,17 +16,6 @@ class LogWrapper {
     addLog(level, counter, message, lno, -1, null);
   }
 
-  public void addLog(Debug.Log.Level level, String counter, String message, long lno, long cno) {
-    if (logCtx == null) return;
-    addLog(level, counter, message, lno, cno, null);
-  }
-
-  public void addLog(
-      Debug.Log.Level level, String counter, String message, long lno, String cname) {
-    if (logCtx == null) return;
-    addLog(level, counter, message, lno, -1, cname);
-  }
-
   public void incrementCounterBy(String counter, int incr) {
     Long c = Long.valueOf(incr);
     if (logCtx.getCounterSet().getCountersMap().containsKey(counter)) {
@@ -40,6 +29,13 @@ class LogWrapper {
     Debug.Log.Entry.Builder e = logCtx.addEntriesBuilder();
     e.setLevel(level);
     e.setUserMessage(message);
+
+    Debug.Log.Location.Builder l = e.getLocationBuilder();
+    l.setFile(fileName);
+    l.setLineNumber(lno);
+    if (cno > 0) l.setColumnNumber(cno);
+    if (cname != null && !cname.isEmpty()) l.setColumnName(cname);
+
     if (counter != null && !counter.isEmpty()) {
       e.setCounterKey(counter);
       logCtx
@@ -47,10 +43,8 @@ class LogWrapper {
           .getCountersMap()
           .put(counter, logCtx.getCounterSet().getCountersOrDefault(counter, 0) + 1);
     }
-    Debug.Log.Location.Builder l = e.getLocationBuilder();
-    l.setFile(fileName);
-    l.setLineNumber(lno);
-    if (cno > 0) l.setColumnNumber(cno);
-    if (cname != null && !cname.isEmpty()) l.setColumnName(cname);
+
+    // Update level summary.
+    logCtx.getLevelSummaryMap().put(level.name(), logCtx.getLevelSummaryOrDefault(level.name(), 0));
   }
 }

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -1,11 +1,20 @@
 package org.datacommons.util;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.datacommons.proto.Debug;
 
-class LogWrapper {
+public class LogWrapper {
   private static final Logger logger = LogManager.getLogger(McfParser.class);
+  private static final int MAX_ERROR_LIMIT = 50;
+  private static final int MAX_MESSAGES_PER_COUNTER = 10;
 
   private Debug.Log.Builder logCtx;
   private String fileName;
@@ -28,29 +37,61 @@ class LogWrapper {
     logCtx.getCounterSetBuilder().putCounters(counter, c);
   }
 
+  public static void writeLog(Debug.Log.Builder logCtx, Path logPath)
+      throws InvalidProtocolBufferException, IOException {
+    if (logCtx.getLevelSummaryMap().isEmpty()) {
+      logger.info("Found no warnings or errors!");
+      return;
+    }
+    logger.info("Failures: {}.  Writing details to {}", logSummary(logCtx), logPath.toString());
+    File logFile = new File(logPath.toString());
+    FileUtils.writeStringToFile(
+        logFile, JsonFormat.printer().print(logCtx), StandardCharsets.UTF_8);
+  }
+
+  public static String logSummary(Debug.Log.Builder logCtx) {
+    return logCtx.getLevelSummaryMap().getOrDefault("LEVEL_FATAL", 0L)
+        + " fatal, "
+        + logCtx.getLevelSummaryMap().getOrDefault("LEVEL_ERROR", 0L)
+        + " error(s), "
+        + logCtx.getLevelSummaryMap().getOrDefault("LEVEL_WARNING", 0L)
+        + " warning(s)";
+  }
+
+  public static boolean loggedTooManyFailures(Debug.Log.Builder logCtx) {
+    if (logCtx.getLevelSummaryOrDefault("LEVEL_FATAL", 0) > 0) {
+      logger.error("Found a fatal failure. Quitting!");
+      return true;
+    }
+    if (logCtx.getLevelSummaryOrDefault("LEVEL_ERROR", 0) > MAX_ERROR_LIMIT) {
+      logger.error("Found too many failures. Quitting!");
+      return true;
+    }
+    return false;
+  }
+
   private void addLog(
       Debug.Log.Level level, String counter, String message, long lno, long cno, String cname) {
     if (level == Debug.Log.Level.LEVEL_ERROR || level == Debug.Log.Level.LEVEL_FATAL) {
       logger.error("{}:{} - {} - {}", level.name(), fileName, lno, counter, message);
     }
-    Debug.Log.Entry.Builder e = logCtx.addEntriesBuilder();
-    e.setLevel(level);
-    e.setUserMessage(message);
-
-    Debug.Log.Location.Builder l = e.getLocationBuilder();
-    l.setFile(fileName);
-    l.setLineNumber(lno);
-    if (cno > 0) l.setColumnNumber(cno);
-    if (cname != null && !cname.isEmpty()) l.setColumnName(cname);
-
-    if (counter != null && !counter.isEmpty()) {
-      e.setCounterKey(counter);
-      logCtx
-          .getCounterSetBuilder()
-          .putCounters(counter, logCtx.getCounterSet().getCountersOrDefault(counter, 0) + 1);
-    }
-
-    // Update level summary.
+    String counterName = counter == null || counter.isEmpty() ? "MissingCounterName" : counter;
+    long counterValue = logCtx.getCounterSet().getCountersOrDefault(counterName, 0);
+    logCtx.getCounterSetBuilder().putCounters(counterName, counterValue + 1);
     logCtx.putLevelSummary(level.name(), logCtx.getLevelSummaryOrDefault(level.name(), 0) + 1);
+
+    if (counterValue > MAX_MESSAGES_PER_COUNTER) {
+      // Log only up to certain full messages per counter. This can spam the log for WARNING msgs.
+      Debug.Log.Entry.Builder e = logCtx.addEntriesBuilder();
+      e.setLevel(level);
+      e.setUserMessage(message);
+      e.setCounterKey(counterName);
+
+      Debug.Log.Location.Builder l = e.getLocationBuilder();
+      l.setFile(fileName);
+      l.setLineNumber(lno);
+      if (cno > 0) l.setColumnNumber(cno);
+      if (cname != null && !cname.isEmpty()) l.setColumnName(cname);
+    }
   }
 }

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -6,95 +6,121 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.datacommons.proto.Debug;
 
+// The class that provides logging functionality.
 public class LogWrapper {
   private static final Logger logger = LogManager.getLogger(McfParser.class);
-  private static final int MAX_ERROR_LIMIT = 50;
-  private static final int MAX_MESSAGES_PER_COUNTER = 10;
 
-  private Debug.Log.Builder logCtx;
-  private String fileName;
+  private static final long SECONDS_BETWEEN_STATUS = 60;
+  public static final String REPORT_JSON = "report.json";
+  public static final int MAX_ERROR_LIMIT = 50;
+  public static final int MAX_MESSAGES_PER_COUNTER = 10;
 
-  public LogWrapper(Debug.Log.Builder logCtx, String fileName) {
-    this.logCtx = logCtx;
-    this.fileName = fileName;
+  private Debug.Log.Builder log;
+  private Path logPath;
+  private String locationFile;
+  private Instant lastStatusAt;
+
+  public LogWrapper(Debug.Log.Builder log, Path outputDir) {
+    this.log = log;
+    this.logPath = Paths.get(outputDir.toString(), REPORT_JSON);
+    lastStatusAt = Instant.now();
+    locationFile = "FileNotSet.idk";
+  }
+
+  public void updateLocationFile(String locationFile) {
+    this.locationFile = locationFile;
   }
 
   public void addLog(Debug.Log.Level level, String counter, String message, long lno) {
-    if (logCtx == null) return;
+    if (log == null) return;
     addLog(level, counter, message, lno, -1, null);
   }
 
   public void incrementCounterBy(String counter, int incr) {
     Long c = Long.valueOf(incr);
-    if (logCtx.getCounterSet().getCountersMap().containsKey(counter)) {
-      c = logCtx.getCounterSet().getCountersMap().get(counter) + Long.valueOf(incr);
+    if (log.getCounterSet().getCountersMap().containsKey(counter)) {
+      c = log.getCounterSet().getCountersMap().get(counter) + Long.valueOf(incr);
     }
-    logCtx.getCounterSetBuilder().putCounters(counter, c);
+    log.getCounterSetBuilder().putCounters(counter, c);
   }
 
-  public static void writeLog(Debug.Log.Builder logCtx, Path logPath)
+  public void provideStatus(long count, String thing)
       throws InvalidProtocolBufferException, IOException {
-    if (logCtx.getLevelSummaryMap().isEmpty()) {
-      logger.info("Found no warnings or errors!");
+    Instant now = Instant.now();
+    if (Duration.between(lastStatusAt, now).getSeconds() >= SECONDS_BETWEEN_STATUS) {
+      logger.info("Processed {} {} of {};  {}.", count, thing, locationFile, summaryString());
+      writeLog(true);
+      lastStatusAt = now;
+    }
+  }
+
+  public void writeLog(boolean silent) throws InvalidProtocolBufferException, IOException {
+    if (log.getLevelSummaryMap().isEmpty()) {
+      if (!silent) logger.info("Found no warnings or errors!");
       return;
     }
-    logger.info(
-        "Failures: {}.  Writing details to {}",
-        logSummary(logCtx),
-        logPath.toAbsolutePath().toString());
+    if (!silent) {
+      logger.info(
+          "Failures: {}.  Writing details to {}",
+          summaryString(),
+          logPath.toAbsolutePath().normalize().toString());
+    }
     File logFile = new File(logPath.toString());
     // Without the unescaping something like 'Node' shows up as \u0027Node\u0027
-    String jsonStr = StringEscapeUtils.unescapeJson(JsonFormat.printer().print(logCtx.build()));
+    String jsonStr = StringEscapeUtils.unescapeJson(JsonFormat.printer().print(log.build()));
     FileUtils.writeStringToFile(logFile, jsonStr, StandardCharsets.UTF_8);
   }
 
-  public static String logSummary(Debug.Log.Builder logCtx) {
-    return logCtx.getLevelSummaryMap().getOrDefault("LEVEL_FATAL", 0L)
-        + " fatal, "
-        + logCtx.getLevelSummaryMap().getOrDefault("LEVEL_ERROR", 0L)
-        + " error(s), "
-        + logCtx.getLevelSummaryMap().getOrDefault("LEVEL_WARNING", 0L)
-        + " warning(s)";
-  }
-
-  public static boolean loggedTooManyFailures(Debug.Log.Builder logCtx) {
-    if (logCtx.getLevelSummaryOrDefault("LEVEL_FATAL", 0) > 0) {
+  public boolean loggedTooManyFailures() {
+    if (log.getLevelSummaryOrDefault("LEVEL_FATAL", 0) > 0) {
       logger.error("Found a fatal failure. Quitting!");
       return true;
     }
-    if (logCtx.getLevelSummaryOrDefault("LEVEL_ERROR", 0) > MAX_ERROR_LIMIT) {
+    if (log.getLevelSummaryOrDefault("LEVEL_ERROR", 0) > MAX_ERROR_LIMIT) {
       logger.error("Found too many failures. Quitting!");
       return true;
     }
     return false;
   }
 
+  public String summaryString() {
+    return log.getLevelSummaryMap().getOrDefault("LEVEL_FATAL", 0L)
+        + " fatal, "
+        + log.getLevelSummaryMap().getOrDefault("LEVEL_ERROR", 0L)
+        + " error(s), "
+        + log.getLevelSummaryMap().getOrDefault("LEVEL_WARNING", 0L)
+        + " warning(s)";
+  }
+
   private void addLog(
       Debug.Log.Level level, String counter, String message, long lno, long cno, String cname) {
     if (level == Debug.Log.Level.LEVEL_ERROR || level == Debug.Log.Level.LEVEL_FATAL) {
       String displayLevel = level.name().replace("LEVEL_", "");
-      logger.error("{} {}:{} - {}: {}", displayLevel, fileName, lno, counter, message);
+      logger.error("{} {}:{} - {}: {}", displayLevel, locationFile, lno, counter, message);
     }
     String counterName = counter == null || counter.isEmpty() ? "MissingCounterName" : counter;
-    long counterValue = logCtx.getCounterSet().getCountersOrDefault(counterName, 0);
-    logCtx.getCounterSetBuilder().putCounters(counterName, counterValue + 1);
-    logCtx.putLevelSummary(level.name(), logCtx.getLevelSummaryOrDefault(level.name(), 0) + 1);
+    long counterValue = log.getCounterSet().getCountersOrDefault(counterName, 0);
+    log.getCounterSetBuilder().putCounters(counterName, counterValue + 1);
+    log.putLevelSummary(level.name(), log.getLevelSummaryOrDefault(level.name(), 0) + 1);
 
     if (counterValue <= MAX_MESSAGES_PER_COUNTER) {
       // Log only up to certain full messages per counter. This can spam the log for WARNING msgs.
-      Debug.Log.Entry.Builder e = logCtx.addEntriesBuilder();
+      Debug.Log.Entry.Builder e = log.addEntriesBuilder();
       e.setLevel(level);
       e.setUserMessage(message);
       e.setCounterKey(counterName);
 
       Debug.Log.Location.Builder l = e.getLocationBuilder();
-      l.setFile(fileName);
+      l.setFile(locationFile);
       l.setLineNumber(lno);
       if (cno > 0) l.setColumnNumber(cno);
       if (cname != null && !cname.isEmpty()) l.setColumnName(cname);

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -2,6 +2,12 @@ package org.datacommons.util;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.datacommons.proto.Debug;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -9,11 +15,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.text.StringEscapeUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.datacommons.proto.Debug;
 
 // The class that provides logging functionality.
 public class LogWrapper {
@@ -69,6 +70,7 @@ public class LogWrapper {
           summaryString());
       persistLog(true);
       lastStatusAt = now;
+      countAtLastStatus = count;
     }
   }
 

--- a/util/src/main/java/org/datacommons/util/McfParser.java
+++ b/util/src/main/java/org/datacommons/util/McfParser.java
@@ -513,6 +513,7 @@ public class McfParser {
     public char delimiter = ',';
     public boolean includeEmpty = false;
     public boolean stripEnclosingQuotes = true;
+    public String context;
   }
   // NOTE: We do not strip enclosing quotes in this function.
   public static List<String> splitAndStripWithQuoteEscape(
@@ -532,13 +533,17 @@ public class McfParser {
       List<CSVRecord> records = parser.getRecords();
       if (records.isEmpty()) {
         if (errCb != null) {
-          errCb.accept("StrSplit_EmptyToken", "Empty token while parsing " + orig);
+          errCb.accept(
+              "StrSplit_EmptyToken",
+              "Empty token while parsing '" + orig + "' (" + arg.context + ")");
         }
         return splits;
       }
       if (records.size() != 1) {
         if (errCb != null) {
-          errCb.accept("StrSplit_MultiToken", "Found more than one record for " + orig);
+          errCb.accept(
+              "StrSplit_MultiToken",
+              "Found more than one record for '" + orig + "' (" + arg.context + ")");
         }
         return splits;
       }
@@ -550,7 +555,8 @@ public class McfParser {
         }
       }
     } catch (IOException e) {
-      errCb.accept("StrSplit_ParserFailure", "Parsing failed on (" + orig);
+      errCb.accept(
+          "StrSplit_ParserFailure", "Parsing failed on '" + orig + "' (" + arg.context + ")");
     }
     return splits;
   }

--- a/util/src/main/java/org/datacommons/util/McfParser.java
+++ b/util/src/main/java/org/datacommons/util/McfParser.java
@@ -24,6 +24,8 @@ import java.util.function.BiConsumer;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.datacommons.proto.Debug;
 import org.datacommons.proto.Mcf;
 import org.datacommons.proto.Mcf.McfGraph;
@@ -31,6 +33,8 @@ import org.datacommons.proto.Mcf.McfGraph;
 // A parser for converting text in Instance or Template MCF format into the McfGraph proto.
 // TODO: Implement COMPLEX_VALUE parsing
 public class McfParser {
+  private static final Logger logger = LogManager.getLogger(McfParser.class);
+
   private McfGraph.Builder graph;
   private LogWrapper logWrapper;
   private boolean isResolved;

--- a/util/src/main/java/org/datacommons/util/McfParser.java
+++ b/util/src/main/java/org/datacommons/util/McfParser.java
@@ -116,7 +116,7 @@ public class McfParser {
     }
     int colon = line.substring(prefixLen).indexOf(Vocabulary.REFERENCE_DELIMITER);
     if (colon < 1) {
-      logCtx.addLog(
+      logCtx.addEntry(
           Debug.Log.Level.LEVEL_ERROR,
           "MCF_MalformedColonLessLine",
           "Malformed line " + "without a colon delimiter (" + line + ")",
@@ -128,7 +128,7 @@ public class McfParser {
     String rhs = line.substring(colon + 1).trim();
     if (lhs.equals(Vocabulary.NODE)) {
       if (rhs.indexOf(',') != -1) {
-        logCtx.addLog(
+        logCtx.addEntry(
             Debug.Log.Level.LEVEL_ERROR,
             "MCF_MalformedNodeName",
             "Found malformed 'Node' name ("
@@ -138,7 +138,7 @@ public class McfParser {
         return;
       }
       if (rhs.startsWith("\"")) {
-        logCtx.addLog(
+        logCtx.addEntry(
             Debug.Log.Level.LEVEL_ERROR,
             "MCF_MalformedNodeName",
             "Found malformed 'Node' name ("
@@ -150,7 +150,7 @@ public class McfParser {
       if (graph.getType() == Mcf.McfType.TEMPLATE_MCF) {
         SchemaTerm term = parseSchemaTerm(rhs, getErrCb());
         if (term.type != SchemaTerm.Type.ENTITY) {
-          logCtx.addLog(
+          logCtx.addEntry(
               Debug.Log.Level.LEVEL_ERROR,
               "TMCF_MalformedEntity",
               "Found malformed entity name that is not an entity prefix " + rhs,
@@ -166,7 +166,7 @@ public class McfParser {
       curEntityLineIdx = 0;
     } else {
       if (curEntity.isEmpty()) {
-        logCtx.addLog(
+        logCtx.addEntry(
             Debug.Log.Level.LEVEL_ERROR,
             "MCF_UnexpectedProperty",
             " Property found without a 'Node' term: " + line,
@@ -214,7 +214,7 @@ public class McfParser {
       return null;
     }
     if (curEntityLineIdx == 0) {
-      logCtx.addLog(
+      logCtx.addEntry(
           Debug.Log.Level.LEVEL_ERROR,
           "MCF_MalformedNode",
           "Found a 'Node' (" + curEntity + ") with properties at the end of the file",
@@ -297,7 +297,7 @@ public class McfParser {
   private BiConsumer<String, String> getErrCb() {
     BiConsumer<String, String> errCb =
         (counter, message) -> {
-          logCtx.addLog(Debug.Log.Level.LEVEL_ERROR, counter, message, lineNum);
+          logCtx.addEntry(Debug.Log.Level.LEVEL_ERROR, counter, message, lineNum);
         };
     return errCb;
   }

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -57,7 +57,7 @@ public class TmcfCsvParser {
 
     // Clean and keep a copy of the header map.
     if (tmcfCsvParser.csvParser.getHeaderMap() == null) {
-      tmcfCsvParser.logCtx.addLog(
+      tmcfCsvParser.logCtx.addEntry(
           Debug.Log.Level.LEVEL_FATAL,
           "CSV_HeaderFailure",
           "Unable to parse header from file " + csvFile,
@@ -313,6 +313,6 @@ public class TmcfCsvParser {
   }
 
   private void addLog(Debug.Log.Level level, String counter, String message) {
-    logCtx.addLog(level, counter, message, csvParser.getCurrentLineNumber());
+    logCtx.addEntry(level, counter, message, csvParser.getCurrentLineNumber());
   }
 }

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -195,11 +195,11 @@ public class TmcfCsvParser {
       // Used for parseSchemaTerm() and splitAndStripWithQuoteEscape()
       BiConsumer<String, String> errCb =
           (counter, message) -> {
-            addLog(Debug.Log.Level.LEVEL_ERROR, counter, "Parsing TMCF entity : " + message);
+            addLog(Debug.Log.Level.LEVEL_ERROR, counter, message);
           };
       BiConsumer<String, String> warnCb =
           (counter, message) -> {
-            addLog(Debug.Log.Level.LEVEL_WARNING, counter, "Parsing CSV column value : " + message);
+            addLog(Debug.Log.Level.LEVEL_WARNING, counter, message);
           };
 
       for (Mcf.McfGraph.TypedValue typedValue : templateValues.getTypedValuesList()) {
@@ -274,6 +274,7 @@ public class TmcfCsvParser {
           ssArg.delimiter = delimiter;
           ssArg.includeEmpty = false;
           ssArg.stripEnclosingQuotes = false;
+          ssArg.context = "CSV column " + term.value;
           // TODO: set stripEscapesBeforeQuotes
           List<String> values =
               McfParser.splitAndStripWithQuoteEscape(dataRow.get(columnIndex), ssArg, warnCb);

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -14,12 +14,6 @@
 
 package org.datacommons.util;
 
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
-import org.datacommons.proto.Debug;
-import org.datacommons.proto.Mcf;
-
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
@@ -27,6 +21,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.BiConsumer;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.datacommons.proto.Debug;
+import org.datacommons.proto.Mcf;
 
 // Converts a Template MCF file and an associated CSV into instance MCF.
 public class TmcfCsvParser {
@@ -152,7 +151,7 @@ public class TmcfCsvParser {
                   + tableEntity.getKey()
                   + ": "
                   + tv.getValue());
-          logWrapper.incrementCounterBy("MalformedDCIDPVFailures", pvs.size());
+          logWrapper.incrementCounterBy("CSV_MalformedDCIDPVFailures", pvs.size());
         }
       }
 

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -195,10 +195,11 @@ public class TmcfCsvParser {
       // Used for parseSchemaTerm() and splitAndStripWithQuoteEscape()
       BiConsumer<String, String> errCb =
           (counter, message) -> {
-            addLog(
-                Debug.Log.Level.LEVEL_ERROR,
-                counter,
-                "Failed to parse TMCF column/entity: " + message);
+            addLog(Debug.Log.Level.LEVEL_ERROR, counter, "Parsing TMCF entity : " + message);
+          };
+      BiConsumer<String, String> warnCb =
+          (counter, message) -> {
+            addLog(Debug.Log.Level.LEVEL_WARNING, counter, "Parsing CSV column value : " + message);
           };
 
       for (Mcf.McfGraph.TypedValue typedValue : templateValues.getTypedValuesList()) {
@@ -275,7 +276,7 @@ public class TmcfCsvParser {
           ssArg.stripEnclosingQuotes = false;
           // TODO: set stripEscapesBeforeQuotes
           List<String> values =
-              McfParser.splitAndStripWithQuoteEscape(dataRow.get(columnIndex), ssArg, errCb);
+              McfParser.splitAndStripWithQuoteEscape(dataRow.get(columnIndex), ssArg, warnCb);
           for (String value : values) {
             McfParser.parseTypedValue(
                 Mcf.McfType.INSTANCE_MCF,

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -34,16 +34,15 @@ public class TmcfCsvParser {
   private Mcf.McfGraph tmcf;
   private char delimiter;
   private CSVParser csvParser;
-  private LogWrapper logWrapper;
+  private LogWrapper logCtx;
   private HashMap<String, Integer> cleanedColumnMap;
 
   // Build a parser given a TMCF file, CSV file, CSV delimiter and a log context.
   public static TmcfCsvParser init(
-      String tmcfFile, String csvFile, char delimiter, Debug.Log.Builder logCtx)
-      throws IOException {
+      String tmcfFile, String csvFile, char delimiter, LogWrapper logCtx) throws IOException {
     TmcfCsvParser tmcfCsvParser = new TmcfCsvParser();
     tmcfCsvParser.tmcf = McfParser.parseTemplateMcfFile(tmcfFile, logCtx);
-    tmcfCsvParser.logWrapper = new LogWrapper(logCtx, csvFile);
+    tmcfCsvParser.logCtx = logCtx;
     tmcfCsvParser.csvParser =
         CSVParser.parse(
             new FileReader(csvFile),
@@ -58,7 +57,7 @@ public class TmcfCsvParser {
 
     // Clean and keep a copy of the header map.
     if (tmcfCsvParser.csvParser.getHeaderMap() == null) {
-      tmcfCsvParser.logWrapper.addLog(
+      tmcfCsvParser.logCtx.addLog(
           Debug.Log.Level.LEVEL_FATAL,
           "CSV_HeaderFailure",
           "Unable to parse header from file " + csvFile,
@@ -151,7 +150,7 @@ public class TmcfCsvParser {
                   + tableEntity.getKey()
                   + ": "
                   + tv.getValue());
-          logWrapper.incrementCounterBy("CSV_MalformedDCIDPVFailures", pvs.size());
+          logCtx.incrementCounterBy("CSV_MalformedDCIDPVFailures", pvs.size());
         }
       }
 
@@ -314,6 +313,6 @@ public class TmcfCsvParser {
   }
 
   private void addLog(Debug.Log.Level level, String counter, String message) {
-    logWrapper.addLog(level, counter, message, csvParser.getCurrentLineNumber());
+    logCtx.addLog(level, counter, message, csvParser.getCurrentLineNumber());
   }
 }

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -218,7 +218,7 @@ public class TmcfCsvParser {
               addLog(
                   Debug.Log.Level.LEVEL_WARNING,
                   "CSV_EmptyDcidReferences",
-                  "Empty dcid reference in property "
+                  "In dcid:{entity} reference, found {entity} to be empty for property "
                       + currentProp
                       + " of TMCF entity "
                       + templateEntity);

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -220,7 +220,7 @@ public class TmcfCsvParser {
                   "CSV_EmptyDcidReferences",
                   "Empty dcid reference in property "
                       + currentProp
-                      + " in TMCF entity "
+                      + " of TMCF entity "
                       + templateEntity);
               continue;
             }
@@ -242,11 +242,11 @@ public class TmcfCsvParser {
             addLog(
                 Debug.Log.Level.LEVEL_ERROR,
                 "CSV_UnexpectedNonColumn",
-                "Unexpected non-column "
+                "Unable to parse TMCF column "
                     + typedValue.getValue()
-                    + " for property "
+                    + " in property "
                     + currentProp
-                    + " in TMCF entity "
+                    + " of TMCF entity "
                     + templateEntity);
             continue;
           }
@@ -254,7 +254,7 @@ public class TmcfCsvParser {
             addLog(
                 Debug.Log.Level.LEVEL_ERROR,
                 "CSV_MissingTmcfColumn",
-                "Missing column " + term.value);
+                "Column " + term.value + " referred in TMCF is missing from CSV header");
             continue;
           }
           int columnIndex = cleanedColumnMap.get(term.value);
@@ -262,10 +262,7 @@ public class TmcfCsvParser {
             addLog(
                 Debug.Log.Level.LEVEL_WARNING,
                 "CSV_UnexpectedRow",
-                "Unexpected short row '"
-                    + dataRow.toString()
-                    + "' under column index "
-                    + columnIndex);
+                "Fewer columns than expected in the row: '" + dataRow.toString() + "'");
             continue;
           }
 

--- a/util/src/main/proto/Debug.proto
+++ b/util/src/main/proto/Debug.proto
@@ -60,4 +60,6 @@ message Log {
 
     repeated Entry entries = 1;
     optional CounterSet counter_set = 2;
+    // Key: Level.name()
+    map<string, int64> level_summary = 3;
 }

--- a/util/src/test/java/org/datacommons/util/LogWrapperTest.java
+++ b/util/src/test/java/org/datacommons/util/LogWrapperTest.java
@@ -21,17 +21,17 @@ public class LogWrapperTest {
     // First use LogWrapper to update logCtx
     LogWrapper lw = new LogWrapper(logCtx, testFolder.getRoot().toPath());
     lw.updateLocationFile("TestInput.mcf");
-    lw.addLog(Debug.Log.Level.LEVEL_ERROR, "MCF_NoColonFound", "Missing Colon", 10);
-    lw.addLog(Debug.Log.Level.LEVEL_WARNING, "MCF_EmptyValue", "Empty value", 20);
+    lw.addEntry(Debug.Log.Level.LEVEL_ERROR, "MCF_NoColonFound", "Missing Colon", 10);
+    lw.addEntry(Debug.Log.Level.LEVEL_WARNING, "MCF_EmptyValue", "Empty value", 20);
     lw.updateLocationFile("TestInput.csv");
     lw.incrementCounterBy("CSV_GeneralStats", 42);
-    lw.addLog(Debug.Log.Level.LEVEL_FATAL, "CSV_FoundABomb", "Found a Time Bomb", 30);
+    lw.addEntry(Debug.Log.Level.LEVEL_FATAL, "CSV_FoundABomb", "Found a Time Bomb", 30);
 
     assertEquals("1 fatal, 1 error(s), 1 warning(s)", lw.summaryString());
     assertEquals(true, lw.loggedTooManyFailures());
 
     File wantFile = new File(this.getClass().getResource("LogWrapperTest_result.json").getPath());
-    lw.writeLog(true);
+    lw.persistLog(true);
     File gotFile = new File(Paths.get(testFolder.getRoot().getPath(), "report.json").toString());
     assertEquals(
         FileUtils.readFileToString(gotFile, StandardCharsets.UTF_8),

--- a/util/src/test/java/org/datacommons/util/LogWrapperTest.java
+++ b/util/src/test/java/org/datacommons/util/LogWrapperTest.java
@@ -1,0 +1,42 @@
+package org.datacommons.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.FileUtils;
+import org.datacommons.proto.Debug;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class LogWrapperTest {
+  @Rule public TemporaryFolder testFolder = new TemporaryFolder();
+
+  @Test
+  public void main() throws IOException {
+    Debug.Log.Builder logCtx = Debug.Log.newBuilder();
+    // First use LogWrapper to update logCtx
+    {
+      LogWrapper lw1 = new LogWrapper(logCtx, "TestInput.mcf");
+      lw1.addLog(Debug.Log.Level.LEVEL_ERROR, "MCF_NoColonFound", "Missing Colon", 10);
+      lw1.addLog(Debug.Log.Level.LEVEL_WARNING, "MCF_EmptyValue", "Empty value", 20);
+    }
+    {
+      LogWrapper lw2 = new LogWrapper(logCtx, "TestInput.csv");
+      lw2.incrementCounterBy("CSV_GeneralStats", 42);
+      lw2.addLog(Debug.Log.Level.LEVEL_FATAL, "CSV_FoundABomb", "Found a Time Bomb", 30);
+    }
+
+    assertEquals("1 fatal, 1 error(s), 1 warning(s)", LogWrapper.logSummary(logCtx));
+    assertEquals(true, LogWrapper.loggedTooManyFailures(logCtx));
+
+    File gotFile = testFolder.newFile("result.json");
+    File wantFile = new File(this.getClass().getResource("LogWrapperTest_result.json").getPath());
+    LogWrapper.writeLog(logCtx, gotFile.toPath());
+    assertEquals(
+        FileUtils.readFileToString(gotFile, StandardCharsets.UTF_8),
+        FileUtils.readFileToString(wantFile, StandardCharsets.UTF_8));
+  }
+}

--- a/util/src/test/java/org/datacommons/util/LogWrapperTest.java
+++ b/util/src/test/java/org/datacommons/util/LogWrapperTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import org.apache.commons.io.FileUtils;
 import org.datacommons.proto.Debug;
 import org.junit.Rule;
@@ -18,23 +19,20 @@ public class LogWrapperTest {
   public void main() throws IOException {
     Debug.Log.Builder logCtx = Debug.Log.newBuilder();
     // First use LogWrapper to update logCtx
-    {
-      LogWrapper lw1 = new LogWrapper(logCtx, "TestInput.mcf");
-      lw1.addLog(Debug.Log.Level.LEVEL_ERROR, "MCF_NoColonFound", "Missing Colon", 10);
-      lw1.addLog(Debug.Log.Level.LEVEL_WARNING, "MCF_EmptyValue", "Empty value", 20);
-    }
-    {
-      LogWrapper lw2 = new LogWrapper(logCtx, "TestInput.csv");
-      lw2.incrementCounterBy("CSV_GeneralStats", 42);
-      lw2.addLog(Debug.Log.Level.LEVEL_FATAL, "CSV_FoundABomb", "Found a Time Bomb", 30);
-    }
+    LogWrapper lw = new LogWrapper(logCtx, testFolder.getRoot().toPath());
+    lw.updateLocationFile("TestInput.mcf");
+    lw.addLog(Debug.Log.Level.LEVEL_ERROR, "MCF_NoColonFound", "Missing Colon", 10);
+    lw.addLog(Debug.Log.Level.LEVEL_WARNING, "MCF_EmptyValue", "Empty value", 20);
+    lw.updateLocationFile("TestInput.csv");
+    lw.incrementCounterBy("CSV_GeneralStats", 42);
+    lw.addLog(Debug.Log.Level.LEVEL_FATAL, "CSV_FoundABomb", "Found a Time Bomb", 30);
 
-    assertEquals("1 fatal, 1 error(s), 1 warning(s)", LogWrapper.logSummary(logCtx));
-    assertEquals(true, LogWrapper.loggedTooManyFailures(logCtx));
+    assertEquals("1 fatal, 1 error(s), 1 warning(s)", lw.summaryString());
+    assertEquals(true, lw.loggedTooManyFailures());
 
-    File gotFile = testFolder.newFile("result.json");
     File wantFile = new File(this.getClass().getResource("LogWrapperTest_result.json").getPath());
-    LogWrapper.writeLog(logCtx, gotFile.toPath());
+    lw.writeLog(true);
+    File gotFile = new File(Paths.get(testFolder.getRoot().getPath(), "report.json").toString());
     assertEquals(
         FileUtils.readFileToString(gotFile, StandardCharsets.UTF_8),
         FileUtils.readFileToString(wantFile, StandardCharsets.UTF_8));

--- a/util/src/test/java/org/datacommons/util/McfParserTest.java
+++ b/util/src/test/java/org/datacommons/util/McfParserTest.java
@@ -14,11 +14,12 @@
 
 package org.datacommons.util;
 
-import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
-import static org.datacommons.util.McfParser.*;
-
 import com.google.protobuf.TextFormat;
+import org.apache.commons.io.IOUtils;
+import org.datacommons.proto.Mcf.McfGraph;
+import org.datacommons.proto.Mcf.McfType;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.URISyntaxException;
@@ -26,49 +27,50 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.io.IOUtils;
-import org.datacommons.proto.Mcf.McfGraph;
-import org.datacommons.proto.Mcf.McfType;
-import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
+import static org.datacommons.util.McfParser.*;
 
 public class McfParserTest {
   @Test
   public void funcSplitAndStripWithQuoteEscape() {
     SplitAndStripArg arg = new SplitAndStripArg();
-    assertThat(splitAndStripWithQuoteEscape("one,two,three", arg))
+    assertThat(splitAndStripWithQuoteEscape("one,two,three", arg, null))
         .containsExactly("one", "two", "three");
 
     // Single quote (unterminated or otherwise) should be preserved.
-    assertThat(splitAndStripWithQuoteEscape("\"O'Brien\", 20", arg))
+    assertThat(splitAndStripWithQuoteEscape("\"O'Brien\", 20", arg, null))
         .containsExactly("O'Brien", "20");
 
     // Whitespace surrounding ',' is excluded, but within is included.
-    assertThat(splitAndStripWithQuoteEscape(" o ne, two ,th ree", arg))
+    assertThat(splitAndStripWithQuoteEscape(" o ne, two ,th ree", arg, null))
         .containsExactly("o ne", "two", "th ree");
 
     // One pair of double quotes are removed.
-    assertThat(splitAndStripWithQuoteEscape(" '\"one\"',two,\"three\"", arg))
+    assertThat(splitAndStripWithQuoteEscape(" '\"one\"',two,\"three\"", arg, null))
         .containsExactly("'\"one\"'", "two", "three");
 
     // Comma within double quotes are not split.
-    assertThat(splitAndStripWithQuoteEscape("'one, two', three, \"four, five\"", arg))
+    assertThat(splitAndStripWithQuoteEscape("'one, two', three, \"four, five\"", arg, null))
         .containsExactly("'one", "two'", "three", "four, five");
 
     // Empty strings are by default removed.
-    assertThat(splitAndStripWithQuoteEscape("one,   ,two, \"\" , three", arg))
+    assertThat(splitAndStripWithQuoteEscape("one,   ,two, \"\" , three", arg, null))
         .containsExactly("one", "two", "three");
 
     // Empty strings are kept when specifically requested.
     arg = new SplitAndStripArg();
     arg.includeEmpty = true;
-    assertThat(splitAndStripWithQuoteEscape("one,   ,two, \"\" , three", arg))
+    assertThat(splitAndStripWithQuoteEscape("one,   ,two, \"\" , three", arg, null))
         .containsExactly("one", "", "two", "", "three");
 
     // Strings that are escaped normally show up without character.
     // TODO: make this behavior match prod.
     arg = new SplitAndStripArg();
     arg.includeEmpty = false;
-    assertThat(splitAndStripWithQuoteEscape("\"{ \\\"type\\\": \\\"feature\\\" }\"", arg))
+    assertThat(splitAndStripWithQuoteEscape("\"{ \\\"type\\\": \\\"feature\\\" }\"", arg,
+            null))
         .containsExactly("{ \"type\": \"feature\" }");
   }
 
@@ -179,7 +181,7 @@ public class McfParserTest {
   private McfGraph actual(String file_name, boolean isResolved)
       throws IOException, URISyntaxException {
     String mcf_file = this.getClass().getResource(file_name).getPath();
-    McfParser parser = McfParser.init(McfType.INSTANCE_MCF, mcf_file, isResolved);
+    McfParser parser = McfParser.init(McfType.INSTANCE_MCF, mcf_file, isResolved, null);
     McfGraph.Builder act = McfGraph.newBuilder();
     act.setType(McfType.INSTANCE_MCF);
     McfGraph n;

--- a/util/src/test/java/org/datacommons/util/McfParserTest.java
+++ b/util/src/test/java/org/datacommons/util/McfParserTest.java
@@ -14,12 +14,11 @@
 
 package org.datacommons.util;
 
-import com.google.protobuf.TextFormat;
-import org.apache.commons.io.IOUtils;
-import org.datacommons.proto.Mcf.McfGraph;
-import org.datacommons.proto.Mcf.McfType;
-import org.junit.Test;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
+import static org.datacommons.util.McfParser.*;
 
+import com.google.protobuf.TextFormat;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.URISyntaxException;
@@ -27,10 +26,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
-import static org.datacommons.util.McfParser.*;
+import org.apache.commons.io.IOUtils;
+import org.datacommons.proto.Mcf.McfGraph;
+import org.datacommons.proto.Mcf.McfType;
+import org.junit.Test;
 
 public class McfParserTest {
   @Test
@@ -69,8 +68,7 @@ public class McfParserTest {
     // TODO: make this behavior match prod.
     arg = new SplitAndStripArg();
     arg.includeEmpty = false;
-    assertThat(splitAndStripWithQuoteEscape("\"{ \\\"type\\\": \\\"feature\\\" }\"", arg,
-            null))
+    assertThat(splitAndStripWithQuoteEscape("\"{ \\\"type\\\": \\\"feature\\\" }\"", arg, null))
         .containsExactly("{ \"type\": \"feature\" }");
   }
 
@@ -90,38 +88,38 @@ public class McfParserTest {
 
   @Test
   public void funcParseResolvedGraphAsString() throws IOException {
-    String mcf_string =
+    String mcfString =
         IOUtils.toString(
             this.getClass().getResourceAsStream("McfParserTest_ResolvedGraph.mcf"),
             StandardCharsets.UTF_8);
-    McfGraph act = McfParser.parseInstanceMcfString(mcf_string, true);
+    McfGraph act = McfParser.parseInstanceMcfString(mcfString, true, null);
     McfGraph exp = expected("McfParserTest_ResolvedGraph.textproto");
     assertThat(act).ignoringRepeatedFieldOrder().isEqualTo(exp);
   }
 
   @Test
   public void funcParseResolvedGraphAsFile() throws IOException, URISyntaxException {
-    String mcf_file = this.getClass().getResource("McfParserTest_ResolvedGraph.mcf").getPath();
-    McfGraph act = McfParser.parseInstanceMcfFile(mcf_file, true);
+    String mcfFile = this.getClass().getResource("McfParserTest_ResolvedGraph.mcf").getPath();
+    McfGraph act = McfParser.parseInstanceMcfFile(mcfFile, true, null);
     McfGraph exp = expected("McfParserTest_ResolvedGraph.textproto");
     assertThat(act).ignoringRepeatedFieldOrder().isEqualTo(exp);
   }
 
   @Test
   public void funcParseTemplateMcfAsString() throws IOException {
-    String mcf_string =
+    String mcfString =
         IOUtils.toString(
             this.getClass().getResourceAsStream("McfParserTest_Template.tmcf"),
             StandardCharsets.UTF_8);
-    McfGraph act = McfParser.parseTemplateMcfString(mcf_string);
+    McfGraph act = McfParser.parseTemplateMcfString(mcfString, null);
     McfGraph exp = expected("McfParserTest_Template.textproto");
     assertThat(act).ignoringRepeatedFieldOrder().isEqualTo(exp);
   }
 
   @Test
   public void funcParseTemplateMcfAsFile() throws IOException, URISyntaxException {
-    String mcf_file = this.getClass().getResource("McfParserTest_Template.tmcf").getPath();
-    McfGraph act = McfParser.parseTemplateMcfFile(mcf_file);
+    String mcfFile = this.getClass().getResource("McfParserTest_Template.tmcf").getPath();
+    McfGraph act = McfParser.parseTemplateMcfFile(mcfFile, null);
     McfGraph exp = expected("McfParserTest_Template.textproto");
     assertThat(act).ignoringRepeatedFieldOrder().isEqualTo(exp);
   }
@@ -136,7 +134,8 @@ public class McfParserTest {
                     + "dcid: dcid:dc/maa\n"
                     + "overlapsWith: dcid:dc/456, dcid:dc/134\n"
                     + "name: \"Madras\"\n",
-                true),
+                true,
+                null),
             parseInstanceMcfString(
                 "Node: MadCity\n"
                     + "typeOf: dcs:Corporation\n"
@@ -144,20 +143,23 @@ public class McfParserTest {
                     + "overlapsWith: dcid:dc/134\n"
                     + "containedInPlace: dcid:dc/tn\n"
                     + "name: \"Chennai\"\n",
-                true),
+                true,
+                null),
             parseInstanceMcfString(
                 "Node: MadState\n"
                     + "typeOf: dcs:State\n"
                     + "dcid: dcid:dc/tn\n"
                     + "containedInPlace: dcid:country/india\n",
-                true),
+                true,
+                null),
             parseInstanceMcfString(
                 "Node: MadState\n"
                     + "typeOf: dcs:State\n"
                     + "dcid: dcid:dc/tn\n"
                     + "capital: dcid:dc/maa\n"
                     + "containedInPlace: dcid:dc/southindia\n",
-                true));
+                true,
+                null));
     // Output should be the second node which is the largest, with other PVs
     // patched in, and all types included.
     McfGraph want =
@@ -174,14 +176,15 @@ public class McfParserTest {
                 + "dcid: dcid:dc/tn\n"
                 + "capital: dcid:dc/maa\n"
                 + "containedInPlace: dcid:country/india, dcid:dc/southindia\n",
-            true);
+            true,
+            null);
     assertThat(mergeGraphs(graphs)).ignoringRepeatedFieldOrder().isEqualTo(want);
   }
 
   private McfGraph actual(String file_name, boolean isResolved)
       throws IOException, URISyntaxException {
-    String mcf_file = this.getClass().getResource(file_name).getPath();
-    McfParser parser = McfParser.init(McfType.INSTANCE_MCF, mcf_file, isResolved, null);
+    String mcfFile = this.getClass().getResource(file_name).getPath();
+    McfParser parser = McfParser.init(McfType.INSTANCE_MCF, mcfFile, isResolved, null);
     McfGraph.Builder act = McfGraph.newBuilder();
     act.setType(McfType.INSTANCE_MCF);
     McfGraph n;
@@ -193,10 +196,10 @@ public class McfParserTest {
     return act.build();
   }
 
-  private McfGraph expected(String proto_file) throws IOException {
+  private McfGraph expected(String protoFile) throws IOException {
     McfGraph.Builder expected = McfGraph.newBuilder();
     String proto =
-        IOUtils.toString(this.getClass().getResourceAsStream(proto_file), StandardCharsets.UTF_8);
+        IOUtils.toString(this.getClass().getResourceAsStream(protoFile), StandardCharsets.UTF_8);
     TextFormat.getParser().merge(new StringReader(proto), expected);
     return expected.build();
   }

--- a/util/src/test/java/org/datacommons/util/McfUtilTest.java
+++ b/util/src/test/java/org/datacommons/util/McfUtilTest.java
@@ -52,7 +52,7 @@ public class McfUtilTest {
             + "name: \"California\"\n"
             + "typeOf: dcid:State\n"
             + "\n";
-    Mcf.McfGraph graph = McfParser.parseInstanceMcfString(SERIALIZE_INPUT, false);
+    Mcf.McfGraph graph = McfParser.parseInstanceMcfString(SERIALIZE_INPUT, false, null);
     assertEquals(McfUtil.serializeMcfGraph(graph, true), output);
   }
 }

--- a/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
+++ b/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
@@ -70,7 +70,6 @@ public class TmcfCsvParserTest {
     while ((graph = parser.parseNextRow()) != null) {
       result.add(graph);
     }
-    System.out.println("CounterSet: " + logCtx.toString());
     return McfUtil.serializeMcfGraph(McfParser.mergeGraphs(result), true);
   }
 

--- a/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
+++ b/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
@@ -58,7 +58,7 @@ public class TmcfCsvParserTest {
 
   private String mcf(String file_name) throws URISyntaxException, IOException {
     return McfUtil.serializeMcfGraph(
-        McfParser.parseInstanceMcfFile(resourceToFile(file_name), false), true);
+        McfParser.parseInstanceMcfFile(resourceToFile(file_name), false, null), true);
   }
 
   private String run(String mcf_file, String csv_file) throws IOException, URISyntaxException {

--- a/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
+++ b/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -62,7 +63,7 @@ public class TmcfCsvParserTest {
   }
 
   private String run(String mcf_file, String csv_file) throws IOException, URISyntaxException {
-    Debug.Log.Builder logCtx = Debug.Log.newBuilder();
+    LogWrapper logCtx = new LogWrapper(Debug.Log.newBuilder(), Paths.get("."));
     TmcfCsvParser parser =
         TmcfCsvParser.init(resourceToFile(mcf_file), resourceToFile(csv_file), ',', logCtx);
     List<McfGraph> result = new ArrayList<>();

--- a/util/src/test/resources/org/datacommons/util/LogWrapperTest_result.json
+++ b/util/src/test/resources/org/datacommons/util/LogWrapperTest_result.json
@@ -1,0 +1,40 @@
+{
+  "entries": [{
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TestInput.mcf",
+      "lineNumber": "10"
+    },
+    "userMessage": "Missing Colon",
+    "counterKey": "MCF_NoColonFound"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "TestInput.mcf",
+      "lineNumber": "20"
+    },
+    "userMessage": "Empty value",
+    "counterKey": "MCF_EmptyValue"
+  }, {
+    "level": "LEVEL_FATAL",
+    "location": {
+      "file": "TestInput.csv",
+      "lineNumber": "30"
+    },
+    "userMessage": "Found a Time Bomb",
+    "counterKey": "CSV_FoundABomb"
+  }],
+  "counterSet": {
+    "counters": {
+      "MCF_NoColonFound": "1",
+      "MCF_EmptyValue": "1",
+      "CSV_GeneralStats": "42",
+      "CSV_FoundABomb": "1"
+    }
+  },
+  "levelSummary": {
+    "LEVEL_ERROR": "1",
+    "LEVEL_WARNING": "1",
+    "LEVEL_FATAL": "1"
+  }
+}


### PR DESCRIPTION
* Add a LogWrapper class to provide helpers for logging to the Debug.Log proto on a file
* Plumb the LogWrapper into MCFParser and TmcfCsvParser classes, replacing every `assert` with a logging call
* Finally, produce a JSON report that can then be viewed in a tabular way using something like jsongrid.com. In future, we can see about producing a self-contained html, maybe.

Example run on a real files:

```
$ dc-import lint Google_Health_COVID19_US*
19:57:06.397 [main] INFO  org.datacommons.tool.Lint - Input includes 1 MCF file(s), 1 TMCF file(s), 1 CSV file(s)
19:57:06.504 [main] INFO  org.datacommons.tool.Processor - Checked Google_Health_COVID19_US_StatisticalVariables.mcf with 12 nodes
19:57:30.730 [main] INFO  org.datacommons.tool.Processor - Processed 100000 rows of Google_Health_COVID19_US.csv.  0 fatal, 0 error(s), 867696 warning(s).
19:57:50.925 [main] INFO  org.datacommons.tool.Processor - Processed 200000 rows of Google_Health_COVID19_US.csv.  0 fatal, 0 error(s), 1765154 warning(s).
19:58:11.079 [main] INFO  org.datacommons.tool.Processor - Processed 300000 rows of Google_Health_COVID19_US.csv.  0 fatal, 0 error(s), 2663454 warning(s).
19:58:31.211 [main] INFO  org.datacommons.tool.Processor - Processed 400000 rows of Google_Health_COVID19_US.csv.  0 fatal, 0 error(s), 3561430 warning(s).
19:58:51.391 [main] INFO  org.datacommons.tool.Processor - Processed 500000 rows of Google_Health_COVID19_US.csv.  0 fatal, 0 error(s), 4459560 warning(s).
19:58:59.669 [main] INFO  org.datacommons.tool.Processor - Checked CSV Google_Health_COVID19_US.csv (540971 rows, 5950681 nodes)
19:58:59.669 [main] INFO  org.datacommons.util.McfParser - Failures: 0 fatal, 0 error(s), 4827975 warning(s).  Writing details to ./report.json
```

The report.json when viewed on jsongrid.com looks like this: https://screenshot.googleplex.com/8JHZBZxndJ3jrDT