### PR TITLE
Updates to ErrCb

### DIFF
--- a/util/src/main/java/org/datacommons/util/ComplexValueParser.java
+++ b/util/src/main/java/org/datacommons/util/ComplexValueParser.java
@@ -96,8 +96,8 @@ public class ComplexValueParser {
         new LogCb(logCtx, Debug.Log.Level.LEVEL_ERROR, lineNumber)
             .setDetail(LogCb.VALUE_KEY, complexValue)
             .setDetail(LogCb.PROP_KEY, prop)
-            .setDetail(LogCb.NODE_KEY, mainNodeId);
-    logCb.setCounterSuffix(prop);
+            .setDetail(LogCb.NODE_KEY, mainNodeId)
+            .setCounterSuffix(prop);
     List<String> fields = McfParser.splitAndStripWithQuoteEscape(trimmedComplexValue, arg, logCb);
     if (fields.size() != 2 && fields.size() != 3) {
       logCtx.addEntry(

--- a/util/src/main/java/org/datacommons/util/ComplexValueParser.java
+++ b/util/src/main/java/org/datacommons/util/ComplexValueParser.java
@@ -17,10 +17,9 @@ package org.datacommons.util;
 import static org.datacommons.proto.Mcf.ValueType.*;
 
 import java.util.List;
-import java.util.Map;
 import org.datacommons.proto.Debug;
 import org.datacommons.proto.Mcf;
-import org.datacommons.util.McfUtil.ErrCb;
+import org.datacommons.util.McfUtil.LogCb;
 
 // Parse complex value strings into nodes.
 //
@@ -93,11 +92,13 @@ public class ComplexValueParser {
     if (!mainNode.getLocationsList().isEmpty()) {
       lineNumber = mainNode.getLocationsList().get(0).getLineNumber();
     }
-    ErrCb errCb = new ErrCb(logCtx, Debug.Log.Level.LEVEL_ERROR, lineNumber);
-    errCb.setDetails(
-        Map.of(ErrCb.VALUE_KEY, complexValue, ErrCb.PROP_KEY, prop, ErrCb.NODE_KEY, mainNodeId));
-    errCb.counter_suffix = "_" + prop;
-    List<String> fields = McfParser.splitAndStripWithQuoteEscape(trimmedComplexValue, arg, errCb);
+    LogCb logCb =
+        new LogCb(logCtx, Debug.Log.Level.LEVEL_ERROR, lineNumber)
+            .setDetail(LogCb.VALUE_KEY, complexValue)
+            .setDetail(LogCb.PROP_KEY, prop)
+            .setDetail(LogCb.NODE_KEY, mainNodeId);
+    logCb.setCounterSuffix(prop);
+    List<String> fields = McfParser.splitAndStripWithQuoteEscape(trimmedComplexValue, arg, logCb);
     if (fields.size() != 2 && fields.size() != 3) {
       logCtx.addEntry(
           Debug.Log.Level.LEVEL_ERROR,

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import org.datacommons.proto.Debug;
 import org.datacommons.proto.Mcf;
-import org.datacommons.util.McfUtil.ErrCb;
+import org.datacommons.util.McfUtil.LogCb;
 
 // Checks common types of nodes on naming and schema requirements.
 //
@@ -125,9 +125,11 @@ public class McfChecker {
           if (!node.getLocationsList().isEmpty()) {
             lineNum = node.getLocationsList().get(0).getLineNumber();
           }
-          ErrCb errCb = new ErrCb(logCtx, Debug.Log.Level.LEVEL_ERROR, lineNum);
-          errCb.setDetails(Map.of(ErrCb.VALUE_KEY, tv.getValue(), ErrCb.NODE_KEY, nodeId));
-          McfParser.SchemaTerm term = McfParser.parseSchemaTerm(tv.getValue(), errCb);
+          LogCb logCb =
+              new LogCb(logCtx, Debug.Log.Level.LEVEL_ERROR, lineNum)
+                  .setDetail(LogCb.VALUE_KEY, tv.getValue())
+                  .setDetail(LogCb.NODE_KEY, nodeId);
+          McfParser.SchemaTerm term = McfParser.parseSchemaTerm(tv.getValue(), logCb);
           if (term.type != McfParser.SchemaTerm.Type.COLUMN) {
             addLog(
                 "Sanity_UnexpectedNonColumn",

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import org.datacommons.proto.Debug;
 import org.datacommons.proto.Mcf;
+import org.datacommons.util.McfUtil.ErrCb;
 
 // Checks common types of nodes on naming and schema requirements.
 //
@@ -120,8 +121,13 @@ public class McfChecker {
         } else if (tv.getType() == Mcf.ValueType.TABLE_COLUMN) {
           // NOTE: If the MCF had parsed, the schema terms should be valid, thus
           // the ValueOrDie().
-          // TODO: Add node info to ErrCbArg to log location.
-          McfParser.SchemaTerm term = McfParser.parseSchemaTerm(tv.getValue(), null);
+          long lineNum = -1;
+          if (!node.getLocationsList().isEmpty()) {
+            lineNum = node.getLocationsList().get(0).getLineNumber();
+          }
+          ErrCb errCb = new ErrCb(logCtx, Debug.Log.Level.LEVEL_ERROR, lineNum);
+          errCb.setDetails(Map.of(ErrCb.VALUE_KEY, tv.getValue(), ErrCb.NODE_KEY, nodeId));
+          McfParser.SchemaTerm term = McfParser.parseSchemaTerm(tv.getValue(), errCb);
           if (term.type != McfParser.SchemaTerm.Type.COLUMN) {
             addLog(
                 "Sanity_UnexpectedNonColumn",

--- a/util/src/main/java/org/datacommons/util/McfParser.java
+++ b/util/src/main/java/org/datacommons/util/McfParser.java
@@ -149,8 +149,7 @@ public class McfParser {
         return;
       }
       if (graph.getType() == Mcf.McfType.TEMPLATE_MCF) {
-        LogCb logCb = getLogCb();
-        logCb.setDetail(LogCb.VALUE_KEY, rhs);
+        LogCb logCb = getLogCb().setDetail(LogCb.VALUE_KEY, rhs);
         SchemaTerm term = parseSchemaTerm(rhs, logCb);
         if (term.type != SchemaTerm.Type.ENTITY) {
           logCtx.addEntry(
@@ -300,11 +299,12 @@ public class McfParser {
     ssArg.delimiter = Vocabulary.VALUE_SEPARATOR;
     ssArg.includeEmpty = false;
     ssArg.stripEnclosingQuotes = false;
-    LogCb logCb = getLogCb();
-    logCb.setDetail(LogCb.PROP_KEY, prop);
-    logCb.setDetail(LogCb.VALUE_KEY, values);
-    logCb.setDetail(LogCb.NODE_KEY, curEntity);
-    logCb.setCounterSuffix(prop);
+    LogCb logCb =
+        getLogCb()
+            .setDetail(LogCb.PROP_KEY, prop)
+            .setDetail(LogCb.VALUE_KEY, values)
+            .setDetail(LogCb.NODE_KEY, curEntity)
+            .setCounterSuffix(prop);
     List<String> fields = splitAndStripWithQuoteEscape(values, ssArg, logCb);
     logCb.setCounterSuffix("");
     for (String field : fields) {

--- a/util/src/main/java/org/datacommons/util/McfUtil.java
+++ b/util/src/main/java/org/datacommons/util/McfUtil.java
@@ -236,4 +236,47 @@ public class McfUtil {
     String v = val.toLowerCase();
     return v.equals("true") || v.equals("1") || v.equals("false") || v.equals("0");
   }
+
+  public static class ErrCb {
+    public static final String VALUE_KEY = "value";
+    public static final String COLUMN_KEY = "column";
+    public static final String PROP_KEY = "property";
+    public static final String NODE_KEY = "node";
+
+    private final LogWrapper logCtx;
+    private final Debug.Log.Level logLevel;
+    private final long lineNum;
+    private Map<String, String> messageDetails = new HashMap<>();
+    public String counter_prefix = "";
+    public String counter_suffix = "";
+
+    public ErrCb(LogWrapper logCtx, Debug.Log.Level logLevel, long lineNum) {
+      this.logCtx = logCtx;
+      this.logLevel = logLevel;
+      this.lineNum = lineNum;
+    }
+
+    public void setDetail(String key, String val) {
+      this.messageDetails.put(key, val);
+    }
+
+    public void setDetails(Map<String, String> details) {
+      this.messageDetails = details;
+    }
+
+    public void logError(String counter, String problemMessage, List<String> detailsToInclude) {
+      counter = counter_prefix + counter + counter_suffix;
+      String message = problemMessage + " ::";
+      for (int i = 0; i < detailsToInclude.size(); i++) {
+        String key = detailsToInclude.get(i);
+        if (messageDetails.containsKey(key)) {
+          message += " " + key + ": '" + messageDetails.get(key) + "'";
+        }
+        if (i < detailsToInclude.size() - 1) {
+          message += ",";
+        }
+      }
+      this.logCtx.addEntry(this.logLevel, counter, message, this.lineNum);
+    }
+  }
 }

--- a/util/src/main/java/org/datacommons/util/McfUtil.java
+++ b/util/src/main/java/org/datacommons/util/McfUtil.java
@@ -263,12 +263,14 @@ public class McfUtil {
       return this;
     }
 
-    public void setCounterPrefix(String prefix) {
+    public LogCb setCounterPrefix(String prefix) {
       this.counter_prefix = prefix;
+      return this;
     }
 
-    public void setCounterSuffix(String suffix) {
+    public LogCb setCounterSuffix(String suffix) {
       this.counter_suffix = suffix;
+      return this;
     }
 
     public void logError(String counter, String problemMessage) {

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -17,17 +17,17 @@ package org.datacommons.util;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.function.BiConsumer;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.datacommons.proto.Debug;
 import org.datacommons.proto.Mcf;
-import org.datacommons.util.McfParser.SplitAndStripArgContext;
+import org.datacommons.util.McfUtil.ErrCb;
 
 // Converts a Template MCF file and an associated CSV into instance MCF.
 //
@@ -133,10 +133,9 @@ public class TmcfCsvParser {
         return;
       }
 
-      BiConsumer<String, String> errCb =
-          (counter, message) -> {
-            addLog(Debug.Log.Level.LEVEL_ERROR, counter, message);
-          };
+      ErrCb errCb =
+          new ErrCb(logCtx, Debug.Log.Level.LEVEL_ERROR, csvParser.getCurrentLineNumber());
+
       // Process DCIDs from all the nodes first and add to entityToDcid map, which will be consulted
       // to resolve entity references in processValues() function.
       for (Map.Entry<String, Mcf.McfGraph.PropertyValues> tableEntity :
@@ -147,7 +146,7 @@ public class TmcfCsvParser {
         // Register the fact that the user has mapped dcid, in case we continue below.
         // TODO: Maybe this should move to after currentNodeId setting below.
         entityToDcid.put(tableEntity.getKey(), Mcf.McfGraph.TypedValue.newBuilder().build());
-
+        errCb.setDetail(ErrCb.VALUE_KEY, tableEntity.getKey());
         currentNodeId = toNodeName(tableEntity.getKey(), errCb);
         if (currentNodeId == null) continue;
 
@@ -176,6 +175,7 @@ public class TmcfCsvParser {
 
       for (Map.Entry<String, Mcf.McfGraph.PropertyValues> tableEntity :
           tmcf.getNodesMap().entrySet()) {
+        errCb.setDetail(ErrCb.VALUE_KEY, tableEntity.getKey());
         currentNodeId = toNodeName(tableEntity.getKey(), errCb);
         if (currentNodeId == null) continue;
         // Case of malformed/empty DCID. SKip this node (counters were updated above).
@@ -223,14 +223,15 @@ public class TmcfCsvParser {
       Mcf.McfGraph.Values.Builder instanceValues = Mcf.McfGraph.Values.newBuilder();
 
       // Used for parseSchemaTerm() and splitAndStripWithQuoteEscape()
-      BiConsumer<String, String> errCb =
-          (counter, message) -> {
-            addLog(Debug.Log.Level.LEVEL_ERROR, counter, message);
-          };
-      BiConsumer<String, String> warnCb =
-          (counter, message) -> {
-            addLog(Debug.Log.Level.LEVEL_WARNING, counter, message);
-          };
+      ErrCb errCb =
+          new ErrCb(logCtx, Debug.Log.Level.LEVEL_ERROR, csvParser.getCurrentLineNumber());
+      ErrCb warnCb =
+          new ErrCb(logCtx, Debug.Log.Level.LEVEL_WARNING, csvParser.getCurrentLineNumber());
+      Map<String, String> errCbDetails = new HashMap<>();
+      errCbDetails.put(ErrCb.PROP_KEY, currentProp);
+      errCbDetails.put(ErrCb.NODE_KEY, templateEntity);
+      errCb.setDetails(errCbDetails);
+      warnCb.setDetails(errCbDetails);
 
       for (Mcf.McfGraph.TypedValue typedValue : templateValues.getTypedValuesList()) {
         if (typedValue.getType() == Mcf.ValueType.TABLE_ENTITY) {
@@ -245,6 +246,7 @@ public class TmcfCsvParser {
                     + "'");
             continue;
           }
+          errCb.setDetail(ErrCb.VALUE_KEY, typedValue.getValue());
           String referenceNode = toNodeName(typedValue.getValue(), errCb);
           Mcf.McfGraph.TypedValue.Builder newTypedValue = Mcf.McfGraph.TypedValue.newBuilder();
           if (referenceNode.startsWith(Vocabulary.DCID_PREFIX)) {
@@ -275,6 +277,7 @@ public class TmcfCsvParser {
           instanceValues.addTypedValues(newTypedValue.build());
         } else if (typedValue.getType() == Mcf.ValueType.TABLE_COLUMN) {
           // Replace column-name with cell-value
+          errCb.setDetail(ErrCb.VALUE_KEY, typedValue.getValue());
           McfParser.SchemaTerm term = McfParser.parseSchemaTerm(typedValue.getValue(), errCb);
           if (term == null) {
             continue;
@@ -315,12 +318,15 @@ public class TmcfCsvParser {
           ssArg.delimiter = delimiter;
           ssArg.includeEmpty = false;
           ssArg.stripEnclosingQuotes = false;
-          ssArg.context = new SplitAndStripArgContext(column, currentProp, templateEntity);
           // TODO: set stripEscapesBeforeQuotes
-          List<String> values =
-              McfParser.splitAndStripWithQuoteEscape(dataRow.get(columnIndex), ssArg, warnCb);
+          String origValue = dataRow.get(columnIndex);
+          warnCb.setDetail(ErrCb.VALUE_KEY, origValue);
+          warnCb.setDetail(ErrCb.COLUMN_KEY, column);
+          warnCb.counter_suffix = "_" + currentProp;
+          List<String> values = McfParser.splitAndStripWithQuoteEscape(origValue, ssArg, warnCb);
           for (String value : values) {
             Mcf.McfGraph.TypedValue.Builder newTypedValue = instanceValues.addTypedValuesBuilder();
+            errCb.setDetail(ErrCb.VALUE_KEY, value);
             McfParser.parseTypedValue(
                 Mcf.McfType.INSTANCE_MCF,
                 false,
@@ -339,7 +345,7 @@ public class TmcfCsvParser {
       return instanceValues.build();
     }
 
-    private String toNodeName(String entityId, BiConsumer<String, String> errCb) {
+    private String toNodeName(String entityId, ErrCb errCb) {
       if (entityToDcid.containsKey(entityId)) {
         return Vocabulary.DCID_PREFIX + entityToDcid.get(entityId).getValue();
       }
@@ -348,11 +354,11 @@ public class TmcfCsvParser {
       if (term == null) return null;
       if (term.type != McfParser.SchemaTerm.Type.ENTITY) {
         // TODO: Consider making this an assertion failure
-        errCb.accept(
+        List<String> detailsToInclude = Arrays.asList(ErrCb.VALUE_KEY);
+        errCb.logError(
             "CSV_UnexpectedNonEntity",
-            "Expected value to be a TMCF entity that starts with 'E:' :: value: '"
-                + entityId
-                + "'");
+            "Expected value to be a TMCF entity that starts with 'E:'",
+            detailsToInclude);
         return null;
       }
 

--- a/util/src/test/java/org/datacommons/util/ComplexValueParserTest.java
+++ b/util/src/test/java/org/datacommons/util/ComplexValueParserTest.java
@@ -86,8 +86,10 @@ public class ComplexValueParserTest {
   @Test
   public void testQuantityFailure() {
     Debug.Log log = toComplexValueFailure("[]");
-    assertTrue(log.getCounterSet().containsCounters("MCF_MalformedComplexValueString"));
-    assertTrue(log.getEntries(0).getUserMessage().contains("malformed"));
+    assertTrue(log.getCounterSet().containsCounters("StrSplit_EmptyToken_p1"));
+    assertTrue(log.getEntries(0).getUserMessage().contains("Empty value found"));
+    assertTrue(log.getCounterSet().containsCounters("MCF_MalformedComplexValueParts"));
+    assertTrue(log.getEntries(1).getUserMessage().contains("value must have 2"));
 
     log = toComplexValueFailure("dcs:Years 10]");
     assertTrue(log.getCounterSet().containsCounters("MCF_UnenclosedComplexValue"));

--- a/util/src/test/java/org/datacommons/util/McfUtilTest.java
+++ b/util/src/test/java/org/datacommons/util/McfUtilTest.java
@@ -25,15 +25,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.datacommons.proto.Debug;
-import org.datacommons.proto.Debug.Log.Level;
 import org.datacommons.proto.Mcf;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class McfUtilTest {
-  @Rule
-  public TemporaryFolder testFolder = new TemporaryFolder();
+  @Rule public TemporaryFolder testFolder = new TemporaryFolder();
 
   private static String SERIALIZE_INPUT =
       "Node: USState[1]\n"

--- a/util/src/test/java/org/datacommons/util/McfUtilTest.java
+++ b/util/src/test/java/org/datacommons/util/McfUtilTest.java
@@ -20,13 +20,21 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
+import org.datacommons.proto.Debug;
+import org.datacommons.proto.Debug.Log.Level;
 import org.datacommons.proto.Mcf;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class McfUtilTest {
+  @Rule
+  public TemporaryFolder testFolder = new TemporaryFolder();
+
   private static String SERIALIZE_INPUT =
       "Node: USState[1]\n"
           + "dcid: dcid:dc/abcd\n"
@@ -180,5 +188,36 @@ public class McfUtilTest {
     assertFalse(isBool("110"));
     assertFalse(isBool("yes"));
     assertFalse(isBool("10"));
+  }
+
+  @Test
+  public void logErrorWithErrCb() {
+    Debug.Log.Builder logCtx = Debug.Log.newBuilder();
+    LogWrapper lw = new LogWrapper(logCtx, testFolder.getRoot().toPath());
+    ErrCb errCb = new ErrCb(lw, Debug.Log.Level.LEVEL_ERROR, 0);
+    List<String> detailsToInclude = new ArrayList<>();
+    String testCounter = "test_counter";
+    String testMessage = "test_message";
+
+    errCb.logError(testCounter, testMessage, detailsToInclude);
+    assertTrue(TestUtil.checkLog(logCtx.build(), "test_counter", "test_message"));
+
+    errCb.setDetail(ErrCb.VALUE_KEY, "test_value");
+    detailsToInclude.add(ErrCb.VALUE_KEY);
+    errCb.logError(testCounter, testMessage, detailsToInclude);
+    assertTrue(TestUtil.checkLog(logCtx.build(), "test_counter", "value: 'test_value'"));
+
+    detailsToInclude.add(ErrCb.COLUMN_KEY);
+    errCb.logError(testCounter, testMessage, detailsToInclude);
+    assertFalse(TestUtil.checkLog(logCtx.build(), "test_counter", "column: '"));
+
+    errCb.counter_prefix = "MCF_";
+    errCb.logError(testCounter, testMessage, detailsToInclude);
+    assertTrue(TestUtil.checkLog(logCtx.build(), "MCF_test_counter", "test_message"));
+
+    errCb.counter_prefix = "";
+    errCb.counter_suffix = "_Prop";
+    errCb.logError(testCounter, testMessage, detailsToInclude);
+    assertTrue(TestUtil.checkLog(logCtx.build(), "test_counter_Prop", "test_message"));
   }
 }

--- a/util/src/test/java/org/datacommons/util/McfUtilTest.java
+++ b/util/src/test/java/org/datacommons/util/McfUtilTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
@@ -192,30 +191,24 @@ public class McfUtilTest {
   public void logErrorWithErrCb() {
     Debug.Log.Builder logCtx = Debug.Log.newBuilder();
     LogWrapper lw = new LogWrapper(logCtx, testFolder.getRoot().toPath());
-    ErrCb errCb = new ErrCb(lw, Debug.Log.Level.LEVEL_ERROR, 0);
-    List<String> detailsToInclude = new ArrayList<>();
+    LogCb logCb = new LogCb(lw, Debug.Log.Level.LEVEL_ERROR, 0);
     String testCounter = "test_counter";
     String testMessage = "test_message";
 
-    errCb.logError(testCounter, testMessage, detailsToInclude);
+    logCb.logError(testCounter, testMessage);
     assertTrue(TestUtil.checkLog(logCtx.build(), "test_counter", "test_message"));
 
-    errCb.setDetail(ErrCb.VALUE_KEY, "test_value");
-    detailsToInclude.add(ErrCb.VALUE_KEY);
-    errCb.logError(testCounter, testMessage, detailsToInclude);
+    logCb.setDetail(LogCb.VALUE_KEY, "test_value");
+    logCb.logError(testCounter, testMessage);
     assertTrue(TestUtil.checkLog(logCtx.build(), "test_counter", "value: 'test_value'"));
 
-    detailsToInclude.add(ErrCb.COLUMN_KEY);
-    errCb.logError(testCounter, testMessage, detailsToInclude);
-    assertFalse(TestUtil.checkLog(logCtx.build(), "test_counter", "column: '"));
-
-    errCb.counter_prefix = "MCF_";
-    errCb.logError(testCounter, testMessage, detailsToInclude);
+    logCb.setCounterPrefix("MCF");
+    logCb.logError(testCounter, testMessage);
     assertTrue(TestUtil.checkLog(logCtx.build(), "MCF_test_counter", "test_message"));
 
-    errCb.counter_prefix = "";
-    errCb.counter_suffix = "_Prop";
-    errCb.logError(testCounter, testMessage, detailsToInclude);
+    logCb.setCounterPrefix("");
+    logCb.setCounterSuffix("Prop");
+    logCb.logError(testCounter, testMessage);
     assertTrue(TestUtil.checkLog(logCtx.build(), "test_counter_Prop", "test_message"));
   }
 }


### PR DESCRIPTION
- instead of using a BiConsumer, create a new class to act as an ErrCb that can take in more arguments
- ErrCb can be used to set details such as Node, Property, Column, Value, Counter Suffix, Counter Prefix, etc. and those can be then used in the message used for logging an error/warning