### PR TITLE
Bug fix: deduplicate single node content

### DIFF
--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -32,7 +32,7 @@ import org.datacommons.proto.Debug;
 
 // The class that provides logging functionality.
 public class LogWrapper {
-  private static final Logger logger = LogManager.getLogger(McfParser.class);
+  private static final Logger logger = LogManager.getLogger(LogWrapper.class);
 
   private static final long SECONDS_BETWEEN_STATUS = 30;
   public static final String REPORT_JSON = "report.json";

--- a/util/src/main/java/org/datacommons/util/McfParser.java
+++ b/util/src/main/java/org/datacommons/util/McfParser.java
@@ -21,10 +21,7 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.function.BiConsumer;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
@@ -94,11 +91,11 @@ public class McfParser {
       parseLine(line);
       McfGraph g = extractNode();
       if (g != null) {
-        return g;
+        return McfUtil.mergeGraphs(Collections.singletonList(g));
       }
     }
     // End of file.
-    return finish();
+    return McfUtil.mergeGraphs(Collections.singletonList(finish()));
   }
 
   // Parse a line of MCF file.
@@ -311,6 +308,7 @@ public class McfParser {
           vals.addTypedValuesBuilder(),
           getErrCb());
     }
+    System.err.print(prop + " :: " + vals.build());
     pvs.putPvs(prop, vals.build());
     graph.putNodes(curEntity, pvs.build());
   }

--- a/util/src/main/java/org/datacommons/util/McfParser.java
+++ b/util/src/main/java/org/datacommons/util/McfParser.java
@@ -308,7 +308,6 @@ public class McfParser {
           vals.addTypedValuesBuilder(),
           getErrCb());
     }
-    System.err.print(prop + " :: " + vals.build());
     pvs.putPvs(prop, vals.build());
     graph.putNodes(curEntity, pvs.build());
   }

--- a/util/src/test/resources/org/datacommons/util/McfParserTest_ResolvedGraph.mcf
+++ b/util/src/test/resources/org/datacommons/util/McfParserTest_ResolvedGraph.mcf
@@ -2,6 +2,7 @@ Node: USACountry
 typeOf: schema:Country
 name: "United States Of America"
 dcid: dc/2sffw13
+typeOf: schema:Country
 
 Node: dcid:dc/mx44
 typeOf: dcs:City

--- a/util/src/test/resources/org/datacommons/util/McfParserTest_ResolvedGraph.textproto
+++ b/util/src/test/resources/org/datacommons/util/McfParserTest_ResolvedGraph.textproto
@@ -34,7 +34,7 @@ nodes {
     }
     locations {
       file: "McfParserTest_ResolvedGraph.mcf"
-      line_number: 6
+      line_number: 7
     }
   }
 }
@@ -76,7 +76,7 @@ nodes {
     }
     locations {
       file: "McfParserTest_ResolvedGraph.mcf"
-      line_number: 15
+      line_number: 16
     }
   }
 }


### PR DESCRIPTION
A user error resulted in duplicate typeOf values. And this then causes duplicate error messages, like below, because we were not deduplicating within a single node.

![image](https://user-images.githubusercontent.com/4375037/129300661-d43b8332-6e1e-4ab9-ade7-aeef82982e62.png)
