### PR TITLE
Implement MCF checking and transformations

### DIFF
--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -55,7 +55,6 @@ public class Processor {
     logger.debug("TMCF " + tmcfFile.getName());
     for (File csvFile : csvFiles) {
       logger.debug("Checking CSV " + csvFile.getPath());
-      logCtx.setLocationFile(csvFile.getName());
       TmcfCsvParser parser =
           TmcfCsvParser.init(tmcfFile.getPath(), csvFile.getPath(), delimiter, logCtx);
       Mcf.McfGraph g;

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -1,9 +1,5 @@
 package org.datacommons.tool;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.datacommons.proto.Mcf;
@@ -11,6 +7,11 @@ import org.datacommons.util.LogWrapper;
 import org.datacommons.util.McfParser;
 import org.datacommons.util.McfUtil;
 import org.datacommons.util.TmcfCsvParser;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
 
 class DCTooManyFailuresException extends Exception {
   public DCTooManyFailuresException() {}

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -34,11 +34,10 @@ public class Processor {
     McfParser parser = McfParser.init(type, file.getPath(), false, logCtx);
     Mcf.McfGraph n;
     while ((n = parser.parseNextNode()) != null) {
-      McfMutator mutator = new McfMutator(n.toBuilder(), logCtx);
-      n = mutator.apply();
+      n = McfMutator.apply(n.toBuilder(), logCtx);
 
-      McfChecker checker = new McfChecker(n, logCtx);
-      checker.check();
+      // This will set counters/messages in logCtx.
+      McfChecker.check(n, logCtx);
 
       numNodesProcessed++;
       logCtx.provideStatus(numNodesProcessed, "nodes");
@@ -60,11 +59,10 @@ public class Processor {
       Mcf.McfGraph g;
       long numNodesProcessed = 0, numRowsProcessed = 0;
       while ((g = parser.parseNextRow()) != null) {
-        McfMutator mutator = new McfMutator(g.toBuilder(), logCtx);
-        g = mutator.apply();
+        g = McfMutator.apply(g.toBuilder(), logCtx);
 
-        McfChecker checker = new McfChecker(g, logCtx);
-        checker.check();
+        // This will set counters/messages in logCtx.
+        McfChecker.check(g, logCtx);
 
         if (writer != null) {
           writer.write(McfUtil.serializeMcfGraph(g, false));

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -1,17 +1,13 @@
 package org.datacommons.tool;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.datacommons.proto.Mcf;
-import org.datacommons.util.LogWrapper;
-import org.datacommons.util.McfParser;
-import org.datacommons.util.McfUtil;
-import org.datacommons.util.TmcfCsvParser;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.datacommons.proto.Mcf;
+import org.datacommons.util.*;
 
 class DCTooManyFailuresException extends Exception {
   public DCTooManyFailuresException() {}
@@ -38,6 +34,12 @@ public class Processor {
     McfParser parser = McfParser.init(type, file.getPath(), false, logCtx);
     Mcf.McfGraph n;
     while ((n = parser.parseNextNode()) != null) {
+      McfMutator mutator = new McfMutator(n.toBuilder(), logCtx);
+      n = mutator.apply();
+
+      McfChecker checker = new McfChecker(n, logCtx);
+      checker.check();
+
       numNodesProcessed++;
       logCtx.provideStatus(numNodesProcessed, "nodes");
       if (logCtx.loggedTooManyFailures()) {
@@ -59,6 +61,12 @@ public class Processor {
       Mcf.McfGraph g;
       long numNodesProcessed = 0, numRowsProcessed = 0;
       while ((g = parser.parseNextRow()) != null) {
+        McfMutator mutator = new McfMutator(g.toBuilder(), logCtx);
+        g = mutator.apply();
+
+        McfChecker checker = new McfChecker(g, logCtx);
+        checker.check();
+
         if (writer != null) {
           writer.write(McfUtil.serializeMcfGraph(g, false));
         }

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -34,7 +34,7 @@ public class Processor {
     McfParser parser = McfParser.init(type, file.getPath(), false, logCtx);
     Mcf.McfGraph n;
     while ((n = parser.parseNextNode()) != null) {
-      n = McfMutator.apply(n.toBuilder(), logCtx);
+      n = McfMutator.mutate(n.toBuilder(), logCtx);
 
       // This will set counters/messages in logCtx.
       McfChecker.check(n, logCtx);
@@ -59,7 +59,7 @@ public class Processor {
       Mcf.McfGraph g;
       long numNodesProcessed = 0, numRowsProcessed = 0;
       while ((g = parser.parseNextRow()) != null) {
-        g = McfMutator.apply(g.toBuilder(), logCtx);
+        g = McfMutator.mutate(g.toBuilder(), logCtx);
 
         // This will set counters/messages in logCtx.
         McfChecker.check(g, logCtx);

--- a/util/src/main/java/org/datacommons/proto/Debug.java
+++ b/util/src/main/java/org/datacommons/proto/Debug.java
@@ -17,17 +17,59 @@ public final class Debug {
       // @@protoc_insertion_point(interface_extends:org.datacommons.proto.Log)
       com.google.protobuf.MessageOrBuilder {
 
-    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-    java.util.List<org.datacommons.proto.Debug.Log.Entry> getEntriesList();
-    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-    org.datacommons.proto.Debug.Log.Entry getEntries(int index);
-    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-    int getEntriesCount();
-    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-    java.util.List<? extends org.datacommons.proto.Debug.Log.EntryOrBuilder>
-        getEntriesOrBuilderList();
-    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-    org.datacommons.proto.Debug.Log.EntryOrBuilder getEntriesOrBuilder(int index);
+    /**
+     *
+     *
+     * <pre>
+     * Key: Level.name()
+     * </pre>
+     *
+     * <code>map&lt;string, int64&gt; level_summary = 1;</code>
+     */
+    int getLevelSummaryCount();
+    /**
+     *
+     *
+     * <pre>
+     * Key: Level.name()
+     * </pre>
+     *
+     * <code>map&lt;string, int64&gt; level_summary = 1;</code>
+     */
+    boolean containsLevelSummary(java.lang.String key);
+    /** Use {@link #getLevelSummaryMap()} instead. */
+    @java.lang.Deprecated
+    java.util.Map<java.lang.String, java.lang.Long> getLevelSummary();
+    /**
+     *
+     *
+     * <pre>
+     * Key: Level.name()
+     * </pre>
+     *
+     * <code>map&lt;string, int64&gt; level_summary = 1;</code>
+     */
+    java.util.Map<java.lang.String, java.lang.Long> getLevelSummaryMap();
+    /**
+     *
+     *
+     * <pre>
+     * Key: Level.name()
+     * </pre>
+     *
+     * <code>map&lt;string, int64&gt; level_summary = 1;</code>
+     */
+    long getLevelSummaryOrDefault(java.lang.String key, long defaultValue);
+    /**
+     *
+     *
+     * <pre>
+     * Key: Level.name()
+     * </pre>
+     *
+     * <code>map&lt;string, int64&gt; level_summary = 1;</code>
+     */
+    long getLevelSummaryOrThrow(java.lang.String key);
 
     /**
      * <code>optional .org.datacommons.proto.Log.CounterSet counter_set = 2;</code>
@@ -44,59 +86,17 @@ public final class Debug {
     /** <code>optional .org.datacommons.proto.Log.CounterSet counter_set = 2;</code> */
     org.datacommons.proto.Debug.Log.CounterSetOrBuilder getCounterSetOrBuilder();
 
-    /**
-     *
-     *
-     * <pre>
-     * Key: Level.name()
-     * </pre>
-     *
-     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
-     */
-    int getLevelSummaryCount();
-    /**
-     *
-     *
-     * <pre>
-     * Key: Level.name()
-     * </pre>
-     *
-     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
-     */
-    boolean containsLevelSummary(java.lang.String key);
-    /** Use {@link #getLevelSummaryMap()} instead. */
-    @java.lang.Deprecated
-    java.util.Map<java.lang.String, java.lang.Long> getLevelSummary();
-    /**
-     *
-     *
-     * <pre>
-     * Key: Level.name()
-     * </pre>
-     *
-     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
-     */
-    java.util.Map<java.lang.String, java.lang.Long> getLevelSummaryMap();
-    /**
-     *
-     *
-     * <pre>
-     * Key: Level.name()
-     * </pre>
-     *
-     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
-     */
-    long getLevelSummaryOrDefault(java.lang.String key, long defaultValue);
-    /**
-     *
-     *
-     * <pre>
-     * Key: Level.name()
-     * </pre>
-     *
-     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
-     */
-    long getLevelSummaryOrThrow(java.lang.String key);
+    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+    java.util.List<org.datacommons.proto.Debug.Log.Entry> getEntriesList();
+    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+    org.datacommons.proto.Debug.Log.Entry getEntries(int index);
+    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+    int getEntriesCount();
+    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+    java.util.List<? extends org.datacommons.proto.Debug.Log.EntryOrBuilder>
+        getEntriesOrBuilderList();
+    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+    org.datacommons.proto.Debug.Log.EntryOrBuilder getEntriesOrBuilder(int index);
   }
   /**
    *
@@ -154,12 +154,18 @@ public final class Debug {
             case 10:
               {
                 if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                  entries_ = new java.util.ArrayList<org.datacommons.proto.Debug.Log.Entry>();
+                  levelSummary_ =
+                      com.google.protobuf.MapField.newMapField(
+                          LevelSummaryDefaultEntryHolder.defaultEntry);
                   mutable_bitField0_ |= 0x00000001;
                 }
-                entries_.add(
+                com.google.protobuf.MapEntry<java.lang.String, java.lang.Long> levelSummary__ =
                     input.readMessage(
-                        org.datacommons.proto.Debug.Log.Entry.PARSER, extensionRegistry));
+                        LevelSummaryDefaultEntryHolder.defaultEntry.getParserForType(),
+                        extensionRegistry);
+                levelSummary_
+                    .getMutableMap()
+                    .put(levelSummary__.getKey(), levelSummary__.getValue());
                 break;
               }
             case 18:
@@ -181,18 +187,12 @@ public final class Debug {
             case 26:
               {
                 if (!((mutable_bitField0_ & 0x00000004) != 0)) {
-                  levelSummary_ =
-                      com.google.protobuf.MapField.newMapField(
-                          LevelSummaryDefaultEntryHolder.defaultEntry);
+                  entries_ = new java.util.ArrayList<org.datacommons.proto.Debug.Log.Entry>();
                   mutable_bitField0_ |= 0x00000004;
                 }
-                com.google.protobuf.MapEntry<java.lang.String, java.lang.Long> levelSummary__ =
+                entries_.add(
                     input.readMessage(
-                        LevelSummaryDefaultEntryHolder.defaultEntry.getParserForType(),
-                        extensionRegistry);
-                levelSummary_
-                    .getMutableMap()
-                    .put(levelSummary__.getKey(), levelSummary__.getValue());
+                        org.datacommons.proto.Debug.Log.Entry.PARSER, extensionRegistry));
                 break;
               }
             default:
@@ -209,7 +209,7 @@ public final class Debug {
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+        if (((mutable_bitField0_ & 0x00000004) != 0)) {
           entries_ = java.util.Collections.unmodifiableList(entries_);
         }
         this.unknownFields = unknownFields.build();
@@ -225,7 +225,7 @@ public final class Debug {
     @java.lang.Override
     protected com.google.protobuf.MapField internalGetMapField(int number) {
       switch (number) {
-        case 3:
+        case 1:
           return internalGetLevelSummary();
         default:
           throw new RuntimeException("Invalid map field number: " + number);
@@ -3670,58 +3670,7 @@ public final class Debug {
     }
 
     private int bitField0_;
-    public static final int ENTRIES_FIELD_NUMBER = 1;
-    private java.util.List<org.datacommons.proto.Debug.Log.Entry> entries_;
-    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-    public java.util.List<org.datacommons.proto.Debug.Log.Entry> getEntriesList() {
-      return entries_;
-    }
-    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-    public java.util.List<? extends org.datacommons.proto.Debug.Log.EntryOrBuilder>
-        getEntriesOrBuilderList() {
-      return entries_;
-    }
-    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-    public int getEntriesCount() {
-      return entries_.size();
-    }
-    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-    public org.datacommons.proto.Debug.Log.Entry getEntries(int index) {
-      return entries_.get(index);
-    }
-    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-    public org.datacommons.proto.Debug.Log.EntryOrBuilder getEntriesOrBuilder(int index) {
-      return entries_.get(index);
-    }
-
-    public static final int COUNTER_SET_FIELD_NUMBER = 2;
-    private org.datacommons.proto.Debug.Log.CounterSet counterSet_;
-    /**
-     * <code>optional .org.datacommons.proto.Log.CounterSet counter_set = 2;</code>
-     *
-     * @return Whether the counterSet field is set.
-     */
-    public boolean hasCounterSet() {
-      return ((bitField0_ & 0x00000001) != 0);
-    }
-    /**
-     * <code>optional .org.datacommons.proto.Log.CounterSet counter_set = 2;</code>
-     *
-     * @return The counterSet.
-     */
-    public org.datacommons.proto.Debug.Log.CounterSet getCounterSet() {
-      return counterSet_ == null
-          ? org.datacommons.proto.Debug.Log.CounterSet.getDefaultInstance()
-          : counterSet_;
-    }
-    /** <code>optional .org.datacommons.proto.Log.CounterSet counter_set = 2;</code> */
-    public org.datacommons.proto.Debug.Log.CounterSetOrBuilder getCounterSetOrBuilder() {
-      return counterSet_ == null
-          ? org.datacommons.proto.Debug.Log.CounterSet.getDefaultInstance()
-          : counterSet_;
-    }
-
-    public static final int LEVEL_SUMMARY_FIELD_NUMBER = 3;
+    public static final int LEVEL_SUMMARY_FIELD_NUMBER = 1;
 
     private static final class LevelSummaryDefaultEntryHolder {
       static final com.google.protobuf.MapEntry<java.lang.String, java.lang.Long> defaultEntry =
@@ -3755,7 +3704,7 @@ public final class Debug {
      * Key: Level.name()
      * </pre>
      *
-     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+     * <code>map&lt;string, int64&gt; level_summary = 1;</code>
      */
     public boolean containsLevelSummary(java.lang.String key) {
       if (key == null) {
@@ -3775,7 +3724,7 @@ public final class Debug {
      * Key: Level.name()
      * </pre>
      *
-     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+     * <code>map&lt;string, int64&gt; level_summary = 1;</code>
      */
     public java.util.Map<java.lang.String, java.lang.Long> getLevelSummaryMap() {
       return internalGetLevelSummary().getMap();
@@ -3787,7 +3736,7 @@ public final class Debug {
      * Key: Level.name()
      * </pre>
      *
-     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+     * <code>map&lt;string, int64&gt; level_summary = 1;</code>
      */
     public long getLevelSummaryOrDefault(java.lang.String key, long defaultValue) {
       if (key == null) {
@@ -3803,7 +3752,7 @@ public final class Debug {
      * Key: Level.name()
      * </pre>
      *
-     * <code>map&lt;string, int64&gt; level_summary = 3;</code>
+     * <code>map&lt;string, int64&gt; level_summary = 1;</code>
      */
     public long getLevelSummaryOrThrow(java.lang.String key) {
       if (key == null) {
@@ -3814,6 +3763,57 @@ public final class Debug {
         throw new java.lang.IllegalArgumentException();
       }
       return map.get(key);
+    }
+
+    public static final int COUNTER_SET_FIELD_NUMBER = 2;
+    private org.datacommons.proto.Debug.Log.CounterSet counterSet_;
+    /**
+     * <code>optional .org.datacommons.proto.Log.CounterSet counter_set = 2;</code>
+     *
+     * @return Whether the counterSet field is set.
+     */
+    public boolean hasCounterSet() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional .org.datacommons.proto.Log.CounterSet counter_set = 2;</code>
+     *
+     * @return The counterSet.
+     */
+    public org.datacommons.proto.Debug.Log.CounterSet getCounterSet() {
+      return counterSet_ == null
+          ? org.datacommons.proto.Debug.Log.CounterSet.getDefaultInstance()
+          : counterSet_;
+    }
+    /** <code>optional .org.datacommons.proto.Log.CounterSet counter_set = 2;</code> */
+    public org.datacommons.proto.Debug.Log.CounterSetOrBuilder getCounterSetOrBuilder() {
+      return counterSet_ == null
+          ? org.datacommons.proto.Debug.Log.CounterSet.getDefaultInstance()
+          : counterSet_;
+    }
+
+    public static final int ENTRIES_FIELD_NUMBER = 3;
+    private java.util.List<org.datacommons.proto.Debug.Log.Entry> entries_;
+    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+    public java.util.List<org.datacommons.proto.Debug.Log.Entry> getEntriesList() {
+      return entries_;
+    }
+    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+    public java.util.List<? extends org.datacommons.proto.Debug.Log.EntryOrBuilder>
+        getEntriesOrBuilderList() {
+      return entries_;
+    }
+    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+    public int getEntriesCount() {
+      return entries_.size();
+    }
+    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+    public org.datacommons.proto.Debug.Log.Entry getEntries(int index) {
+      return entries_.get(index);
+    }
+    /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+    public org.datacommons.proto.Debug.Log.EntryOrBuilder getEntriesOrBuilder(int index) {
+      return entries_.get(index);
     }
 
     private byte memoizedIsInitialized = -1;
@@ -3830,14 +3830,14 @@ public final class Debug {
 
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
-      for (int i = 0; i < entries_.size(); i++) {
-        output.writeMessage(1, entries_.get(i));
-      }
+      com.google.protobuf.GeneratedMessageV3.serializeStringMapTo(
+          output, internalGetLevelSummary(), LevelSummaryDefaultEntryHolder.defaultEntry, 1);
       if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(2, getCounterSet());
       }
-      com.google.protobuf.GeneratedMessageV3.serializeStringMapTo(
-          output, internalGetLevelSummary(), LevelSummaryDefaultEntryHolder.defaultEntry, 3);
+      for (int i = 0; i < entries_.size(); i++) {
+        output.writeMessage(3, entries_.get(i));
+      }
       unknownFields.writeTo(output);
     }
 
@@ -3847,12 +3847,6 @@ public final class Debug {
       if (size != -1) return size;
 
       size = 0;
-      for (int i = 0; i < entries_.size(); i++) {
-        size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, entries_.get(i));
-      }
-      if (((bitField0_ & 0x00000001) != 0)) {
-        size += com.google.protobuf.CodedOutputStream.computeMessageSize(2, getCounterSet());
-      }
       for (java.util.Map.Entry<java.lang.String, java.lang.Long> entry :
           internalGetLevelSummary().getMap().entrySet()) {
         com.google.protobuf.MapEntry<java.lang.String, java.lang.Long> levelSummary__ =
@@ -3861,7 +3855,13 @@ public final class Debug {
                 .setKey(entry.getKey())
                 .setValue(entry.getValue())
                 .build();
-        size += com.google.protobuf.CodedOutputStream.computeMessageSize(3, levelSummary__);
+        size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, levelSummary__);
+      }
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream.computeMessageSize(2, getCounterSet());
+      }
+      for (int i = 0; i < entries_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream.computeMessageSize(3, entries_.get(i));
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -3878,12 +3878,12 @@ public final class Debug {
       }
       org.datacommons.proto.Debug.Log other = (org.datacommons.proto.Debug.Log) obj;
 
-      if (!getEntriesList().equals(other.getEntriesList())) return false;
+      if (!internalGetLevelSummary().equals(other.internalGetLevelSummary())) return false;
       if (hasCounterSet() != other.hasCounterSet()) return false;
       if (hasCounterSet()) {
         if (!getCounterSet().equals(other.getCounterSet())) return false;
       }
-      if (!internalGetLevelSummary().equals(other.internalGetLevelSummary())) return false;
+      if (!getEntriesList().equals(other.getEntriesList())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -3895,17 +3895,17 @@ public final class Debug {
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      if (getEntriesCount() > 0) {
-        hash = (37 * hash) + ENTRIES_FIELD_NUMBER;
-        hash = (53 * hash) + getEntriesList().hashCode();
+      if (!internalGetLevelSummary().getMap().isEmpty()) {
+        hash = (37 * hash) + LEVEL_SUMMARY_FIELD_NUMBER;
+        hash = (53 * hash) + internalGetLevelSummary().hashCode();
       }
       if (hasCounterSet()) {
         hash = (37 * hash) + COUNTER_SET_FIELD_NUMBER;
         hash = (53 * hash) + getCounterSet().hashCode();
       }
-      if (!internalGetLevelSummary().getMap().isEmpty()) {
-        hash = (37 * hash) + LEVEL_SUMMARY_FIELD_NUMBER;
-        hash = (53 * hash) + internalGetLevelSummary().hashCode();
+      if (getEntriesCount() > 0) {
+        hash = (37 * hash) + ENTRIES_FIELD_NUMBER;
+        hash = (53 * hash) + getEntriesList().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -4028,7 +4028,7 @@ public final class Debug {
       @SuppressWarnings({"rawtypes"})
       protected com.google.protobuf.MapField internalGetMapField(int number) {
         switch (number) {
-          case 3:
+          case 1:
             return internalGetLevelSummary();
           default:
             throw new RuntimeException("Invalid map field number: " + number);
@@ -4038,7 +4038,7 @@ public final class Debug {
       @SuppressWarnings({"rawtypes"})
       protected com.google.protobuf.MapField internalGetMutableMapField(int number) {
         switch (number) {
-          case 3:
+          case 1:
             return internalGetMutableLevelSummary();
           default:
             throw new RuntimeException("Invalid map field number: " + number);
@@ -4067,27 +4067,27 @@ public final class Debug {
 
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {
-          getEntriesFieldBuilder();
           getCounterSetFieldBuilder();
+          getEntriesFieldBuilder();
         }
       }
 
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (entriesBuilder_ == null) {
-          entries_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        } else {
-          entriesBuilder_.clear();
-        }
+        internalGetMutableLevelSummary().clear();
         if (counterSetBuilder_ == null) {
           counterSet_ = null;
         } else {
           counterSetBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000002);
-        internalGetMutableLevelSummary().clear();
+        if (entriesBuilder_ == null) {
+          entries_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+        } else {
+          entriesBuilder_.clear();
+        }
         return this;
       }
 
@@ -4115,15 +4115,8 @@ public final class Debug {
         org.datacommons.proto.Debug.Log result = new org.datacommons.proto.Debug.Log(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (entriesBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) != 0)) {
-            entries_ = java.util.Collections.unmodifiableList(entries_);
-            bitField0_ = (bitField0_ & ~0x00000001);
-          }
-          result.entries_ = entries_;
-        } else {
-          result.entries_ = entriesBuilder_.build();
-        }
+        result.levelSummary_ = internalGetLevelSummary();
+        result.levelSummary_.makeImmutable();
         if (((from_bitField0_ & 0x00000002) != 0)) {
           if (counterSetBuilder_ == null) {
             result.counterSet_ = counterSet_;
@@ -4132,8 +4125,15 @@ public final class Debug {
           }
           to_bitField0_ |= 0x00000001;
         }
-        result.levelSummary_ = internalGetLevelSummary();
-        result.levelSummary_.makeImmutable();
+        if (entriesBuilder_ == null) {
+          if (((bitField0_ & 0x00000004) != 0)) {
+            entries_ = java.util.Collections.unmodifiableList(entries_);
+            bitField0_ = (bitField0_ & ~0x00000004);
+          }
+          result.entries_ = entries_;
+        } else {
+          result.entries_ = entriesBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -4186,11 +4186,15 @@ public final class Debug {
 
       public Builder mergeFrom(org.datacommons.proto.Debug.Log other) {
         if (other == org.datacommons.proto.Debug.Log.getDefaultInstance()) return this;
+        internalGetMutableLevelSummary().mergeFrom(other.internalGetLevelSummary());
+        if (other.hasCounterSet()) {
+          mergeCounterSet(other.getCounterSet());
+        }
         if (entriesBuilder_ == null) {
           if (!other.entries_.isEmpty()) {
             if (entries_.isEmpty()) {
               entries_ = other.entries_;
-              bitField0_ = (bitField0_ & ~0x00000001);
+              bitField0_ = (bitField0_ & ~0x00000004);
             } else {
               ensureEntriesIsMutable();
               entries_.addAll(other.entries_);
@@ -4203,7 +4207,7 @@ public final class Debug {
               entriesBuilder_.dispose();
               entriesBuilder_ = null;
               entries_ = other.entries_;
-              bitField0_ = (bitField0_ & ~0x00000001);
+              bitField0_ = (bitField0_ & ~0x00000004);
               entriesBuilder_ =
                   com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders
                       ? getEntriesFieldBuilder()
@@ -4213,10 +4217,6 @@ public final class Debug {
             }
           }
         }
-        if (other.hasCounterSet()) {
-          mergeCounterSet(other.getCounterSet());
-        }
-        internalGetMutableLevelSummary().mergeFrom(other.internalGetLevelSummary());
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -4248,208 +4248,156 @@ public final class Debug {
 
       private int bitField0_;
 
-      private java.util.List<org.datacommons.proto.Debug.Log.Entry> entries_ =
-          java.util.Collections.emptyList();
+      private com.google.protobuf.MapField<java.lang.String, java.lang.Long> levelSummary_;
 
-      private void ensureEntriesIsMutable() {
-        if (!((bitField0_ & 0x00000001) != 0)) {
-          entries_ = new java.util.ArrayList<org.datacommons.proto.Debug.Log.Entry>(entries_);
-          bitField0_ |= 0x00000001;
+      private com.google.protobuf.MapField<java.lang.String, java.lang.Long>
+          internalGetLevelSummary() {
+        if (levelSummary_ == null) {
+          return com.google.protobuf.MapField.emptyMapField(
+              LevelSummaryDefaultEntryHolder.defaultEntry);
         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-              org.datacommons.proto.Debug.Log.Entry,
-              org.datacommons.proto.Debug.Log.Entry.Builder,
-              org.datacommons.proto.Debug.Log.EntryOrBuilder>
-          entriesBuilder_;
-
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public java.util.List<org.datacommons.proto.Debug.Log.Entry> getEntriesList() {
-        if (entriesBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(entries_);
-        } else {
-          return entriesBuilder_.getMessageList();
-        }
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public int getEntriesCount() {
-        if (entriesBuilder_ == null) {
-          return entries_.size();
-        } else {
-          return entriesBuilder_.getCount();
-        }
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public org.datacommons.proto.Debug.Log.Entry getEntries(int index) {
-        if (entriesBuilder_ == null) {
-          return entries_.get(index);
-        } else {
-          return entriesBuilder_.getMessage(index);
-        }
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public Builder setEntries(int index, org.datacommons.proto.Debug.Log.Entry value) {
-        if (entriesBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureEntriesIsMutable();
-          entries_.set(index, value);
-          onChanged();
-        } else {
-          entriesBuilder_.setMessage(index, value);
-        }
-        return this;
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public Builder setEntries(
-          int index, org.datacommons.proto.Debug.Log.Entry.Builder builderForValue) {
-        if (entriesBuilder_ == null) {
-          ensureEntriesIsMutable();
-          entries_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          entriesBuilder_.setMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public Builder addEntries(org.datacommons.proto.Debug.Log.Entry value) {
-        if (entriesBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureEntriesIsMutable();
-          entries_.add(value);
-          onChanged();
-        } else {
-          entriesBuilder_.addMessage(value);
-        }
-        return this;
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public Builder addEntries(int index, org.datacommons.proto.Debug.Log.Entry value) {
-        if (entriesBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureEntriesIsMutable();
-          entries_.add(index, value);
-          onChanged();
-        } else {
-          entriesBuilder_.addMessage(index, value);
-        }
-        return this;
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public Builder addEntries(org.datacommons.proto.Debug.Log.Entry.Builder builderForValue) {
-        if (entriesBuilder_ == null) {
-          ensureEntriesIsMutable();
-          entries_.add(builderForValue.build());
-          onChanged();
-        } else {
-          entriesBuilder_.addMessage(builderForValue.build());
-        }
-        return this;
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public Builder addEntries(
-          int index, org.datacommons.proto.Debug.Log.Entry.Builder builderForValue) {
-        if (entriesBuilder_ == null) {
-          ensureEntriesIsMutable();
-          entries_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          entriesBuilder_.addMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public Builder addAllEntries(
-          java.lang.Iterable<? extends org.datacommons.proto.Debug.Log.Entry> values) {
-        if (entriesBuilder_ == null) {
-          ensureEntriesIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(values, entries_);
-          onChanged();
-        } else {
-          entriesBuilder_.addAllMessages(values);
-        }
-        return this;
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public Builder clearEntries() {
-        if (entriesBuilder_ == null) {
-          entries_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-          onChanged();
-        } else {
-          entriesBuilder_.clear();
-        }
-        return this;
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public Builder removeEntries(int index) {
-        if (entriesBuilder_ == null) {
-          ensureEntriesIsMutable();
-          entries_.remove(index);
-          onChanged();
-        } else {
-          entriesBuilder_.remove(index);
-        }
-        return this;
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public org.datacommons.proto.Debug.Log.Entry.Builder getEntriesBuilder(int index) {
-        return getEntriesFieldBuilder().getBuilder(index);
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public org.datacommons.proto.Debug.Log.EntryOrBuilder getEntriesOrBuilder(int index) {
-        if (entriesBuilder_ == null) {
-          return entries_.get(index);
-        } else {
-          return entriesBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public java.util.List<? extends org.datacommons.proto.Debug.Log.EntryOrBuilder>
-          getEntriesOrBuilderList() {
-        if (entriesBuilder_ != null) {
-          return entriesBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(entries_);
-        }
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public org.datacommons.proto.Debug.Log.Entry.Builder addEntriesBuilder() {
-        return getEntriesFieldBuilder()
-            .addBuilder(org.datacommons.proto.Debug.Log.Entry.getDefaultInstance());
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public org.datacommons.proto.Debug.Log.Entry.Builder addEntriesBuilder(int index) {
-        return getEntriesFieldBuilder()
-            .addBuilder(index, org.datacommons.proto.Debug.Log.Entry.getDefaultInstance());
-      }
-      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 1;</code> */
-      public java.util.List<org.datacommons.proto.Debug.Log.Entry.Builder> getEntriesBuilderList() {
-        return getEntriesFieldBuilder().getBuilderList();
+        return levelSummary_;
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-              org.datacommons.proto.Debug.Log.Entry,
-              org.datacommons.proto.Debug.Log.Entry.Builder,
-              org.datacommons.proto.Debug.Log.EntryOrBuilder>
-          getEntriesFieldBuilder() {
-        if (entriesBuilder_ == null) {
-          entriesBuilder_ =
-              new com.google.protobuf.RepeatedFieldBuilderV3<
-                  org.datacommons.proto.Debug.Log.Entry,
-                  org.datacommons.proto.Debug.Log.Entry.Builder,
-                  org.datacommons.proto.Debug.Log.EntryOrBuilder>(
-                  entries_, ((bitField0_ & 0x00000001) != 0), getParentForChildren(), isClean());
-          entries_ = null;
+      private com.google.protobuf.MapField<java.lang.String, java.lang.Long>
+          internalGetMutableLevelSummary() {
+        onChanged();
+        ;
+        if (levelSummary_ == null) {
+          levelSummary_ =
+              com.google.protobuf.MapField.newMapField(LevelSummaryDefaultEntryHolder.defaultEntry);
         }
-        return entriesBuilder_;
+        if (!levelSummary_.isMutable()) {
+          levelSummary_ = levelSummary_.copy();
+        }
+        return levelSummary_;
+      }
+
+      public int getLevelSummaryCount() {
+        return internalGetLevelSummary().getMap().size();
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Key: Level.name()
+       * </pre>
+       *
+       * <code>map&lt;string, int64&gt; level_summary = 1;</code>
+       */
+      public boolean containsLevelSummary(java.lang.String key) {
+        if (key == null) {
+          throw new java.lang.NullPointerException();
+        }
+        return internalGetLevelSummary().getMap().containsKey(key);
+      }
+      /** Use {@link #getLevelSummaryMap()} instead. */
+      @java.lang.Deprecated
+      public java.util.Map<java.lang.String, java.lang.Long> getLevelSummary() {
+        return getLevelSummaryMap();
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Key: Level.name()
+       * </pre>
+       *
+       * <code>map&lt;string, int64&gt; level_summary = 1;</code>
+       */
+      public java.util.Map<java.lang.String, java.lang.Long> getLevelSummaryMap() {
+        return internalGetLevelSummary().getMap();
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Key: Level.name()
+       * </pre>
+       *
+       * <code>map&lt;string, int64&gt; level_summary = 1;</code>
+       */
+      public long getLevelSummaryOrDefault(java.lang.String key, long defaultValue) {
+        if (key == null) {
+          throw new java.lang.NullPointerException();
+        }
+        java.util.Map<java.lang.String, java.lang.Long> map = internalGetLevelSummary().getMap();
+        return map.containsKey(key) ? map.get(key) : defaultValue;
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Key: Level.name()
+       * </pre>
+       *
+       * <code>map&lt;string, int64&gt; level_summary = 1;</code>
+       */
+      public long getLevelSummaryOrThrow(java.lang.String key) {
+        if (key == null) {
+          throw new java.lang.NullPointerException();
+        }
+        java.util.Map<java.lang.String, java.lang.Long> map = internalGetLevelSummary().getMap();
+        if (!map.containsKey(key)) {
+          throw new java.lang.IllegalArgumentException();
+        }
+        return map.get(key);
+      }
+
+      public Builder clearLevelSummary() {
+        internalGetMutableLevelSummary().getMutableMap().clear();
+        return this;
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Key: Level.name()
+       * </pre>
+       *
+       * <code>map&lt;string, int64&gt; level_summary = 1;</code>
+       */
+      public Builder removeLevelSummary(java.lang.String key) {
+        if (key == null) {
+          throw new java.lang.NullPointerException();
+        }
+        internalGetMutableLevelSummary().getMutableMap().remove(key);
+        return this;
+      }
+      /** Use alternate mutation accessors instead. */
+      @java.lang.Deprecated
+      public java.util.Map<java.lang.String, java.lang.Long> getMutableLevelSummary() {
+        return internalGetMutableLevelSummary().getMutableMap();
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Key: Level.name()
+       * </pre>
+       *
+       * <code>map&lt;string, int64&gt; level_summary = 1;</code>
+       */
+      public Builder putLevelSummary(java.lang.String key, long value) {
+        if (key == null) {
+          throw new java.lang.NullPointerException();
+        }
+
+        internalGetMutableLevelSummary().getMutableMap().put(key, value);
+        return this;
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Key: Level.name()
+       * </pre>
+       *
+       * <code>map&lt;string, int64&gt; level_summary = 1;</code>
+       */
+      public Builder putAllLevelSummary(java.util.Map<java.lang.String, java.lang.Long> values) {
+        internalGetMutableLevelSummary().getMutableMap().putAll(values);
+        return this;
       }
 
       private org.datacommons.proto.Debug.Log.CounterSet counterSet_;
@@ -4571,156 +4519,208 @@ public final class Debug {
         return counterSetBuilder_;
       }
 
-      private com.google.protobuf.MapField<java.lang.String, java.lang.Long> levelSummary_;
+      private java.util.List<org.datacommons.proto.Debug.Log.Entry> entries_ =
+          java.util.Collections.emptyList();
 
-      private com.google.protobuf.MapField<java.lang.String, java.lang.Long>
-          internalGetLevelSummary() {
-        if (levelSummary_ == null) {
-          return com.google.protobuf.MapField.emptyMapField(
-              LevelSummaryDefaultEntryHolder.defaultEntry);
+      private void ensureEntriesIsMutable() {
+        if (!((bitField0_ & 0x00000004) != 0)) {
+          entries_ = new java.util.ArrayList<org.datacommons.proto.Debug.Log.Entry>(entries_);
+          bitField0_ |= 0x00000004;
         }
-        return levelSummary_;
-      }
-
-      private com.google.protobuf.MapField<java.lang.String, java.lang.Long>
-          internalGetMutableLevelSummary() {
-        onChanged();
-        ;
-        if (levelSummary_ == null) {
-          levelSummary_ =
-              com.google.protobuf.MapField.newMapField(LevelSummaryDefaultEntryHolder.defaultEntry);
-        }
-        if (!levelSummary_.isMutable()) {
-          levelSummary_ = levelSummary_.copy();
-        }
-        return levelSummary_;
       }
 
-      public int getLevelSummaryCount() {
-        return internalGetLevelSummary().getMap().size();
-      }
-      /**
-       *
-       *
-       * <pre>
-       * Key: Level.name()
-       * </pre>
-       *
-       * <code>map&lt;string, int64&gt; level_summary = 3;</code>
-       */
-      public boolean containsLevelSummary(java.lang.String key) {
-        if (key == null) {
-          throw new java.lang.NullPointerException();
-        }
-        return internalGetLevelSummary().getMap().containsKey(key);
-      }
-      /** Use {@link #getLevelSummaryMap()} instead. */
-      @java.lang.Deprecated
-      public java.util.Map<java.lang.String, java.lang.Long> getLevelSummary() {
-        return getLevelSummaryMap();
-      }
-      /**
-       *
-       *
-       * <pre>
-       * Key: Level.name()
-       * </pre>
-       *
-       * <code>map&lt;string, int64&gt; level_summary = 3;</code>
-       */
-      public java.util.Map<java.lang.String, java.lang.Long> getLevelSummaryMap() {
-        return internalGetLevelSummary().getMap();
-      }
-      /**
-       *
-       *
-       * <pre>
-       * Key: Level.name()
-       * </pre>
-       *
-       * <code>map&lt;string, int64&gt; level_summary = 3;</code>
-       */
-      public long getLevelSummaryOrDefault(java.lang.String key, long defaultValue) {
-        if (key == null) {
-          throw new java.lang.NullPointerException();
-        }
-        java.util.Map<java.lang.String, java.lang.Long> map = internalGetLevelSummary().getMap();
-        return map.containsKey(key) ? map.get(key) : defaultValue;
-      }
-      /**
-       *
-       *
-       * <pre>
-       * Key: Level.name()
-       * </pre>
-       *
-       * <code>map&lt;string, int64&gt; level_summary = 3;</code>
-       */
-      public long getLevelSummaryOrThrow(java.lang.String key) {
-        if (key == null) {
-          throw new java.lang.NullPointerException();
-        }
-        java.util.Map<java.lang.String, java.lang.Long> map = internalGetLevelSummary().getMap();
-        if (!map.containsKey(key)) {
-          throw new java.lang.IllegalArgumentException();
-        }
-        return map.get(key);
-      }
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+              org.datacommons.proto.Debug.Log.Entry,
+              org.datacommons.proto.Debug.Log.Entry.Builder,
+              org.datacommons.proto.Debug.Log.EntryOrBuilder>
+          entriesBuilder_;
 
-      public Builder clearLevelSummary() {
-        internalGetMutableLevelSummary().getMutableMap().clear();
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public java.util.List<org.datacommons.proto.Debug.Log.Entry> getEntriesList() {
+        if (entriesBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(entries_);
+        } else {
+          return entriesBuilder_.getMessageList();
+        }
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public int getEntriesCount() {
+        if (entriesBuilder_ == null) {
+          return entries_.size();
+        } else {
+          return entriesBuilder_.getCount();
+        }
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public org.datacommons.proto.Debug.Log.Entry getEntries(int index) {
+        if (entriesBuilder_ == null) {
+          return entries_.get(index);
+        } else {
+          return entriesBuilder_.getMessage(index);
+        }
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public Builder setEntries(int index, org.datacommons.proto.Debug.Log.Entry value) {
+        if (entriesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEntriesIsMutable();
+          entries_.set(index, value);
+          onChanged();
+        } else {
+          entriesBuilder_.setMessage(index, value);
+        }
         return this;
       }
-      /**
-       *
-       *
-       * <pre>
-       * Key: Level.name()
-       * </pre>
-       *
-       * <code>map&lt;string, int64&gt; level_summary = 3;</code>
-       */
-      public Builder removeLevelSummary(java.lang.String key) {
-        if (key == null) {
-          throw new java.lang.NullPointerException();
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public Builder setEntries(
+          int index, org.datacommons.proto.Debug.Log.Entry.Builder builderForValue) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          entriesBuilder_.setMessage(index, builderForValue.build());
         }
-        internalGetMutableLevelSummary().getMutableMap().remove(key);
         return this;
       }
-      /** Use alternate mutation accessors instead. */
-      @java.lang.Deprecated
-      public java.util.Map<java.lang.String, java.lang.Long> getMutableLevelSummary() {
-        return internalGetMutableLevelSummary().getMutableMap();
-      }
-      /**
-       *
-       *
-       * <pre>
-       * Key: Level.name()
-       * </pre>
-       *
-       * <code>map&lt;string, int64&gt; level_summary = 3;</code>
-       */
-      public Builder putLevelSummary(java.lang.String key, long value) {
-        if (key == null) {
-          throw new java.lang.NullPointerException();
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public Builder addEntries(org.datacommons.proto.Debug.Log.Entry value) {
+        if (entriesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEntriesIsMutable();
+          entries_.add(value);
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(value);
         }
+        return this;
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public Builder addEntries(int index, org.datacommons.proto.Debug.Log.Entry value) {
+        if (entriesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEntriesIsMutable();
+          entries_.add(index, value);
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public Builder addEntries(org.datacommons.proto.Debug.Log.Entry.Builder builderForValue) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.add(builderForValue.build());
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public Builder addEntries(
+          int index, org.datacommons.proto.Debug.Log.Entry.Builder builderForValue) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          entriesBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public Builder addAllEntries(
+          java.lang.Iterable<? extends org.datacommons.proto.Debug.Log.Entry> values) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(values, entries_);
+          onChanged();
+        } else {
+          entriesBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public Builder clearEntries() {
+        if (entriesBuilder_ == null) {
+          entries_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+          onChanged();
+        } else {
+          entriesBuilder_.clear();
+        }
+        return this;
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public Builder removeEntries(int index) {
+        if (entriesBuilder_ == null) {
+          ensureEntriesIsMutable();
+          entries_.remove(index);
+          onChanged();
+        } else {
+          entriesBuilder_.remove(index);
+        }
+        return this;
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public org.datacommons.proto.Debug.Log.Entry.Builder getEntriesBuilder(int index) {
+        return getEntriesFieldBuilder().getBuilder(index);
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public org.datacommons.proto.Debug.Log.EntryOrBuilder getEntriesOrBuilder(int index) {
+        if (entriesBuilder_ == null) {
+          return entries_.get(index);
+        } else {
+          return entriesBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public java.util.List<? extends org.datacommons.proto.Debug.Log.EntryOrBuilder>
+          getEntriesOrBuilderList() {
+        if (entriesBuilder_ != null) {
+          return entriesBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(entries_);
+        }
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public org.datacommons.proto.Debug.Log.Entry.Builder addEntriesBuilder() {
+        return getEntriesFieldBuilder()
+            .addBuilder(org.datacommons.proto.Debug.Log.Entry.getDefaultInstance());
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public org.datacommons.proto.Debug.Log.Entry.Builder addEntriesBuilder(int index) {
+        return getEntriesFieldBuilder()
+            .addBuilder(index, org.datacommons.proto.Debug.Log.Entry.getDefaultInstance());
+      }
+      /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
+      public java.util.List<org.datacommons.proto.Debug.Log.Entry.Builder> getEntriesBuilderList() {
+        return getEntriesFieldBuilder().getBuilderList();
+      }
 
-        internalGetMutableLevelSummary().getMutableMap().put(key, value);
-        return this;
-      }
-      /**
-       *
-       *
-       * <pre>
-       * Key: Level.name()
-       * </pre>
-       *
-       * <code>map&lt;string, int64&gt; level_summary = 3;</code>
-       */
-      public Builder putAllLevelSummary(java.util.Map<java.lang.String, java.lang.Long> values) {
-        internalGetMutableLevelSummary().getMutableMap().putAll(values);
-        return this;
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+              org.datacommons.proto.Debug.Log.Entry,
+              org.datacommons.proto.Debug.Log.Entry.Builder,
+              org.datacommons.proto.Debug.Log.EntryOrBuilder>
+          getEntriesFieldBuilder() {
+        if (entriesBuilder_ == null) {
+          entriesBuilder_ =
+              new com.google.protobuf.RepeatedFieldBuilderV3<
+                  org.datacommons.proto.Debug.Log.Entry,
+                  org.datacommons.proto.Debug.Log.Entry.Builder,
+                  org.datacommons.proto.Debug.Log.EntryOrBuilder>(
+                  entries_, ((bitField0_ & 0x00000004) != 0), getParentForChildren(), isClean());
+          entries_ = null;
+        }
+        return entriesBuilder_;
       }
 
       @java.lang.Override
@@ -4810,11 +4810,11 @@ public final class Debug {
   static {
     java.lang.String[] descriptorData = {
       "\n\013Debug.proto\022\025org.datacommons.proto\"\273\005\n"
-          + "\003Log\0221\n\007entries\030\001 \003(\0132 .org.datacommons."
-          + "proto.Log.Entry\022:\n\013counter_set\030\002 \001(\0132%.o"
-          + "rg.datacommons.proto.Log.CounterSet\022C\n\rl"
-          + "evel_summary\030\003 \003(\0132,.org.datacommons.pro"
-          + "to.Log.LevelSummaryEntry\032-\n\010Location\022\014\n\004"
+          + "\003Log\022C\n\rlevel_summary\030\001 \003(\0132,.org.dataco"
+          + "mmons.proto.Log.LevelSummaryEntry\022:\n\013cou"
+          + "nter_set\030\002 \001(\0132%.org.datacommons.proto.L"
+          + "og.CounterSet\0221\n\007entries\030\003 \003(\0132 .org.dat"
+          + "acommons.proto.Log.Entry\032-\n\010Location\022\014\n\004"
           + "file\030\001 \001(\t\022\023\n\013line_number\030\002 \001(\003\032\204\001\n\nCoun"
           + "terSet\022E\n\010counters\030\001 \003(\01323.org.datacommo"
           + "ns.proto.Log.CounterSet.CountersEntry\032/\n"
@@ -4837,7 +4837,7 @@ public final class Debug {
         new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
             internal_static_org_datacommons_proto_Log_descriptor,
             new java.lang.String[] {
-              "Entries", "CounterSet", "LevelSummary",
+              "LevelSummary", "CounterSet", "Entries",
             });
     internal_static_org_datacommons_proto_Log_Location_descriptor =
         internal_static_org_datacommons_proto_Log_descriptor.getNestedTypes().get(0);

--- a/util/src/main/java/org/datacommons/proto/Mcf.java
+++ b/util/src/main/java/org/datacommons/proto/Mcf.java
@@ -2742,6 +2742,43 @@ public final class Mcf {
        * <code>repeated .org.datacommons.proto.Log.Location locations = 2;</code>
        */
       org.datacommons.proto.Debug.Log.LocationOrBuilder getLocationsOrBuilder(int index);
+
+      /**
+       *
+       *
+       * <pre>
+       * Debug info. For nodes that are generated from TMCF/CSV, this refers to the template Node.
+       * </pre>
+       *
+       * <code>optional string template_node = 3;</code>
+       *
+       * @return Whether the templateNode field is set.
+       */
+      boolean hasTemplateNode();
+      /**
+       *
+       *
+       * <pre>
+       * Debug info. For nodes that are generated from TMCF/CSV, this refers to the template Node.
+       * </pre>
+       *
+       * <code>optional string template_node = 3;</code>
+       *
+       * @return The templateNode.
+       */
+      java.lang.String getTemplateNode();
+      /**
+       *
+       *
+       * <pre>
+       * Debug info. For nodes that are generated from TMCF/CSV, this refers to the template Node.
+       * </pre>
+       *
+       * <code>optional string template_node = 3;</code>
+       *
+       * @return The bytes for templateNode.
+       */
+      com.google.protobuf.ByteString getTemplateNodeBytes();
     }
     /**
      *
@@ -2764,6 +2801,7 @@ public final class Mcf {
 
       private PropertyValues() {
         locations_ = java.util.Collections.emptyList();
+        templateNode_ = "";
       }
 
       @java.lang.Override
@@ -2825,6 +2863,13 @@ public final class Mcf {
                           org.datacommons.proto.Debug.Log.Location.PARSER, extensionRegistry));
                   break;
                 }
+              case 26:
+                {
+                  com.google.protobuf.ByteString bs = input.readBytes();
+                  bitField0_ |= 0x00000001;
+                  templateNode_ = bs;
+                  break;
+                }
               default:
                 {
                   if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
@@ -2874,6 +2919,7 @@ public final class Mcf {
                 org.datacommons.proto.Mcf.McfGraph.PropertyValues.Builder.class);
       }
 
+      private int bitField0_;
       public static final int PVS_FIELD_NUMBER = 1;
 
       private static final class PvsDefaultEntryHolder {
@@ -3048,6 +3094,69 @@ public final class Mcf {
         return locations_.get(index);
       }
 
+      public static final int TEMPLATE_NODE_FIELD_NUMBER = 3;
+      private volatile java.lang.Object templateNode_;
+      /**
+       *
+       *
+       * <pre>
+       * Debug info. For nodes that are generated from TMCF/CSV, this refers to the template Node.
+       * </pre>
+       *
+       * <code>optional string template_node = 3;</code>
+       *
+       * @return Whether the templateNode field is set.
+       */
+      public boolean hasTemplateNode() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Debug info. For nodes that are generated from TMCF/CSV, this refers to the template Node.
+       * </pre>
+       *
+       * <code>optional string template_node = 3;</code>
+       *
+       * @return The templateNode.
+       */
+      public java.lang.String getTemplateNode() {
+        java.lang.Object ref = templateNode_;
+        if (ref instanceof java.lang.String) {
+          return (java.lang.String) ref;
+        } else {
+          com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            templateNode_ = s;
+          }
+          return s;
+        }
+      }
+      /**
+       *
+       *
+       * <pre>
+       * Debug info. For nodes that are generated from TMCF/CSV, this refers to the template Node.
+       * </pre>
+       *
+       * <code>optional string template_node = 3;</code>
+       *
+       * @return The bytes for templateNode.
+       */
+      public com.google.protobuf.ByteString getTemplateNodeBytes() {
+        java.lang.Object ref = templateNode_;
+        if (ref instanceof java.lang.String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          templateNode_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+
       private byte memoizedIsInitialized = -1;
 
       @java.lang.Override
@@ -3066,6 +3175,9 @@ public final class Mcf {
             output, internalGetPvs(), PvsDefaultEntryHolder.defaultEntry, 1);
         for (int i = 0; i < locations_.size(); i++) {
           output.writeMessage(2, locations_.get(i));
+        }
+        if (((bitField0_ & 0x00000001) != 0)) {
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 3, templateNode_);
         }
         unknownFields.writeTo(output);
       }
@@ -3090,6 +3202,9 @@ public final class Mcf {
         for (int i = 0; i < locations_.size(); i++) {
           size += com.google.protobuf.CodedOutputStream.computeMessageSize(2, locations_.get(i));
         }
+        if (((bitField0_ & 0x00000001) != 0)) {
+          size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, templateNode_);
+        }
         size += unknownFields.getSerializedSize();
         memoizedSize = size;
         return size;
@@ -3108,6 +3223,10 @@ public final class Mcf {
 
         if (!internalGetPvs().equals(other.internalGetPvs())) return false;
         if (!getLocationsList().equals(other.getLocationsList())) return false;
+        if (hasTemplateNode() != other.hasTemplateNode()) return false;
+        if (hasTemplateNode()) {
+          if (!getTemplateNode().equals(other.getTemplateNode())) return false;
+        }
         if (!unknownFields.equals(other.unknownFields)) return false;
         return true;
       }
@@ -3126,6 +3245,10 @@ public final class Mcf {
         if (getLocationsCount() > 0) {
           hash = (37 * hash) + LOCATIONS_FIELD_NUMBER;
           hash = (53 * hash) + getLocationsList().hashCode();
+        }
+        if (hasTemplateNode()) {
+          hash = (37 * hash) + TEMPLATE_NODE_FIELD_NUMBER;
+          hash = (53 * hash) + getTemplateNode().hashCode();
         }
         hash = (29 * hash) + unknownFields.hashCode();
         memoizedHashCode = hash;
@@ -3304,6 +3427,8 @@ public final class Mcf {
           } else {
             locationsBuilder_.clear();
           }
+          templateNode_ = "";
+          bitField0_ = (bitField0_ & ~0x00000004);
           return this;
         }
 
@@ -3332,6 +3457,7 @@ public final class Mcf {
           org.datacommons.proto.Mcf.McfGraph.PropertyValues result =
               new org.datacommons.proto.Mcf.McfGraph.PropertyValues(this);
           int from_bitField0_ = bitField0_;
+          int to_bitField0_ = 0;
           result.pvs_ = internalGetPvs();
           result.pvs_.makeImmutable();
           if (locationsBuilder_ == null) {
@@ -3343,6 +3469,11 @@ public final class Mcf {
           } else {
             result.locations_ = locationsBuilder_.build();
           }
+          if (((from_bitField0_ & 0x00000004) != 0)) {
+            to_bitField0_ |= 0x00000001;
+          }
+          result.templateNode_ = templateNode_;
+          result.bitField0_ = to_bitField0_;
           onBuilt();
           return result;
         }
@@ -3422,6 +3553,11 @@ public final class Mcf {
                 locationsBuilder_.addAllMessages(other.locations_);
               }
             }
+          }
+          if (other.hasTemplateNode()) {
+            bitField0_ |= 0x00000004;
+            templateNode_ = other.templateNode_;
+            onChanged();
           }
           this.mergeUnknownFields(other.unknownFields);
           onChanged();
@@ -3988,6 +4124,127 @@ public final class Mcf {
             locations_ = null;
           }
           return locationsBuilder_;
+        }
+
+        private java.lang.Object templateNode_ = "";
+        /**
+         *
+         *
+         * <pre>
+         * Debug info. For nodes that are generated from TMCF/CSV, this refers to the template Node.
+         * </pre>
+         *
+         * <code>optional string template_node = 3;</code>
+         *
+         * @return Whether the templateNode field is set.
+         */
+        public boolean hasTemplateNode() {
+          return ((bitField0_ & 0x00000004) != 0);
+        }
+        /**
+         *
+         *
+         * <pre>
+         * Debug info. For nodes that are generated from TMCF/CSV, this refers to the template Node.
+         * </pre>
+         *
+         * <code>optional string template_node = 3;</code>
+         *
+         * @return The templateNode.
+         */
+        public java.lang.String getTemplateNode() {
+          java.lang.Object ref = templateNode_;
+          if (!(ref instanceof java.lang.String)) {
+            com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              templateNode_ = s;
+            }
+            return s;
+          } else {
+            return (java.lang.String) ref;
+          }
+        }
+        /**
+         *
+         *
+         * <pre>
+         * Debug info. For nodes that are generated from TMCF/CSV, this refers to the template Node.
+         * </pre>
+         *
+         * <code>optional string template_node = 3;</code>
+         *
+         * @return The bytes for templateNode.
+         */
+        public com.google.protobuf.ByteString getTemplateNodeBytes() {
+          java.lang.Object ref = templateNode_;
+          if (ref instanceof String) {
+            com.google.protobuf.ByteString b =
+                com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+            templateNode_ = b;
+            return b;
+          } else {
+            return (com.google.protobuf.ByteString) ref;
+          }
+        }
+        /**
+         *
+         *
+         * <pre>
+         * Debug info. For nodes that are generated from TMCF/CSV, this refers to the template Node.
+         * </pre>
+         *
+         * <code>optional string template_node = 3;</code>
+         *
+         * @param value The templateNode to set.
+         * @return This builder for chaining.
+         */
+        public Builder setTemplateNode(java.lang.String value) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          bitField0_ |= 0x00000004;
+          templateNode_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         *
+         *
+         * <pre>
+         * Debug info. For nodes that are generated from TMCF/CSV, this refers to the template Node.
+         * </pre>
+         *
+         * <code>optional string template_node = 3;</code>
+         *
+         * @return This builder for chaining.
+         */
+        public Builder clearTemplateNode() {
+          bitField0_ = (bitField0_ & ~0x00000004);
+          templateNode_ = getDefaultInstance().getTemplateNode();
+          onChanged();
+          return this;
+        }
+        /**
+         *
+         *
+         * <pre>
+         * Debug info. For nodes that are generated from TMCF/CSV, this refers to the template Node.
+         * </pre>
+         *
+         * <code>optional string template_node = 3;</code>
+         *
+         * @param value The bytes for templateNode to set.
+         * @return This builder for chaining.
+         */
+        public Builder setTemplateNodeBytes(com.google.protobuf.ByteString value) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          bitField0_ |= 0x00000004;
+          templateNode_ = value;
+          onChanged();
+          return this;
         }
 
         @java.lang.Override
@@ -4877,28 +5134,28 @@ public final class Mcf {
   static {
     java.lang.String[] descriptorData = {
       "\n\tMcf.proto\022\025org.datacommons.proto\032\013Debu"
-          + "g.proto\"\355\004\n\010McfGraph\022:\n\004type\030\001 \001(\0162\036.org"
+          + "g.proto\"\204\005\n\010McfGraph\022:\n\004type\030\001 \001(\0162\036.org"
           + ".datacommons.proto.McfType:\014INSTANCE_MCF"
           + "\0229\n\005nodes\030\002 \003(\0132*.org.datacommons.proto."
           + "McfGraph.NodesEntry\032[\n\nTypedValue\022.\n\004typ"
           + "e\030\001 \001(\0162 .org.datacommons.proto.ValueTyp"
           + "e\022\r\n\005value\030\002 \001(\t\022\016\n\006column\030\003 \001(\t\032J\n\006Valu"
           + "es\022@\n\014typed_values\030\001 \003(\0132*.org.datacommo"
-          + "ns.proto.McfGraph.TypedValue\032\342\001\n\016Propert"
+          + "ns.proto.McfGraph.TypedValue\032\371\001\n\016Propert"
           + "yValues\022D\n\003pvs\030\001 \003(\01327.org.datacommons.p"
           + "roto.McfGraph.PropertyValues.PvsEntry\0226\n"
           + "\tlocations\030\002 \003(\0132#.org.datacommons.proto"
-          + ".Log.Location\032R\n\010PvsEntry\022\013\n\003key\030\001 \001(\t\0225"
-          + "\n\005value\030\002 \001(\0132&.org.datacommons.proto.Mc"
-          + "fGraph.Values:\0028\001\032\\\n\nNodesEntry\022\013\n\003key\030\001"
-          + " \001(\t\022=\n\005value\030\002 \001(\0132..org.datacommons.pr"
-          + "oto.McfGraph.PropertyValues:\0028\001*C\n\007McfTy"
-          + "pe\022\024\n\020UNKNOWN_MCF_TYPE\020\000\022\020\n\014INSTANCE_MCF"
-          + "\020\001\022\020\n\014TEMPLATE_MCF\020\002*\226\001\n\tValueType\022\026\n\022UN"
-          + "KNOWN_VALUE_TYPE\020\000\022\010\n\004TEXT\020\001\022\n\n\006NUMBER\020\002"
-          + "\022\022\n\016UNRESOLVED_REF\020\003\022\020\n\014RESOLVED_REF\020\004\022\021"
-          + "\n\rCOMPLEX_VALUE\020\005\022\020\n\014TABLE_COLUMN\020\006\022\020\n\014T"
-          + "ABLE_ENTITY\020\007"
+          + ".Log.Location\022\025\n\rtemplate_node\030\003 \001(\t\032R\n\010"
+          + "PvsEntry\022\013\n\003key\030\001 \001(\t\0225\n\005value\030\002 \001(\0132&.o"
+          + "rg.datacommons.proto.McfGraph.Values:\0028\001"
+          + "\032\\\n\nNodesEntry\022\013\n\003key\030\001 \001(\t\022=\n\005value\030\002 \001"
+          + "(\0132..org.datacommons.proto.McfGraph.Prop"
+          + "ertyValues:\0028\001*C\n\007McfType\022\024\n\020UNKNOWN_MCF"
+          + "_TYPE\020\000\022\020\n\014INSTANCE_MCF\020\001\022\020\n\014TEMPLATE_MC"
+          + "F\020\002*\226\001\n\tValueType\022\026\n\022UNKNOWN_VALUE_TYPE\020"
+          + "\000\022\010\n\004TEXT\020\001\022\n\n\006NUMBER\020\002\022\022\n\016UNRESOLVED_RE"
+          + "F\020\003\022\020\n\014RESOLVED_REF\020\004\022\021\n\rCOMPLEX_VALUE\020\005"
+          + "\022\020\n\014TABLE_COLUMN\020\006\022\020\n\014TABLE_ENTITY\020\007"
     };
     descriptor =
         com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
@@ -4936,7 +5193,7 @@ public final class Mcf {
         new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
             internal_static_org_datacommons_proto_McfGraph_PropertyValues_descriptor,
             new java.lang.String[] {
-              "Pvs", "Locations",
+              "Pvs", "Locations", "TemplateNode",
             });
     internal_static_org_datacommons_proto_McfGraph_PropertyValues_PvsEntry_descriptor =
         internal_static_org_datacommons_proto_McfGraph_PropertyValues_descriptor

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -20,7 +20,7 @@ import org.datacommons.proto.Debug;
 public class LogWrapper {
   private static final Logger logger = LogManager.getLogger(McfParser.class);
 
-  private static final long SECONDS_BETWEEN_STATUS = 60;
+  private static final long SECONDS_BETWEEN_STATUS = 30;
   public static final String REPORT_JSON = "report.json";
   public static final int MAX_ERROR_LIMIT = 50;
   public static final int MAX_MESSAGES_PER_COUNTER = 10;

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -35,7 +35,9 @@ public class LogWrapper {
     this.log = log;
     logPath = Paths.get(outputDir.toString(), REPORT_JSON);
     logger.info(
-        "Report written periodically to {}", logPath.toAbsolutePath().normalize().toString());
+        "Report written every {}s to {}",
+        SECONDS_BETWEEN_STATUS,
+        logPath.toAbsolutePath().normalize().toString());
     locationFile = "FileNotSet.idk";
     lastStatusAt = Instant.now();
     countAtLastStatus = 0;

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -25,17 +25,20 @@ public class McfChecker {
   private Set<String> columns; // Relevant only when graph.type() == TEMPLATE_MCF
   boolean foundFailure = false;
 
+  // Argument |graph| may be Instance or Template MCF.
   public McfChecker(Mcf.McfGraph graph, LogWrapper logCtx) {
     this.graph = graph;
     this.logCtx = logCtx;
   }
 
+  // Used with Template MCF when there are columns from CSV header.
   public McfChecker(Mcf.McfGraph graph, Set<String> columns, LogWrapper logCtx) {
     this.graph = graph;
     this.columns = columns;
     this.logCtx = logCtx;
   }
 
+  // Used to check a single node.
   public McfChecker(
       Mcf.McfType mcfType, String nodeId, Mcf.McfGraph.PropertyValues node, LogWrapper logCtx) {
     Mcf.McfGraph.Builder nodeGraph = Mcf.McfGraph.newBuilder();
@@ -45,6 +48,7 @@ public class McfChecker {
     this.logCtx = logCtx;
   }
 
+  // Returns true if there was an sanity error found.
   public boolean check() {
     foundFailure = false;
     for (String nodeId : graph.getNodesMap().keySet()) {

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -442,9 +442,9 @@ public class McfChecker {
     if (vals.isEmpty()) {
       addLog(
           "Sanity_MissingOrEmpty_" + prop,
-          "Missing or empty value for property "
+          "Missing or empty value for property '"
               + prop
-              + " in node "
+              + "' in node "
               + nodeId
               + " of type "
               + typeOf,

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -28,30 +28,32 @@ public class McfChecker {
   boolean foundFailure = false;
 
   // Argument |graph| may be Instance or Template MCF.
-  public McfChecker(Mcf.McfGraph graph, LogWrapper logCtx) {
-    this.graph = graph;
-    this.logCtx = logCtx;
+  public static boolean check(Mcf.McfGraph graph, LogWrapper logCtx) {
+    return new McfChecker(graph, null, logCtx).check();
+  }
+
+  // Used to check a single node.
+  public static boolean check(
+      Mcf.McfType mcfType, String nodeId, Mcf.McfGraph.PropertyValues node, LogWrapper logCtx) {
+    Mcf.McfGraph.Builder nodeGraph = Mcf.McfGraph.newBuilder();
+    nodeGraph.setType(mcfType);
+    nodeGraph.putNodes(nodeId, node);
+    return new McfChecker(nodeGraph.build(), null, logCtx).check();
   }
 
   // Used with Template MCF when there are columns from CSV header.
-  public McfChecker(Mcf.McfGraph graph, Set<String> columns, LogWrapper logCtx) {
+  public static boolean check(Mcf.McfGraph graph, Set<String> columns, LogWrapper logCtx) {
+    return new McfChecker(graph, columns, logCtx).check();
+  }
+
+  private McfChecker(Mcf.McfGraph graph, Set<String> columns, LogWrapper logCtx) {
     this.graph = graph;
     this.columns = columns;
     this.logCtx = logCtx;
   }
 
-  // Used to check a single node.
-  public McfChecker(
-      Mcf.McfType mcfType, String nodeId, Mcf.McfGraph.PropertyValues node, LogWrapper logCtx) {
-    Mcf.McfGraph.Builder nodeGraph = Mcf.McfGraph.newBuilder();
-    nodeGraph.setType(mcfType);
-    nodeGraph.putNodes(nodeId, node);
-    this.graph = nodeGraph.build();
-    this.logCtx = logCtx;
-  }
-
   // Returns true if there was an sanity error found.
-  public boolean check() {
+  private boolean check() {
     foundFailure = false;
     for (String nodeId : graph.getNodesMap().keySet()) {
       Mcf.McfGraph.PropertyValues node = graph.toBuilder().getNodesOrThrow(nodeId);

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -1,0 +1,430 @@
+package org.datacommons.util;
+
+import com.google.common.base.Charsets;
+import org.datacommons.proto.Debug;
+import org.datacommons.proto.Mcf;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+// Checks common types of nodes on naming and schema requirements.
+// TODO: Pass in a separate SV nodes so we can validate SVObs better.
+public class McfChecker {
+  private final int MAX_DCID_LENGTH = 256;
+  private final List<String> PROPS_ONLY_IN_PROP =
+      List.of(Vocabulary.DOMAIN_INCLUDES, Vocabulary.RANGE_INCLUDES, Vocabulary.SUB_PROPERTY_OF);
+  private final List<String> PROPS_ONLY_IN_CLASS = List.of(Vocabulary.SUB_CLASS_OF);
+  private final Set<String> CLASS_REFS_IN_CLASS =
+      Set.of(Vocabulary.NAME, Vocabulary.LABEL, Vocabulary.DCID, Vocabulary.SUB_CLASS_OF);
+  private final Set<String> CLASS_REFS_IN_PROP =
+      Set.of(Vocabulary.DOMAIN_INCLUDES, Vocabulary.RANGE_INCLUDES);
+  private final Set<String> PROP_REFS_IN_PROP =
+      Set.of(Vocabulary.NAME, Vocabulary.LABEL, Vocabulary.DCID, Vocabulary.SUB_PROPERTY_OF);
+  private Mcf.McfGraph graph;
+  private LogWrapper logCtx;
+  private HashSet<String> columns;  // Relevant only when graph.type() == TEMPLATE_MCF
+  boolean foundFailure = false;
+
+  public McfChecker(Mcf.McfGraph graph, LogWrapper logCtx) {
+    this.graph = graph;
+    this.logCtx = logCtx;
+  }
+
+  public McfChecker(Mcf.McfGraph graph, HashSet<String> columns, LogWrapper logCtx) {
+    this.graph = graph;
+    this.columns = columns;
+    this.logCtx = logCtx;
+  }
+
+  public McfChecker(
+      Mcf.McfType mcfType, String nodeId, Mcf.McfGraph.PropertyValues node, LogWrapper logCtx) {
+    Mcf.McfGraph.Builder nodeGraph = Mcf.McfGraph.newBuilder();
+    nodeGraph.setType(mcfType);
+    nodeGraph.putNodes(nodeId, node);
+    this.graph = nodeGraph.build();
+    this.logCtx = logCtx;
+  }
+
+  public boolean check() {
+    foundFailure = false;
+    for (String nodeId : graph.getNodesMap().keySet()) {
+      Mcf.McfGraph.PropertyValues node = graph.toBuilder().getNodesOrThrow(nodeId);
+      checkNode(nodeId, node);
+      if (graph.getType() == Mcf.McfType.TEMPLATE_MCF) {
+        checkTemplate(nodeId, node);
+      }
+    }
+    return foundFailure;
+  }
+
+  private void checkNode(String nodeId, Mcf.McfGraph.PropertyValues node) {
+    checkCommon(nodeId, node);
+    for (String typeOf : McfUtil.getPropVals(node, Vocabulary.TYPE_OF)) {
+      if (Vocabulary.isStatVarObs(typeOf)) {
+        checkSVObs(nodeId, node);
+      } else if (typeOf.equals(Vocabulary.CLASS_TYPE) || typeOf.equals(Vocabulary.PROPERTY_TYPE)) {
+        checkClassOrProp(typeOf, nodeId, node);
+      } else if (Vocabulary.isStatVar(typeOf)) {
+        checkStatVar(nodeId, node);
+      } else if (Vocabulary.isLegacyObservation(typeOf)) {
+        checkLegacyObs(nodeId, node);
+      } else if (Vocabulary.isPopulation(typeOf)) {
+        checkLegacyPopulation(nodeId, node);
+      }
+    }
+  }
+
+  private void checkStatVar(String nodeId, Mcf.McfGraph.PropertyValues node) {
+    String popType =
+        checkRequiredSingleValueProp(
+            nodeId, node, Vocabulary.STAT_VAR_TYPE, Vocabulary.POPULATION_TYPE);
+    checkInitCasing(nodeId, node, Vocabulary.POPULATION_TYPE, popType, true);
+
+    String mProp =
+        checkRequiredSingleValueProp(
+            nodeId, node, Vocabulary.STAT_VAR_TYPE, Vocabulary.MEASURED_PROP);
+    checkInitCasing(nodeId, node, Vocabulary.MEASURED_PROP, mProp, false);
+
+    String statType =
+        checkRequiredSingleValueProp(nodeId, node, Vocabulary.STAT_VAR_TYPE, Vocabulary.STAT_TYPE);
+    checkInitCasing(nodeId, node, Vocabulary.STAT_TYPE, statType, false);
+  }
+
+  private void checkSVObs(String nodeId, Mcf.McfGraph.PropertyValues node) {
+    checkRequiredSingleValueProp(
+        nodeId, node, Vocabulary.STAT_VAR_OBSERVATION_TYPE, Vocabulary.VARIABLE_MEASURED);
+    checkRequiredSingleValueProp(
+        nodeId, node, Vocabulary.STAT_VAR_OBSERVATION_TYPE, Vocabulary.OBSERVATION_ABOUT);
+    checkRequiredSingleValueProp(
+        nodeId, node, Vocabulary.STAT_VAR_OBSERVATION_TYPE, Vocabulary.GENERIC_VALUE);
+    String obsDate =
+        checkRequiredSingleValueProp(
+            nodeId, node, Vocabulary.STAT_VAR_OBSERVATION_TYPE, Vocabulary.OBSERVATION_DATE);
+    if (graph.getType() != Mcf.McfType.TEMPLATE_MCF
+        && !obsDate.isEmpty()
+        && !McfUtil.isValidISO8601Date(obsDate)) {
+      addLog(
+          "Sanity_InvalidObsDate",
+          "Found a non-ISO8601 compliant value '"
+              + obsDate
+              + "' for property "
+              + Vocabulary.OBSERVATION_DATE
+              + " in node "
+              + nodeId,
+          node);
+    }
+  }
+
+  private void checkLegacyPopulation(String nodeId, Mcf.McfGraph.PropertyValues node) {
+    String popType =
+        checkRequiredSingleValueProp(
+            nodeId, node, "StatisticalPopulation", Vocabulary.POPULATION_TYPE);
+    checkInitCasing(nodeId, node, Vocabulary.POPULATION_TYPE, popType, true);
+
+    checkRequiredSingleValueProp(nodeId, node, "StatisticalPopulation", Vocabulary.LOCATION);
+  }
+
+  private void checkLegacyObs(String nodeId, Mcf.McfGraph.PropertyValues node) {
+    String mProp =
+        checkRequiredSingleValueProp(
+            nodeId, node, Vocabulary.LEGACY_OBSERVATION_TYPE_SUFFIX, Vocabulary.MEASURED_PROP);
+    checkInitCasing(nodeId, node, Vocabulary.MEASURED_PROP, mProp, false);
+
+    checkRequiredSingleValueProp(
+        nodeId, node, Vocabulary.LEGACY_OBSERVATION_TYPE_SUFFIX, Vocabulary.OBSERVED_NODE);
+
+    String obsDate =
+        checkRequiredSingleValueProp(
+            nodeId, node, Vocabulary.LEGACY_OBSERVATION_TYPE_SUFFIX, Vocabulary.OBSERVATION_DATE);
+    if (graph.getType() != Mcf.McfType.TEMPLATE_MCF
+        && !obsDate.isEmpty()
+        && !McfUtil.isValidISO8601Date(obsDate)) {
+      addLog(
+          "Sanity_InvalidObsDate",
+          "Found a non-ISO8601 compliant value '"
+              + obsDate
+              + "' for property "
+              + Vocabulary.OBSERVATION_DATE
+              + " in node "
+              + nodeId,
+          node);
+    }
+
+    boolean value_present = false;
+    for (Map.Entry<String, Mcf.McfGraph.Values> pv : node.getPvsMap().entrySet()) {
+      String prop = pv.getKey();
+      if (Vocabulary.isStatValueProperty(prop)) {
+        String val =
+            checkRequiredSingleValueProp(
+                nodeId, node, Vocabulary.LEGACY_OBSERVATION_TYPE_SUFFIX, prop);
+        if (graph.getType() != Mcf.McfType.TEMPLATE_MCF && !val.isEmpty()) {
+          if (!McfUtil.isNumber(val)) {
+            addLog(
+                "Sanity_NonDoubleObsValue",
+                "Expected value of type double for Observation property "
+                    + prop
+                    + " in node "
+                    + nodeId,
+                node);
+          }
+        }
+        value_present = true;
+      }
+    }
+    if (!value_present) {
+      checkRequiredSingleValueProp(
+          nodeId, node, Vocabulary.LEGACY_OBSERVATION_TYPE_SUFFIX, Vocabulary.MEASUREMENT_RESULT);
+    }
+  }
+
+  private void checkCommon(String nodeId, Mcf.McfGraph.PropertyValues node) {
+    checkRequiredValueProp(nodeId, node, "Thing", Vocabulary.TYPE_OF);
+    for (Map.Entry<String, Mcf.McfGraph.Values> pv : node.getPvsMap().entrySet()) {
+      String prop = pv.getKey();
+      if (prop.isEmpty()) {
+        addLog("Sanity_EmptyProperty", "Found an empty property in node " + nodeId, node);
+        continue;
+      }
+
+      if (!Character.isLowerCase(prop.charAt(0))) {
+        addLog(
+            "Sanity_InitUpperCasePropName",
+            "Found property name "
+                + prop
+                + " that does not start with a "
+                + " lower-case in node "
+                + nodeId,
+            node);
+        continue;
+      }
+
+      Mcf.McfGraph.Values vals = pv.getValue();
+      if (prop.equals(Vocabulary.DCID)) {
+        if (vals.getTypedValuesCount() != 1) {
+          addLog(
+              "Sanity_MultipleDCIDValues",
+              "Property dcid must have exactly one value, but found "
+                  + vals.getTypedValuesCount()
+                  + " in node "
+                  + nodeId,
+              node);
+          continue;
+        }
+        String dcid = vals.getTypedValues(0).getValue();
+        if (vals.getTypedValues(0).getType() == Mcf.ValueType.TABLE_ENTITY) {
+          addLog(
+              "Sanity_DcidTableEntity",
+              "Value of property dcid must not be an entity reference ("
+                  + dcid
+                  + ") in node "
+                  + nodeId,
+              node);
+          continue;
+        }
+        if (dcid.length() > MAX_DCID_LENGTH) {
+          addLog(
+              "Sanity_VeryLongDcid",
+              "Found a very long dcid value (> " + MAX_DCID_LENGTH + ") for node " + nodeId,
+              node);
+          continue;
+        }
+        // TODO: Expand this to include other special characters.
+        if (!dcid.startsWith("bio/") && dcid.contains(" ")) {
+          addLog(
+              "Sanity_SpaceInDcid",
+              "Found a whitespace in dcid value (" + dcid + ") in node " + nodeId,
+              node);
+          continue;
+        }
+      }
+
+      for (Mcf.McfGraph.TypedValue tv : pv.getValue().getTypedValuesList()) {
+        if (tv.getType() != Mcf.ValueType.TEXT
+            && !Charsets.US_ASCII.newEncoder().canEncode(tv.getValue())) {
+          // Non-text values must be ascii.
+          addLog(
+              "Sanity_NonAsciiValueInNonText",
+              "Value '"
+                  + tv.getValue()
+                  + "' for property "
+                  + prop
+                  + " in "
+                  + "node "
+                  + nodeId
+                  + " is a non-text value which contains non-ascii "
+                  + "characters.",
+              node);
+        }
+        if (Vocabulary.isReferenceProperty(prop)
+            && (tv.getType() == Mcf.ValueType.TEXT || tv.getType() == Mcf.ValueType.NUMBER)) {
+          addLog(
+              "Sanity_RefPropHasNonRefValue",
+              "Value '"
+                  + tv.getValue()
+                  + "' for reference property "
+                  + prop
+                  + " in "
+                  + "node "
+                  + nodeId
+                  + " is not a reference.",
+              node);
+        }
+      }
+    }
+  }
+
+  private void checkClassOrProp(String typeOf, String nodeId, Mcf.McfGraph.PropertyValues node) {
+    List<String> unexpectedProps =
+        typeOf.equals(Vocabulary.CLASS_TYPE) ? PROPS_ONLY_IN_CLASS : PROPS_ONLY_IN_PROP;
+    for (String prop : unexpectedProps) {
+      if (!McfUtil.getPropVal(node, prop).isEmpty()) {
+        addLog(
+            "Sanity_UnexpectedPropInSchema",
+            typeOf + " node " + nodeId + " must not include property " + prop,
+            node);
+      }
+    }
+    for (Map.Entry<String, Mcf.McfGraph.Values> pv : node.getPvsMap().entrySet()) {
+      String prop = pv.getKey();
+      for (Mcf.McfGraph.TypedValue tv : pv.getValue().getTypedValuesList()) {
+        String val = tv.getValue();
+        if (val.isEmpty()) {
+          addLog(
+              "Sanity_EmptySchemaValue",
+              "Found empty value for property " + prop + " in node " + nodeId,
+              node);
+          continue;
+        }
+        if (!Charsets.US_ASCII.newEncoder().canEncode(val)) {
+          addLog(
+              "Sanity_NonAsciiValueInSchema",
+              "Value ("
+                  + val
+                  + ") in property "
+                  + prop
+                  + " of node "
+                  + nodeId
+                  + " contains non-ascii characters",
+              node);
+          continue;
+        }
+        if (typeOf.equals(Vocabulary.CLASS_TYPE) && CLASS_REFS_IN_CLASS.contains(prop)
+            || (typeOf.equals(Vocabulary.PROPERTY_TYPE) && CLASS_REFS_IN_PROP.contains(prop))) {
+          checkInitCasing(nodeId, node, prop, val, true);
+        }
+        if (typeOf.equals(Vocabulary.PROPERTY_TYPE) && PROP_REFS_IN_PROP.contains(prop)) {
+          checkInitCasing(nodeId, node, prop, val, false);
+        }
+      }
+    }
+    if (typeOf.equals(Vocabulary.CLASS_TYPE)
+        && !McfUtil.getPropVal(node, Vocabulary.DCID).equals(Vocabulary.THING_TYPE)) {
+      checkRequiredSingleValueProp(nodeId, node, Vocabulary.CLASS_TYPE, Vocabulary.SUB_CLASS_OF);
+    }
+  }
+
+  private void checkTemplate(String nodeId, Mcf.McfGraph.PropertyValues node) {
+    for (Map.Entry<String, Mcf.McfGraph.Values> pv : node.getPvsMap().entrySet()) {
+      for (Mcf.McfGraph.TypedValue tv : pv.getValue().getTypedValuesList()) {
+        if (tv.getType() == Mcf.ValueType.TABLE_ENTITY) {
+          if (!graph.getNodesMap().containsKey(tv.getValue())) {
+              << "Missing entity " << tv.val() << " in " << kv1.first;
+          }
+        } else if (tv.getType() == Mcf.ValueType.TABLE_COLUMN) {
+          // NOTE: If the MCF had parsed, the schema terms should be valid, thus
+          // the ValueOrDie().
+          McfParser.SchemaTerm term = McfParser.parseSchemaTerm(tv.getValue(), null)
+          if (term.type != McfParser.SchemaTerm.Type.COLUMN) {
+            addLog("Sanity_TemplateColumnParseFailure",
+                    "Failed to parse ");
+          }
+          if (columns != null && !columns.contains(term.value)) {
+            RET_CHECK(gtl::ContainsKey(columns, term.value))
+              << "Missing column " << term.value << " (" << tv.val()
+                    << ") found in " << kv1.first;
+          }
+        }
+      }
+    }
+  }
+
+  private String checkRequiredSingleValueProp(
+      String nodeId, Mcf.McfGraph.PropertyValues node, String typeOf, String prop) {
+    List<String> vals = McfUtil.getPropVals(node, prop);
+    if (vals.isEmpty()) {
+      addLog(
+          "Sanity_MissingOrEmpty_" + prop,
+          "Missing or empty value for property "
+              + prop
+              + " in node "
+              + nodeId
+              + " of type "
+              + typeOf,
+          node);
+      return "";
+    }
+    if (vals.size() != 1) {
+      addLog(
+          "Sanity_MultipleVals_" + prop,
+          "Found multiple values for " + prop + " in node " + nodeId,
+          node);
+      return "";
+    }
+    return vals.get(0);
+  }
+
+  private void checkRequiredValueProp(
+      String nodeId, Mcf.McfGraph.PropertyValues node, String typeOf, String prop) {
+    List<String> vals = McfUtil.getPropVals(node, prop);
+    if (vals.isEmpty()) {
+      addLog(
+          "Sanity_MissingOrEmpty_" + prop,
+          "Missing or empty value for property "
+              + prop
+              + " in node "
+              + nodeId
+              + " of type "
+              + typeOf,
+          node);
+    }
+  }
+
+  private void checkInitCasing(
+      String nodeId,
+      Mcf.McfGraph.PropertyValues node,
+      String prop,
+      String value,
+      boolean expectInitUpper) {
+    if (value.isEmpty()) return;
+    if (expectInitUpper && !Character.isUpperCase(value.charAt(0))) {
+      addLog(
+          "Sanity_NotInitUpper_" + prop,
+          "Found a class ref '"
+              + value
+              + "' in property "
+              + prop
+              + " in node "
+              + nodeId
+              + " which does not start with an upper case",
+          node);
+    } else if (!expectInitUpper && !Character.isLowerCase(value.charAt(0))) {
+      addLog(
+          "Sanity_NotInitLower_" + prop,
+          "Found a property ref '"
+              + value
+              + "' in property "
+              + prop
+              + " in node "
+              + nodeId
+              + " which does not start with a lower case",
+          node);
+    }
+  }
+
+  private void addLog(String counter, String message, Mcf.McfGraph.PropertyValues node) {
+    foundFailure = true;
+    logCtx.addEntry(Debug.Log.Level.LEVEL_ERROR, counter, message, node.getLocationsList());
+  }
+}

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -64,6 +64,10 @@ public class McfChecker {
   }
 
   private void checkNode(String nodeId, Mcf.McfGraph.PropertyValues node) {
+    if (node.hasTemplateNode()) {
+      // The TMCF node ref is more user-friendly.
+      nodeId = node.getTemplateNode();
+    }
     checkCommon(nodeId, node);
     for (String typeOf : McfUtil.getPropVals(node, Vocabulary.TYPE_OF)) {
       if (Vocabulary.isStatVarObs(typeOf)) {

--- a/util/src/main/java/org/datacommons/util/McfMutator.java
+++ b/util/src/main/java/org/datacommons/util/McfMutator.java
@@ -1,0 +1,88 @@
+package org.datacommons.util;
+
+import static org.datacommons.util.McfUtil.getPropVals;
+
+import java.util.List;
+import java.util.Map;
+import org.datacommons.proto.Debug;
+import org.datacommons.proto.Mcf;
+
+// Does additional transformations on parsed MCF nodes, like expanding ComplexValues into nodes.
+//
+// TODO: Implement constraintProperties computation for SV (CPP Partiy).
+// TODO: Attach provenance maybe (CPP Partiy).
+// TODO: Pass in a separate SV nodes to clean SVObs double values.
+public class McfMutator {
+  private Mcf.McfGraph.Builder graph;
+  private LogWrapper logCtx;
+
+  public McfMutator(Mcf.McfGraph.Builder graph, LogWrapper logCtx) {
+    this.graph = graph;
+    this.logCtx = logCtx;
+  }
+
+  public Mcf.McfGraph apply() {
+    for (String nodeId : graph.getNodesMap().keySet()) {
+      graph.putNodes(nodeId, applyOnNode(nodeId, graph.getNodesOrThrow(nodeId).toBuilder()));
+    }
+    return graph.build();
+  }
+
+  private Mcf.McfGraph.PropertyValues applyOnNode(
+      String nodeId, Mcf.McfGraph.PropertyValues.Builder node) {
+    List<String> types = getPropVals(node.build(), Vocabulary.TYPE_OF);
+    if (types == null) {
+      logCtx.addEntry(
+          Debug.Log.Level.LEVEL_ERROR,
+          "Mutator_MissingTypeOf",
+          "Missing typeOf value for node " + nodeId,
+          node.getLocationsList());
+      return node.build();
+    }
+    boolean isLegacyObs = false;
+    for (String type : types) {
+      if (Vocabulary.isLegacyObservation(type)) {
+        isLegacyObs = true;
+        break;
+      }
+    }
+    for (Map.Entry<String, Mcf.McfGraph.Values> pv : node.getPvsMap().entrySet()) {
+      String prop = pv.getKey();
+      Mcf.McfGraph.Values.Builder vb = Mcf.McfGraph.Values.newBuilder();
+      for (Mcf.McfGraph.TypedValue tv : pv.getValue().getTypedValuesList()) {
+        Mcf.McfGraph.TypedValue.Builder tvb = tv.toBuilder();
+        if (isLegacyObs && Vocabulary.isStatValueProperty(prop)) {
+          if (tv.getType() != Mcf.ValueType.NUMBER && tv.getType() != Mcf.ValueType.TEXT) {
+            logCtx.addEntry(
+                Debug.Log.Level.LEVEL_ERROR,
+                "Mutator_InvalidObsValue",
+                "Wrong inferred type " + tv.getType() + " for property " + prop + " in " + nodeId,
+                node.getLocationsList());
+            return node.build();
+          }
+          tvb.setValue(prepForDoubleConversion(tv.getValue()));
+        }
+
+        if (tv.getType() == Mcf.ValueType.COMPLEX_VALUE) {
+          Mcf.McfGraph.PropertyValues.Builder complexNode =
+              Mcf.McfGraph.PropertyValues.newBuilder();
+          ComplexValueParser cvParser =
+              new ComplexValueParser(
+                  nodeId, node.build(), prop, tv.getValue(), complexNode, logCtx);
+          if (cvParser.parse()) {
+            tvb.setValue(cvParser.getDcid());
+            tvb.setType(Mcf.ValueType.RESOLVED_REF);
+            graph.putNodes(cvParser.getDcid(), complexNode.build());
+          }
+        }
+        vb.addTypedValues(tvb.build());
+      }
+      node.putPvs(prop, vb.build());
+    }
+    return node.build();
+  }
+
+  private static String prepForDoubleConversion(String v) {
+    return v.replace(" ", "").replace(",", "").replace("%", "");
+  }
+}

--- a/util/src/main/java/org/datacommons/util/McfMutator.java
+++ b/util/src/main/java/org/datacommons/util/McfMutator.java
@@ -9,24 +9,24 @@ import org.datacommons.proto.Mcf;
 
 // Does additional transformations on parsed MCF nodes, like expanding ComplexValues into nodes.
 //
-// TODO: Implement constraintProperties computation for SV (CPP Partiy).
-// TODO: Attach provenance maybe (CPP Partiy).
+// TODO: Implement constraintProperties computation for SV (CPP Parity).
+// TODO: Attach provenance maybe (CPP Parity).
 // TODO: Pass in a separate SV nodes to clean SVObs double values.
 public class McfMutator {
   private Mcf.McfGraph.Builder graph;
   private LogWrapper logCtx;
 
-  public static Mcf.McfGraph apply(Mcf.McfGraph.Builder graph, LogWrapper logCtx) {
+  public static Mcf.McfGraph mutate(Mcf.McfGraph.Builder graph, LogWrapper logCtx) {
     McfMutator m = new McfMutator();
     m.graph = graph;
     m.logCtx = logCtx;
     for (String nodeId : graph.getNodesMap().keySet()) {
-      m.graph.putNodes(nodeId, m.applyOnNode(nodeId, m.graph.getNodesOrThrow(nodeId).toBuilder()));
+      m.graph.putNodes(nodeId, m.mutateNode(nodeId, m.graph.getNodesOrThrow(nodeId).toBuilder()));
     }
     return m.graph.build();
   }
 
-  private Mcf.McfGraph.PropertyValues applyOnNode(
+  private Mcf.McfGraph.PropertyValues mutateNode(
       String nodeId, Mcf.McfGraph.PropertyValues.Builder node) {
     List<String> types = getPropVals(node.build(), Vocabulary.TYPE_OF);
     if (types == null) {

--- a/util/src/main/java/org/datacommons/util/McfMutator.java
+++ b/util/src/main/java/org/datacommons/util/McfMutator.java
@@ -16,16 +16,14 @@ public class McfMutator {
   private Mcf.McfGraph.Builder graph;
   private LogWrapper logCtx;
 
-  public McfMutator(Mcf.McfGraph.Builder graph, LogWrapper logCtx) {
-    this.graph = graph;
-    this.logCtx = logCtx;
-  }
-
-  public Mcf.McfGraph apply() {
+  public static Mcf.McfGraph apply(Mcf.McfGraph.Builder graph, LogWrapper logCtx) {
+    McfMutator m = new McfMutator();
+    m.graph = graph;
+    m.logCtx = logCtx;
     for (String nodeId : graph.getNodesMap().keySet()) {
-      graph.putNodes(nodeId, applyOnNode(nodeId, graph.getNodesOrThrow(nodeId).toBuilder()));
+      m.graph.putNodes(nodeId, m.applyOnNode(nodeId, m.graph.getNodesOrThrow(nodeId).toBuilder()));
     }
-    return graph.build();
+    return m.graph.build();
   }
 
   private Mcf.McfGraph.PropertyValues applyOnNode(

--- a/util/src/main/java/org/datacommons/util/McfParser.java
+++ b/util/src/main/java/org/datacommons/util/McfParser.java
@@ -507,9 +507,7 @@ public class McfParser {
       List<CSVRecord> records = parser.getRecords();
       if (records.isEmpty()) {
         if (errCb != null) {
-          errCb.accept(
-              "StrSplit_EmptyToken",
-              "Empty token while parsing '" + orig + "' (" + arg.context + ")");
+          errCb.accept("StrSplit_EmptyToken", "Empty value found (" + arg.context + ")");
         }
         return splits;
       }
@@ -517,7 +515,7 @@ public class McfParser {
         if (errCb != null) {
           errCb.accept(
               "StrSplit_MultiToken",
-              "Found more than one record for '" + orig + "' (" + arg.context + ")");
+              "Found more than one line for '" + orig + "' (" + arg.context + ")");
         }
         return splits;
       }

--- a/util/src/main/java/org/datacommons/util/McfParser.java
+++ b/util/src/main/java/org/datacommons/util/McfParser.java
@@ -36,6 +36,8 @@ import org.datacommons.proto.Mcf;
 import org.datacommons.proto.Mcf.McfGraph;
 
 // A parser for converting text in Instance or Template MCF format into the McfGraph proto.
+//
+// NOTE: Expects caller to set location file in LogWrapper.
 public class McfParser {
   private static final Logger logger = LogManager.getLogger(McfParser.class);
 

--- a/util/src/main/java/org/datacommons/util/McfUtil.java
+++ b/util/src/main/java/org/datacommons/util/McfUtil.java
@@ -84,6 +84,16 @@ public class McfUtil {
     return result;
   }
 
+  public static List<Mcf.McfGraph.TypedValue> getPropTvs(
+      Mcf.McfGraph.PropertyValues node, String property) {
+    try {
+      return node.getPvsOrThrow(property).getTypedValuesList();
+    } catch (IllegalArgumentException ex) {
+      // Not having a value is not an error.
+    }
+    return null;
+  }
+
   public static Mcf.McfGraph.Values newValues(Mcf.ValueType type, String value) {
     Mcf.McfGraph.Values.Builder vals = Mcf.McfGraph.Values.newBuilder();
     Mcf.McfGraph.TypedValue.Builder tv = vals.addTypedValuesBuilder();
@@ -149,7 +159,7 @@ public class McfUtil {
     return result.build();
   }
 
-  private static String stripNamespace(String val) {
+  public static String stripNamespace(String val) {
     if (val.startsWith(Vocabulary.DCID_PREFIX)
         || val.startsWith(Vocabulary.SCHEMA_ORG_PREFIX)
         || val.startsWith(Vocabulary.DC_SCHEMA_PREFIX)) {

--- a/util/src/main/java/org/datacommons/util/McfUtil.java
+++ b/util/src/main/java/org/datacommons/util/McfUtil.java
@@ -57,7 +57,7 @@ public class McfUtil {
   }
 
   public static String getPropVal(Mcf.McfGraph.PropertyValues node, String property) {
-    String val = null;
+    String val = "";
     try {
       Mcf.McfGraph.Values vals = node.getPvsOrThrow(property);
       if (vals.getTypedValuesCount() > 0) {
@@ -70,11 +70,10 @@ public class McfUtil {
   }
 
   public static List<String> getPropVals(Mcf.McfGraph.PropertyValues node, String property) {
-    List<String> result = null;
+    List<String> result = new ArrayList<>();
     try {
       Mcf.McfGraph.Values vals = node.getPvsOrThrow(property);
       if (vals.getTypedValuesCount() > 0) {
-        result = new ArrayList<>();
         for (Mcf.McfGraph.TypedValue tv : vals.getTypedValuesList()) {
           result.add(stripNamespace(tv.getValue()));
         }

--- a/util/src/main/java/org/datacommons/util/TestUtil.java
+++ b/util/src/main/java/org/datacommons/util/TestUtil.java
@@ -38,23 +38,20 @@ public class TestUtil {
       System.err.println("Missing counter " + counter + " stat :: " + log.getCounterSet());
       return false;
     }
+    boolean foundCounter = false;
     for (Debug.Log.Entry ent : log.getEntriesList()) {
       if (ent.getCounterKey().equals(counter)) {
+        foundCounter = true;
         if (ent.getUserMessage().contains(subMessage)) {
           return true;
-        } else {
-          System.err.println(
-              "Missing message fragment '"
-                  + subMessage
-                  + "'. Instead found '"
-                  + ent.getUserMessage()
-                  + "' :: "
-                  + ent);
-          return false;
         }
       }
     }
-    System.err.println("Missing counter " + counter + " in entries :: " + log.getCounterSet());
+    if (foundCounter) {
+      System.err.println("Missing message fragment '" + subMessage + "' :: " + log);
+    } else {
+      System.err.println("Missing counter " + counter + " in entries :: " + log.getCounterSet());
+    }
     return false;
   }
 

--- a/util/src/main/java/org/datacommons/util/TestUtil.java
+++ b/util/src/main/java/org/datacommons/util/TestUtil.java
@@ -17,16 +17,45 @@ public class TestUtil {
     return logCtx;
   }
 
-  public static Mcf.McfGraph graph(String protoString) throws IOException {
+  public static Mcf.McfGraph graphFromProto(String protoString) throws IOException {
     Mcf.McfGraph.Builder expected = Mcf.McfGraph.newBuilder();
     TextFormat.getParser().merge(new StringReader(protoString), expected);
     return expected.build();
   }
 
-  public static String mcf(String filePath) throws IOException {
+  public static Mcf.McfGraph graphFromMcf(String mcfString) throws IOException {
+    return McfParser.parseInstanceMcfString(mcfString, false, TestUtil.newLogCtx("InMemory"));
+  }
+
+  public static String mcfFromFile(String filePath) throws IOException {
     Mcf.McfGraph graph =
         McfParser.parseInstanceMcfFile(filePath, false, TestUtil.newLogCtx(filePath));
     return McfUtil.serializeMcfGraph(graph, true);
+  }
+
+  public static boolean checkLog(Debug.Log log, String counter, String subMessage) {
+    if (!log.getCounterSet().getCountersMap().containsKey(counter)) {
+      System.err.println("Missing counter " + counter + " stat :: " + log.getCounterSet());
+      return false;
+    }
+    for (Debug.Log.Entry ent : log.getEntriesList()) {
+      if (ent.getCounterKey().equals(counter)) {
+        if (ent.getUserMessage().contains(subMessage)) {
+          return true;
+        } else {
+          System.err.println(
+              "Missing message fragment '"
+                  + subMessage
+                  + "'. Instead found '"
+                  + ent.getUserMessage()
+                  + "' :: "
+                  + ent);
+          return false;
+        }
+      }
+    }
+    System.err.println("Missing counter " + counter + " in entries :: " + log.getCounterSet());
+    return false;
   }
 
   public static Mcf.McfGraph getLocations(Mcf.McfGraph graph) {

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -71,9 +71,10 @@ public class TmcfCsvParser {
       return null;
     }
     // Check TMCF.
-    McfChecker checker =
-        new McfChecker(tmcfCsvParser.tmcf, tmcfCsvParser.csvParser.getHeaderMap().keySet(), logCtx);
-    if (!checker.check()) {
+    boolean success =
+        McfChecker.check(
+            tmcfCsvParser.tmcf, tmcfCsvParser.csvParser.getHeaderMap().keySet(), logCtx);
+    if (!success) {
       tmcfCsvParser.logCtx.addEntry(
           Debug.Log.Level.LEVEL_FATAL,
           "CSV_TmcfCheckFailure",
@@ -205,9 +206,9 @@ public class TmcfCsvParser {
         loc.setLineNumber(csvParser.getCurrentLineNumber());
 
         Mcf.McfGraph.PropertyValues newNode = nodeBuilder.build();
-        McfChecker checker =
-            new McfChecker(Mcf.McfType.INSTANCE_MCF, currentNodeId, newNode, logCtx);
-        if (checker.check()) {
+        boolean success =
+            McfChecker.check(Mcf.McfType.INSTANCE_MCF, currentNodeId, newNode, logCtx);
+        if (success) {
           instanceMcf.putNodes(currentNodeId, newNode);
         }
       }

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -31,6 +31,7 @@ import org.datacommons.proto.Mcf;
 // Converts a Template MCF file and an associated CSV into instance MCF.
 //
 // NOTE: Sets the location file in LogWrapper (at different times to point to TMCF and CSV).
+// TODO: Add more column info in generated MCF, even when values are missing.
 public class TmcfCsvParser {
   public static boolean TEST_mode = false;
 
@@ -303,7 +304,8 @@ public class TmcfCsvParser {
           ssArg.delimiter = delimiter;
           ssArg.includeEmpty = false;
           ssArg.stripEnclosingQuotes = false;
-          ssArg.context = "CSV column " + column;
+          ssArg.context =
+              "column " + column + ", property " + currentProp + ", entity " + templateEntity;
           // TODO: set stripEscapesBeforeQuotes
           List<String> values =
               McfParser.splitAndStripWithQuoteEscape(dataRow.get(columnIndex), ssArg, warnCb);

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -185,7 +185,11 @@ public class TmcfCsvParser {
         loc.setLineNumber(csvParser.getCurrentLineNumber());
 
         Mcf.McfGraph.PropertyValues newNode = nodeBuilder.build();
-        instanceMcf.putNodes(currentNodeId, newNode);
+        McfChecker checker =
+            new McfChecker(Mcf.McfType.INSTANCE_MCF, currentNodeId, newNode, logCtx);
+        if (checker.check()) {
+          instanceMcf.putNodes(currentNodeId, newNode);
+        }
       }
     }
 

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -199,6 +199,7 @@ public class TmcfCsvParser {
           }
           nodeBuilder.putPvs(currentProp, values);
         }
+        nodeBuilder.setTemplateNode(tableEntity.getKey());
         Debug.Log.Location.Builder loc = nodeBuilder.addLocationsBuilder();
         loc.setFile(logCtx.getLocationFile());
         loc.setLineNumber(csvParser.getCurrentLineNumber());

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -251,7 +251,7 @@ public class TmcfCsvParser {
           if (term.type != McfParser.SchemaTerm.Type.COLUMN) {
             addLog(
                 Debug.Log.Level.LEVEL_ERROR,
-                "CSV_UnexpectedNonColumn",
+                "CSV_TmcfUnexpectedNonColumn",
                 "Unable to parse TMCF column "
                     + typedValue.getValue()
                     + " in property "
@@ -264,7 +264,7 @@ public class TmcfCsvParser {
           if (!cleanedColumnMap.containsKey(column)) {
             addLog(
                 Debug.Log.Level.LEVEL_ERROR,
-                "CSV_MissingTmcfColumn",
+                "CSV_TmcfMissingColumn",
                 "Column " + column + " referred in TMCF is missing from CSV header");
             continue;
           }

--- a/util/src/main/proto/Debug.proto
+++ b/util/src/main/proto/Debug.proto
@@ -59,8 +59,8 @@ message Log {
         repeated string column_name = 5;
     }
 
-    repeated Entry entries = 1;
-    optional CounterSet counter_set = 2;
     // Key: Level.name()
-    map<string, int64> level_summary = 3;
+    map<string, int64> level_summary = 1;
+    optional CounterSet counter_set = 2;
+    repeated Entry entries = 3;
 }

--- a/util/src/main/proto/Mcf.proto
+++ b/util/src/main/proto/Mcf.proto
@@ -44,6 +44,9 @@ message McfGraph {
     // Information identifying the location of this node in the source.
     // There can be multiple if PVs in this node are merged from different files.
     repeated Log.Location locations = 2;
+
+    // Debug info. For nodes that are generated from TMCF/CSV, this refers to the template Node.
+    optional string template_node = 3;
   }
 
   // Type of the sub-graph.

--- a/util/src/test/java/org/datacommons/util/McfCheckerTest.java
+++ b/util/src/test/java/org/datacommons/util/McfCheckerTest.java
@@ -99,7 +99,7 @@ public class McfCheckerTest {
             + "observationDate: \"2017\"\n"
             + "observationPeriod: \"P1M\"\n"
             + "unit: \"AnnualUSDollars\"\n";
-    assertTrue(failure(mcf, "Sanity_NonDoubleObsValue", "value of type double"));
+    assertTrue(failure(mcf, "Sanity_NonDoubleObsValue", "double value"));
 
     // No date.
     mcf =
@@ -119,7 +119,7 @@ public class McfCheckerTest {
             + "observedNode: l:USStateFemales\n"
             + "observationDate: \"2017-07\"\n"
             + "medianValue: nan\n";
-    assertTrue(failure(mcf, "Sanity_NonDoubleObsValue", "value of type double"));
+    assertTrue(failure(mcf, "Sanity_NonDoubleObsValue", "double value"));
 
     // Measured property name should start with lower case.
     mcf =

--- a/util/src/test/java/org/datacommons/util/McfCheckerTest.java
+++ b/util/src/test/java/org/datacommons/util/McfCheckerTest.java
@@ -407,8 +407,7 @@ public class McfCheckerTest {
     } else {
       graph = McfParser.parseInstanceMcfString(mcfString, false, lw);
     }
-    McfChecker checker = new McfChecker(graph, columns, lw);
-    if (checker.check()) {
+    if (McfChecker.check(graph, columns, lw)) {
       System.err.println("Check unexpectedly passed for " + mcfString);
       return false;
     }
@@ -429,8 +428,7 @@ public class McfCheckerTest {
     } else {
       graph = McfParser.parseInstanceMcfString(mcfString, false, lw);
     }
-    McfChecker checker = new McfChecker(graph, columns, lw);
-    if (!checker.check()) {
+    if (!McfChecker.check(graph, columns, lw)) {
       System.err.println("Check unexpectedly failed for \n" + mcfString + "\n :: \n" + log);
       return false;
     }

--- a/util/src/test/java/org/datacommons/util/McfCheckerTest.java
+++ b/util/src/test/java/org/datacommons/util/McfCheckerTest.java
@@ -13,8 +13,9 @@ public class McfCheckerTest {
 
   @Test
   public void checkBasic() throws IOException {
+    // Missing typeOf.
     String mcf = "Node: USState\n" + "name: \"California\"";
-    assertTrue(failure(mcf, "Sanity_MissingOrEmpty_typeOf", "property typeOf in node USState"));
+    assertTrue(failure(mcf, "Sanity_MissingOrEmpty_typeOf", "property 'typeOf' in node USState"));
 
     // Good node.
     mcf = "Node: USState\n" + "typeOf: schema:State\n" + "name: \"California\"";

--- a/util/src/test/java/org/datacommons/util/McfCheckerTest.java
+++ b/util/src/test/java/org/datacommons/util/McfCheckerTest.java
@@ -1,0 +1,442 @@
+package org.datacommons.util;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Set;
+import org.datacommons.proto.Debug;
+import org.datacommons.proto.Mcf;
+import org.junit.Test;
+
+public class McfCheckerTest {
+
+  @Test
+  public void checkBasic() throws IOException {
+    String mcf = "Node: USState\n" + "name: \"California\"";
+    assertTrue(failure(mcf, "Sanity_MissingOrEmpty_typeOf", "property typeOf in node USState"));
+
+    // Good node.
+    mcf = "Node: USState\n" + "typeOf: schema:State\n" + "name: \"California\"";
+    assertTrue(success(mcf));
+
+    // A valid node.
+    mcf =
+        "Node: USState\n"
+            + "typeOf: schema:State\n"
+            + "name: California\n"
+            + "\n"
+            + "Node: USCity\n"
+            + "typeOf: City\n"
+            + "name: San Francisco\n"
+            + "containedIn: \"USState\"\n";
+    assertTrue(success(mcf));
+
+    // A valid node with complex value.
+    mcf =
+        "Node: EQ\n"
+            + "typeOf: dcs:Earthquake\n"
+            + "name: \"The Large One\"\n"
+            + "location: [LatLong 41.4 -81.9]\n";
+    assertTrue(success(mcf));
+  }
+
+  @Test
+  public void checkDcid() throws IOException {
+    // DCID must have exactly one value.
+    String mcf = "Node: USState\n" + "typeOf: schema:State\n" + "dcid: geoId/06, geoId/07\n";
+    assertTrue(failure(mcf, "Sanity_MultipleDcidValues", "dcid must have exactly one"));
+
+    // DCID must not be too long.
+    mcf =
+        "Node: USState\n"
+            + "typeOf: schema:State\n"
+            + "dcid: "
+            + new String(new char[257]).replace('\0', 'x');
+    assertTrue(failure(mcf, "Sanity_VeryLongDcid", "a very long dcid value"));
+
+    // DCID must not have space.
+    mcf = "Node: USState\n" + "typeOf: schema:State\n" + "dcid: \"dc/Not Allowed\"\n";
+    assertTrue(failure(mcf, "Sanity_SpaceInDcid", "whitespace in dcid"));
+
+    // Temporarily, bio/ DCIDs can have space.
+    mcf = "Node: USState\n" + "typeOf: schema:State\n" + "dcid: \"bio/For Now Allowed\"\n";
+    assertTrue(success(mcf));
+  }
+
+  @Test
+  public void checkPopObs() throws IOException {
+    // A valid Pop node.
+    String mcf =
+        "Node: USState\n"
+            + "typeOf: schema:State\n"
+            + "name: \"California\"\n"
+            + "\n"
+            + "Node: USStateAll\n"
+            + "typeOf: schema:Population\n"
+            + "populationType: schema:Person\n"
+            + "location: l:USState\n";
+    assertTrue(success(mcf));
+
+    // A bad observation node with no value.
+    mcf =
+        "Node: USStateFemalesIncome\n"
+            + "typeOf: schema:Observation\n"
+            + "measuredProperty: schema:income\n"
+            + "observedNode: l:USStateFemales\n"
+            + "observationDate: \"2010\"\n"
+            + "observationPeriod: \"P1M\"\n"
+            + "unit: \"AnnualUSDollars\"\n";
+    assertTrue(failure(mcf, "Sanity_ObsMissingValueProp", "Missing any value property"));
+
+    // Non-double measured value.
+    mcf =
+        "Node: USStateFemalesIncome\n"
+            + "typeOf: schema:Observation\n"
+            + "measuredProperty: schema:income\n"
+            + "observedNode: l:USStateFemales\n"
+            + "measuredValue: \"nonqualified\"\n"
+            + "observationDate: \"2017\"\n"
+            + "observationPeriod: \"P1M\"\n"
+            + "unit: \"AnnualUSDollars\"\n";
+    assertTrue(failure(mcf, "Sanity_NonDoubleObsValue", "value of type double"));
+
+    // No date.
+    mcf =
+        "Node: USStateFemalesIncome\n"
+            + "typeOf: schema:Observation\n"
+            + "measuredProperty: schema:income\n"
+            + "observedNode: l:USStateFemales\n"
+            + "unit: \"AnnualUSDollars\"\n"
+            + "medianValue: 200000\n";
+    assertTrue(failure(mcf, "Sanity_MissingOrEmpty_observationDate", "observationDate"));
+
+    // An observation with nan.
+    mcf =
+        "Node: USStateFemalesIncome\n"
+            + "typeOf: schema:Observation\n"
+            + "measuredProperty: schema:income\n"
+            + "observedNode: l:USStateFemales\n"
+            + "observationDate: \"2017-07\"\n"
+            + "medianValue: nan\n";
+    assertTrue(failure(mcf, "Sanity_NonDoubleObsValue", "value of type double"));
+
+    // Measured property name should start with lower case.
+    mcf =
+        "Node: USStateFemalesIncome\n"
+            + "typeOf: schema:Observation\n"
+            + "measuredProperty: schema:Income\n"
+            + "observedNode: dcid:dc/p/0x34534\n"
+            + "observationDate: \"2017-07\"\n"
+            + "measuredValue: 200000\n";
+    assertTrue(failure(mcf, "Sanity_NotInitLower_measuredProperty", "Income"));
+
+    // popType should start with upper case.
+    mcf =
+        "Node: USStateFemales\n"
+            + "typeOf: schema:Population\n"
+            + "populationType: schema:mortalityEvent\n"
+            + "location: l:USState\n";
+    assertTrue(failure(mcf, "Sanity_NotInitUpper_populationType", "mortalityEvent"));
+  }
+
+  @Test
+  public void checkStatVar() throws IOException {
+    // Missing popType
+    String mcf =
+        "Node: SV\n"
+            + "typeOf: schema:StatisticalVariable\n"
+            + "measuredProperty: dcs:count\n"
+            + "statType: dcs:measuredValue";
+    assertTrue(failure(mcf, "Sanity_MissingOrEmpty_populationType", "populationType in node SV"));
+
+    // Non-class popType
+    mcf =
+        "Node: SV\n"
+            + "typeOf: schema:StatisticalVariable\n"
+            + "populationType: dcs:person\n"
+            + "measuredProperty: dcs:count\n"
+            + "statType: dcs:measuredValue";
+    assertTrue(failure(mcf, "Sanity_NotInitUpper_populationType", "person"));
+
+    // Missing mprop
+    mcf =
+        "Node: SV\n"
+            + "typeOf: schema:StatisticalVariable\n"
+            + "populationType: schema:Person\n"
+            + "statType: dcs:measuredValue";
+    assertTrue(
+        failure(mcf, "Sanity_MissingOrEmpty_measuredProperty", "measuredProperty in node SV"));
+
+    // Non-prop mprop
+    mcf =
+        "Node: SV\n"
+            + "typeOf: schema:StatisticalVariable\n"
+            + "populationType: schema:Person\n"
+            + "statType: dcs:measuredValue\n"
+            + "measuredProperty: dcs:Income";
+    assertTrue(failure(mcf, "Sanity_NotInitLower_measuredProperty", "Income"));
+
+    // Unknown statType
+    mcf =
+        "Node: SV\n"
+            + "typeOf: schema:StatisticalVariable\n"
+            + "populationType: schema:Person\n"
+            + "statType: dcs:projection\n"
+            + "measuredProperty: dcs:income";
+    assertTrue(failure(mcf, "Sanity_UnknownStatType", "projection"));
+  }
+
+  @Test
+  public void checkSVObs() throws IOException {
+    // A good StatVarObs node with double value.
+    String mcf =
+        "Node: SFWomenIncome2020\n"
+            + "typeOf: dcs:StatVarObservation\n"
+            + "variableMeasured: dcid:WomenIncome\n"
+            + "value: 10000000.0\n"
+            + "observationAbout: dcid:geoId/SF\n"
+            + "observationDate: \"2020\"\n";
+    assertTrue(success(mcf));
+
+    // Another good StatVarObs node with string value.
+    mcf =
+        "Node: SFWomenIncome2020\n"
+            + "typeOf: dcs:StatVarObservation\n"
+            + "variableMeasured: dcid:WomenIncome\n"
+            + "value: \"DataSuppressed\"\n"
+            + "observationAbout: dcid:geoId/SF\n"
+            + "observationDate: \"2020\"\n";
+    assertTrue(success(mcf));
+
+    // A bad StatVarObs node with no value.
+    mcf =
+        "Node: SFWomenIncome2020\n"
+            + "typeOf: dcs:StatVarObservation\n"
+            + "variableMeasured: dcid:WomenIncome\n"
+            + "observationAbout: dcid:geoId/SF\n"
+            + "observationDate: \"2020\"\n";
+    assertTrue(failure(mcf, "Sanity_MissingOrEmpty_value", "value in node SFWomenIncome2020"));
+
+    // A bad StatVarObs node with no variableMeasured.
+    mcf =
+        "Node: SFWomenIncome2020\n"
+            + "typeOf: dcs:StatVarObservation\n"
+            + "value: 10000000.0\n"
+            + "observationAbout: dcid:geoId/SF\n"
+            + "observationDate: \"2020\"\n";
+    assertTrue(
+        failure(
+            mcf,
+            "Sanity_MissingOrEmpty_variableMeasured",
+            "variableMeasured in node SFWomenIncome2020"));
+
+    // A bad StatVarObs node with no observationAbout.
+    mcf =
+        "Node: SFWomenIncome2020\n"
+            + "typeOf: dcs:StatVarObservation\n"
+            + "value: 10000000.0\n"
+            + "variableMeasured: dcid:WomenIncome\n"
+            + "observationDate: \"2020\"\n";
+    assertTrue(
+        failure(
+            mcf,
+            "Sanity_MissingOrEmpty_observationAbout",
+            "observationAbout in node SFWomenIncome2020"));
+
+    // A bad StatVarObs node with no date.
+    mcf =
+        "Node: SFWomenIncome2020\n"
+            + "typeOf: dcs:StatVarObservation\n"
+            + "value: 10000000.0\n"
+            + "variableMeasured: dcid:WomenIncome\n"
+            + "observationAbout: dcid:geoId/SF\n";
+    assertTrue(
+        failure(
+            mcf,
+            "Sanity_MissingOrEmpty_observationDate",
+            "observationDate in node SFWomenIncome2020"));
+
+    // A bad StatVarObs node with bogus date.
+    mcf =
+        "Node: SFWomenIncome2020\n"
+            + "typeOf: dcs:StatVarObservation\n"
+            + "value: 10000000.0\n"
+            + "observationDate: \"January, 2020\"\n"
+            + "variableMeasured: dcid:WomenIncome\n"
+            + "observationAbout: dcid:geoId/SF\n";
+    assertTrue(failure(mcf, "Sanity_InvalidObsDate", "non-ISO8601 compliant value"));
+  }
+
+  @Test
+  public void checkSchema() throws IOException {
+    // Property names must start with lower case.
+    String mcf =
+        "Node: dcid:Place\n"
+            + "typeOf: schema:Class\n"
+            + "Name: \"Place\"\n"
+            + "description: \"Physical location.\"\n";
+    assertTrue(
+        failure(mcf, "Sanity_NotInitLowerPropName", "'Name' does not start with a lower-case"));
+
+    // Class types must have upper-case names/IDs.
+    mcf =
+        "Node: dcid:place\n"
+            + "typeOf: schema:Class\n"
+            + "name: \"Place\"\n"
+            + "description: \"Physical location.\"\n";
+    assertTrue(failure(mcf, "Sanity_NotInitUpper_dcidInClass", "place"));
+
+    // No non-ascii values for non-text items.
+    mcf = "Node: dcid:geoId/06\n" + "typeOf: schema:Plaçe\n" + "capital: \"Sacramento\"\n";
+    assertTrue(failure(mcf, "Sanity_NonAsciiValueInNonText", "Plaçe"));
+
+    // No non-ascii values for non-text items.
+    mcf =
+        "Node: dcid:Place\n"
+            + "typeOf: schema:Class\n"
+            + "subClassOf: schema:Thing\n"
+            + "name: “Place”\n"
+            + "description: \"Physical location.\"\n";
+    assertTrue(failure(mcf, "Sanity_NonAsciiValueInSchema", "“Place”"));
+
+    // Property types must have lower-case names/IDs.
+    mcf =
+        "Node: dcid:age\n"
+            + "typeOf: schema:Property\n"
+            + "name: \"Age\"\n"
+            + "domainIncludes: schema:Person\n"
+            + "rangeIncludes: schema:Number\n"
+            + "description: \"Person Age.\"\n";
+    assertTrue(failure(mcf, "Sanity_NotInitLower_nameInProperty", "Age"));
+
+    // Property types must not have subClassOf.
+    mcf =
+        "Node: dcid:age\n"
+            + "typeOf: schema:Property\n"
+            + "name: \"age\"\n"
+            + "subClassOf: schema:Person\n";
+    assertTrue(failure(mcf, "Sanity_UnexpectedPropInProperty", "subClassOf"));
+
+    // Class types must include subClassOf.
+    mcf =
+        "Node: dcid:Place\n"
+            + "typeOf: schema:Class\n"
+            + "name: \"Place\"\n"
+            + "description: \"Physical location.\"\n";
+    assertTrue(failure(mcf, "Sanity_MissingOrEmpty_subClassOf", "subClassOf"));
+
+    // Class types must not have domainIncludes|rangeIncludes|subPropertyOf
+    mcf =
+        "Node: schema:Place\n"
+            + "typeOf: schema:Class\n"
+            + "name: \"Place\"\n"
+            + "domainIncludes: schema:Person\n";
+    assertTrue(failure(mcf, "Sanity_UnexpectedPropInClass", "domainIncludes"));
+
+    mcf =
+        "Node: schema:Place\n"
+            + "typeOf: schema:Class\n"
+            + "name: \"Place\"\n"
+            + "rangeIncludes: schema:Person\n";
+    assertTrue(failure(mcf, "Sanity_UnexpectedPropInClass", "rangeIncludes"));
+
+    mcf =
+        "Node: schema:Place\n"
+            + "typeOf: schema:Class\n"
+            + "name: \"Place\"\n"
+            + "subPropertyOf: schema:sibling\n";
+    assertTrue(failure(mcf, "Sanity_UnexpectedPropInClass", "subPropertyOf"));
+  }
+
+  @Test
+  public void checkTemplate() throws IOException {
+    // Incorrect column name.
+    String mcf =
+        "Node: E:CityStats->E1\n"
+            + "typeOf: State\n"
+            + "dcid: C:CityStats->StateId\n"
+            + "name: C:CityStats->StateNam\n";
+    assertTrue(
+        failure(
+            mcf,
+            "Sanity_TmcfMissingColumn",
+            "'StateNam' referred",
+            Set.of("StateId", "StateName")));
+
+    mcf =
+        "Node: E:CityStats->E1\n"
+            + "typeOf: State\n"
+            + "dcid: C:CityStats->StateId\n"
+            + "name: C:CityStats->StateName\n"
+            + "\n"
+            + "Node: E:CityStats->E2\n"
+            + "typeOf: City\n"
+            + "name: C:CityStats->CityName\n"
+            + "containedIn: E:CityStats->E3\n";
+    assertTrue(
+        failure(
+            mcf,
+            "Sanity_TmcfMissingEntityDef",
+            "'E:CityStats->E3'",
+            Set.of("StateId", "StateName", "CityName")));
+
+    // A legitimate mapping both with and without the columns.
+    mcf =
+        "Node: E:CityStats->E1\n"
+            + "typeOf: State\n"
+            + "dcid: C:CityStats->StateId\n"
+            + "name: C:CityStats->StateName\n"
+            + "\n"
+            + "Node: E:CityStats->E2\n"
+            + "typeOf: City\n"
+            + "name: C:CityStats->City\n"
+            + "containedIn: E:CityStats->E1\n";
+    assertTrue(success(mcf, Set.of("StateId", "StateName", "City")));
+    assertTrue(success(mcf));
+  }
+
+  private static boolean failure(
+      String mcfString, String counter, String message, Set<String> columns) throws IOException {
+    Debug.Log.Builder log = Debug.Log.newBuilder();
+    LogWrapper lw = new LogWrapper(log, Path.of("InMemory"));
+    Mcf.McfGraph graph;
+    if (columns != null) {
+      graph = McfParser.parseTemplateMcfString(mcfString, lw);
+    } else {
+      graph = McfParser.parseInstanceMcfString(mcfString, false, lw);
+    }
+    McfChecker checker = new McfChecker(graph, columns, lw);
+    if (checker.check()) {
+      System.err.println("Check unexpectedly passed for " + mcfString);
+      return false;
+    }
+    return TestUtil.checkLog(log.build(), counter, message);
+  }
+
+  private static boolean failure(String mcfString, String counter, String message)
+      throws IOException {
+    return failure(mcfString, counter, message, null);
+  }
+
+  private static boolean success(String mcfString, Set<String> columns) throws IOException {
+    Debug.Log.Builder log = Debug.Log.newBuilder();
+    LogWrapper lw = new LogWrapper(log, Path.of("InMemory"));
+    Mcf.McfGraph graph;
+    if (columns != null) {
+      graph = McfParser.parseTemplateMcfString(mcfString, lw);
+    } else {
+      graph = McfParser.parseInstanceMcfString(mcfString, false, lw);
+    }
+    McfChecker checker = new McfChecker(graph, columns, lw);
+    if (!checker.check()) {
+      System.err.println("Check unexpectedly failed for \n" + mcfString + "\n :: \n" + log);
+      return false;
+    }
+    return true;
+  }
+
+  private static boolean success(String mcfString) throws IOException {
+    return success(mcfString, null);
+  }
+}

--- a/util/src/test/java/org/datacommons/util/McfMutatorTest.java
+++ b/util/src/test/java/org/datacommons/util/McfMutatorTest.java
@@ -19,7 +19,7 @@ public class McfMutatorTest {
             + "income: [dcs:USDollar 1000 2000]\n"
             + "bogusProp: [LatLong 37.3884812 -122.0834373]";
     Mcf.McfGraph got =
-        McfMutator.apply(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
+        McfMutator.mutate(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
 
     String want =
         "Node: USDollar1000To2000\n"
@@ -65,7 +65,7 @@ public class McfMutatorTest {
             + "measuredValue: \"1000,0000.0%\"\n"
             + "observationDate: \"2009\"\n";
     Mcf.McfGraph got =
-        McfMutator.apply(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
+        McfMutator.mutate(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
     String want =
         "Node: LegacyObs\n"
             + "measuredValue: \"10000000.0\"\n"
@@ -87,7 +87,7 @@ public class McfMutatorTest {
             + "variableMeasured: dcid:Count_Male_18Years_1000To2000USD\n"
             + "\n";
     Mcf.McfGraph got =
-        McfMutator.apply(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
+        McfMutator.mutate(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
     assertEquals(McfUtil.serializeMcfGraph(got, true), mcf);
   }
 }

--- a/util/src/test/java/org/datacommons/util/McfMutatorTest.java
+++ b/util/src/test/java/org/datacommons/util/McfMutatorTest.java
@@ -1,0 +1,92 @@
+package org.datacommons.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import org.junit.Test;
+
+public class McfMutatorTest {
+  @Test
+  public void testComplex() throws IOException {
+    String mcf =
+        "Node: dcid:Count_Person_18Years_1000To2000USD\n"
+            + "typeOf: schema:StatisticalVariable\n"
+            + "populationType: schema:Person\n"
+            + "measuredProperty: schema:count\n"
+            + "statType: dcs:measuredValue\n"
+            + "age: [dcs:Year 18]\n"
+            + "income: [dcs:USDollar 1000 2000]\n"
+            + "bogusProp: [LatLong 37.3884812 -122.0834373]";
+    McfMutator mutator =
+        new McfMutator(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
+
+    String want =
+        "Node: USDollar1000To2000\n"
+            + "dcid: \"USDollar1000To2000\"\n"
+            + "endValue: 2000\n"
+            + "name: \"USDollar 1000 To 2000\"\n"
+            + "startValue: 1000\n"
+            + "typeOf: dcid:QuantityRange\n"
+            + "unit: dcid:USDollar\n"
+            + "\n"
+            + "Node: Year18\n"
+            + "dcid: \"Year18\"\n"
+            + "name: \"Year 18\"\n"
+            + "typeOf: dcid:Quantity\n"
+            + "unit: dcid:Year\n"
+            + "value: 18\n"
+            + "\n"
+            + "Node: dcid:Count_Person_18Years_1000To2000USD\n"
+            + "age: dcid:Year18\n"
+            + "bogusProp: dcid:latLong/3738848_-12208344\n"
+            + "dcid: \"Count_Person_18Years_1000To2000USD\"\n"
+            + "income: dcid:USDollar1000To2000\n"
+            + "measuredProperty: dcid:count\n"
+            + "populationType: dcid:Person\n"
+            + "statType: dcid:measuredValue\n"
+            + "typeOf: dcid:StatisticalVariable\n"
+            + "\n"
+            + "Node: latLong/3738848_-12208344\n"
+            + "dcid: \"latLong/3738848_-12208344\"\n"
+            + "latitude: \"37.3884812\"\n"
+            + "longitude: \"-122.0834373\"\n"
+            + "name: \"37.38848,-122.08344\"\n"
+            + "typeOf: dcid:GeoCoordinates\n\n";
+    assertEquals(McfUtil.serializeMcfGraph(mutator.apply(), true), want);
+  }
+
+  @Test
+  public void testLegacyObsValue() throws IOException {
+    String mcf =
+        "Node: LegacyObs\n"
+            + "typeOf: schema:Observation\n"
+            + "observedNode: dcid:country/USA\n"
+            + "measuredValue: \"1000,0000.0%\"\n"
+            + "observationDate: \"2009\"\n";
+    McfMutator mutator =
+        new McfMutator(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
+    String want =
+        "Node: LegacyObs\n"
+            + "measuredValue: \"10000000.0\"\n"
+            + "observationDate: 2009\n"
+            + "observedNode: dcid:country/USA\n"
+            + "typeOf: dcid:Observation\n"
+            + "\n";
+    assertEquals(McfUtil.serializeMcfGraph(mutator.apply(), true), want);
+  }
+
+  @Test
+  public void testSVObsValue() throws IOException {
+    String mcf =
+        "Node: SVObs\n"
+            + "observationAbout: dcid:country/USA\n"
+            + "observationDate: 2009\n"
+            + "typeOf: dcid:StatVarObservation\n"
+            + "value: \"10000000.0%\"\n"
+            + "variableMeasured: dcid:Count_Male_18Years_1000To2000USD\n"
+            + "\n";
+    McfMutator mutator =
+        new McfMutator(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
+    assertEquals(McfUtil.serializeMcfGraph(mutator.apply(), true), mcf);
+  }
+}

--- a/util/src/test/java/org/datacommons/util/McfMutatorTest.java
+++ b/util/src/test/java/org/datacommons/util/McfMutatorTest.java
@@ -3,6 +3,7 @@ package org.datacommons.util;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import org.datacommons.proto.Mcf;
 import org.junit.Test;
 
 public class McfMutatorTest {
@@ -17,8 +18,8 @@ public class McfMutatorTest {
             + "age: [dcs:Year 18]\n"
             + "income: [dcs:USDollar 1000 2000]\n"
             + "bogusProp: [LatLong 37.3884812 -122.0834373]";
-    McfMutator mutator =
-        new McfMutator(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
+    Mcf.McfGraph got =
+        McfMutator.apply(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
 
     String want =
         "Node: USDollar1000To2000\n"
@@ -52,7 +53,7 @@ public class McfMutatorTest {
             + "longitude: \"-122.0834373\"\n"
             + "name: \"37.38848,-122.08344\"\n"
             + "typeOf: dcid:GeoCoordinates\n\n";
-    assertEquals(McfUtil.serializeMcfGraph(mutator.apply(), true), want);
+    assertEquals(McfUtil.serializeMcfGraph(got, true), want);
   }
 
   @Test
@@ -63,8 +64,8 @@ public class McfMutatorTest {
             + "observedNode: dcid:country/USA\n"
             + "measuredValue: \"1000,0000.0%\"\n"
             + "observationDate: \"2009\"\n";
-    McfMutator mutator =
-        new McfMutator(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
+    Mcf.McfGraph got =
+        McfMutator.apply(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
     String want =
         "Node: LegacyObs\n"
             + "measuredValue: \"10000000.0\"\n"
@@ -72,7 +73,7 @@ public class McfMutatorTest {
             + "observedNode: dcid:country/USA\n"
             + "typeOf: dcid:Observation\n"
             + "\n";
-    assertEquals(McfUtil.serializeMcfGraph(mutator.apply(), true), want);
+    assertEquals(McfUtil.serializeMcfGraph(got, true), want);
   }
 
   @Test
@@ -85,8 +86,8 @@ public class McfMutatorTest {
             + "value: \"10000000.0%\"\n"
             + "variableMeasured: dcid:Count_Male_18Years_1000To2000USD\n"
             + "\n";
-    McfMutator mutator =
-        new McfMutator(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
-    assertEquals(McfUtil.serializeMcfGraph(mutator.apply(), true), mcf);
+    Mcf.McfGraph got =
+        McfMutator.apply(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx("InMemory"));
+    assertEquals(McfUtil.serializeMcfGraph(got, true), mcf);
   }
 }

--- a/util/src/test/java/org/datacommons/util/McfParserTest.java
+++ b/util/src/test/java/org/datacommons/util/McfParserTest.java
@@ -142,7 +142,7 @@ public class McfParserTest {
   }
 
   private McfGraph expected(String protoFile) throws IOException {
-    return TestUtil.graph(
+    return TestUtil.graphFromProto(
         IOUtils.toString(this.getClass().getResourceAsStream(protoFile), StandardCharsets.UTF_8));
   }
 }

--- a/util/src/test/java/org/datacommons/util/McfUtilTest.java
+++ b/util/src/test/java/org/datacommons/util/McfUtilTest.java
@@ -124,7 +124,7 @@ public class McfUtilTest {
 
     // Match locations.
     Mcf.McfGraph expLoc =
-        TestUtil.graph(
+        TestUtil.graphFromProto(
             IOUtils.toString(
                 this.getClass().getResourceAsStream("McfUtilTest_MergedLocations.textproto"),
                 StandardCharsets.UTF_8));

--- a/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
+++ b/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
@@ -44,7 +44,7 @@ public class TmcfCsvParserTest {
     String got = run("TmcfCsvParser_SVO.tmcf", "TmcfCsvParser_SVO.csv");
     assertEquals(want, got);
     // The third line has empty values.
-    assertTrue(TestUtil.checkLog(log.build(), "Sanity_MissingOrEmpty_value", "FBI_Crime/E1/3"));
+    assertTrue(TestUtil.checkLog(log.build(), "Sanity_MissingOrEmpty_value", "E:FBI_Crime->E1"));
   }
 
   @Test

--- a/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
+++ b/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
@@ -15,6 +15,7 @@
 package org.datacommons.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -30,6 +31,7 @@ import org.junit.Test;
 // TODO: Add test once sanity-check is implemented.
 public class TmcfCsvParserTest {
   private static final Logger LOGGER = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+  private Debug.Log.Builder log = Debug.Log.newBuilder();
 
   @Before
   public void setUp() {
@@ -41,6 +43,8 @@ public class TmcfCsvParserTest {
     String want = TestUtil.mcfFromFile(resourceFile("TmcfCsvParser_SVO.mcf"));
     String got = run("TmcfCsvParser_SVO.tmcf", "TmcfCsvParser_SVO.csv");
     assertEquals(want, got);
+    // The third line has empty values.
+    assertTrue(TestUtil.checkLog(log.build(), "Sanity_MissingOrEmpty_value", "FBI_Crime/E1/3"));
   }
 
   @Test
@@ -58,7 +62,7 @@ public class TmcfCsvParserTest {
   }
 
   private String run(String mcfFile, String csvFile) throws IOException, URISyntaxException {
-    LogWrapper logCtx = new LogWrapper(Debug.Log.newBuilder(), Paths.get("."));
+    LogWrapper logCtx = new LogWrapper(log, Paths.get("."));
     logCtx.setLocationFile(csvFile);
     TmcfCsvParser parser =
         TmcfCsvParser.init(resourceFile(mcfFile), resourceFile(csvFile), ',', logCtx);

--- a/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
+++ b/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
@@ -61,6 +61,21 @@ public class TmcfCsvParserTest {
     assertEquals(want, got);
   }
 
+  @Test
+  public void tmcfFailure() throws IOException, URISyntaxException {
+    LogWrapper logCtx = new LogWrapper(log, Paths.get("."));
+    TmcfCsvParser parser =
+        TmcfCsvParser.init(
+            resourceFile("TmcfCsvParser_SVO_Failure.tmcf"),
+            resourceFile("TmcfCsvParser_SVO.csv"),
+            ',',
+            logCtx);
+    assertEquals(null, parser);
+    assertTrue(
+        TestUtil.checkLog(
+            log.build(), "Sanity_TmcfMissingColumn", "Count_CriminalActivities_Missing"));
+  }
+
   private String run(String mcfFile, String csvFile) throws IOException, URISyntaxException {
     LogWrapper logCtx = new LogWrapper(log, Paths.get("."));
     logCtx.setLocationFile(csvFile);

--- a/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
+++ b/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
@@ -38,21 +38,21 @@ public class TmcfCsvParserTest {
 
   @Test
   public void statVarObs() throws IOException, URISyntaxException {
-    String want = TestUtil.mcf(resourceFile("TmcfCsvParser_SVO.mcf"));
+    String want = TestUtil.mcfFromFile(resourceFile("TmcfCsvParser_SVO.mcf"));
     String got = run("TmcfCsvParser_SVO.tmcf", "TmcfCsvParser_SVO.csv");
     assertEquals(want, got);
   }
 
   @Test
   public void popObs() throws IOException, URISyntaxException {
-    String want = TestUtil.mcf(resourceFile("TmcfCsvParser_PopObs.mcf"));
+    String want = TestUtil.mcfFromFile(resourceFile("TmcfCsvParser_PopObs.mcf"));
     String got = run("TmcfCsvParser_PopObs.tmcf", "TmcfCsvParser_PopObs.csv");
     assertEquals(want, got);
   }
 
   @Test
   public void multiValue() throws IOException, URISyntaxException {
-    String want = TestUtil.mcf(resourceFile("TmcfCsvParser_MultiValue.mcf"));
+    String want = TestUtil.mcfFromFile(resourceFile("TmcfCsvParser_MultiValue.mcf"));
     String got = run("TmcfCsvParser_MultiValue.tmcf", "TmcfCsvParser_MultiValue.csv");
     assertEquals(want, got);
   }

--- a/util/src/test/resources/org/datacommons/util/LogWrapperTest_result.json
+++ b/util/src/test/resources/org/datacommons/util/LogWrapperTest_result.json
@@ -1,4 +1,17 @@
 {
+  "levelSummary": {
+    "LEVEL_ERROR": "1",
+    "LEVEL_WARNING": "1",
+    "LEVEL_FATAL": "1"
+  },
+  "counterSet": {
+    "counters": {
+      "MCF_NoColonFound": "1",
+      "MCF_EmptyValue": "1",
+      "CSV_GeneralStats": "42",
+      "CSV_FoundABomb": "1"
+    }
+  },
   "entries": [{
     "level": "LEVEL_ERROR",
     "location": {
@@ -23,18 +36,5 @@
     },
     "userMessage": "Found a Time Bomb",
     "counterKey": "CSV_FoundABomb"
-  }],
-  "counterSet": {
-    "counters": {
-      "MCF_NoColonFound": "1",
-      "MCF_EmptyValue": "1",
-      "CSV_GeneralStats": "42",
-      "CSV_FoundABomb": "1"
-    }
-  },
-  "levelSummary": {
-    "LEVEL_ERROR": "1",
-    "LEVEL_WARNING": "1",
-    "LEVEL_FATAL": "1"
-  }
+  }]
 }

--- a/util/src/test/resources/org/datacommons/util/TmcfCsvParser_SVO.csv
+++ b/util/src/test/resources/org/datacommons/util/TmcfCsvParser_SVO.csv
@@ -1,3 +1,4 @@
 Year,GeoId,Count_CriminalActivities_ViolentCrime,Count_CriminalActivities_MurderAndNonNegligentManslaughter
 2019,dcid:geoId/0135896,114,4
 2019,dcid:geoId/0203000,3581,32
+2020,dcid:geoId/06,,

--- a/util/src/test/resources/org/datacommons/util/TmcfCsvParser_SVO_Failure.tmcf
+++ b/util/src/test/resources/org/datacommons/util/TmcfCsvParser_SVO_Failure.tmcf
@@ -1,0 +1,15 @@
+Node: E:FBI_Crime->E0
+typeOf: dcs:StatVarObservation
+variableMeasured: dcs:Count_CriminalActivities_ViolentCrime
+measurementMethod: dcs:FBI_Crime
+observationAbout: C:FBI_Crime->GeoId
+observationDate: C:FBI_Crime->Year
+value: C:FBI_Crime->Count_CriminalActivities_ViolentCrime
+
+Node: E:FBI_Crime->E1
+typeOf: dcs:StatVarObservation
+variableMeasured: dcs:Count_CriminalActivities_MurderAndNonNegligentManslaughter
+measurementMethod: dcs:FBI_Crime
+observationAbout: C:FBI_Crime->GeoId
+observationDate: C:FBI_Crime->Year
+value: C:FBI_Crime->Count_CriminalActivities_Missing


### PR DESCRIPTION
This PR largely implements logic in g3's [mcf_schema_util.cc](https://source.corp.google.com/piper///depot/google3/datacommons/import/util/mcf_schema_util.cc).

With this PR, modulo some minor transformation TODOs, the tool should have parity with cpp code for parsing MCF/TMCF/CSV and checking them.

So, for imports where the place DCIDs are mapped (because no resolution support yet), if the tool reports no errors/warnings, then the import should be structurally sane (or its a tool bug).