### PR TITLE
Add End to End tests

### DIFF
--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -57,6 +57,12 @@
             <artifactId>protobuf-java-util</artifactId>
             <version>3.7.1</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -70,6 +70,8 @@ public class Processor {
       logger.debug("Checking CSV " + csvFile.getPath());
       TmcfCsvParser parser =
           TmcfCsvParser.init(tmcfFile.getPath(), csvFile.getPath(), delimiter, logCtx);
+      // If there were too many failures when initializing the parser, parser will be null and we
+      // don't want to continue processing.
       if (logCtx.loggedTooManyFailures()) {
         throw new DCTooManyFailuresException("processTables encountered too many failures");
       }

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -70,6 +70,9 @@ public class Processor {
       logger.debug("Checking CSV " + csvFile.getPath());
       TmcfCsvParser parser =
           TmcfCsvParser.init(tmcfFile.getPath(), csvFile.getPath(), delimiter, logCtx);
+      if (logCtx.loggedTooManyFailures()) {
+        throw new DCTooManyFailuresException("processTables encountered too many failures");
+      }
       Mcf.McfGraph g;
       long numNodesProcessed = 0, numRowsProcessed = 0;
       while ((g = parser.parseNextRow()) != null) {

--- a/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
+++ b/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
@@ -16,14 +16,11 @@ package org.datacommons.tool;
 
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
-import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -39,14 +36,11 @@ public class GenMcfTest {
     String csv = resourceFile("Csv1.csv");
     CommandLine cmd = new CommandLine(app);
     cmd.execute("genmcf", tmcf, csv, "--output-dir=" + testFolder.getRoot().getPath());
-    File actualReportFile =
-        new File(Paths.get(testFolder.getRoot().getPath(), "report.json").toString());
-    File expectedReportFile =
-        new File(this.getClass().getResource("GenMcfTest_FatalTmcfReport.json").getPath());
-    File actualGeneratedMcfFile =
-        new File(Paths.get(testFolder.getRoot().getPath(), "generated.mcf").toString());
-    TestUtil.assertReportFilesAreSimilar(expectedReportFile, actualReportFile);
-    assertTrue(FileUtils.readFileToString(actualGeneratedMcfFile, StandardCharsets.UTF_8).isEmpty());
+    String actualReportString = TestUtil.getStringFromTestFile(testFolder, "report.json");
+    String expectedReportString =
+        TestUtil.getStringFromResource(this.getClass(), "GenMcfTest_FatalTmcfReport.json");
+    TestUtil.assertReportFilesAreSimilar(expectedReportString, actualReportString);
+    assertTrue(TestUtil.getStringFromTestFile(testFolder, "generated.mcf").isEmpty());
   }
 
   @Test
@@ -56,14 +50,13 @@ public class GenMcfTest {
     String csv = resourceFile("Csv1.csv");
     CommandLine cmd = new CommandLine(app);
     cmd.execute("genmcf", tmcf, csv, "--output-dir=" + testFolder.getRoot().getPath());
-    File actualReportFile =
-        new File(Paths.get(testFolder.getRoot().getPath(), "report.json").toString());
-    File expectedReportFile =
-        new File(this.getClass().getResource("GenMcfTest_SuccessTmcfReport.json").getPath());
+    String actualReportString = TestUtil.getStringFromTestFile(testFolder, "report.json");
+    String expectedReportString =
+        TestUtil.getStringFromResource(this.getClass(), "GenMcfTest_SuccessTmcfReport.json");
     Path actualGeneratedFilePath = Paths.get(testFolder.getRoot().getPath(), "generated.mcf");
     Path expectedGeneratedFilePath =
         Paths.get(this.getClass().getResource("GenMcfTest_SuccessTmcfGenerated.mcf").getPath());
-    TestUtil.assertReportFilesAreSimilar(expectedReportFile, actualReportFile);
+    TestUtil.assertReportFilesAreSimilar(expectedReportString, actualReportString);
     assertTrue(areSimilarGeneratedMcf(expectedGeneratedFilePath, actualGeneratedFilePath));
   }
 
@@ -71,6 +64,8 @@ public class GenMcfTest {
     return this.getClass().getResource(resource).getPath();
   }
 
+  // When testing GeneratedMcf, can't just check against an expected file because When generating
+  // SVO MCF from csv and tmcf, Nodes will be assigned an ID that may not always be the same
   private boolean areSimilarGeneratedMcf(Path expectedFilePath, Path actualFilePath)
       throws IOException {
     Iterator<String> expectedFileLines = Files.lines(expectedFilePath).iterator();

--- a/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
+++ b/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
@@ -14,7 +14,7 @@
 
 package org.datacommons.tool;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,7 +30,6 @@ import org.junit.rules.TemporaryFolder;
 import picocli.CommandLine;
 
 public class GenMcfTest {
-
   @Rule public TemporaryFolder testFolder = new TemporaryFolder();
 
   @Test
@@ -40,16 +39,14 @@ public class GenMcfTest {
     String csv = resourceFile("Csv1.csv");
     CommandLine cmd = new CommandLine(app);
     cmd.execute("genmcf", tmcf, csv, "--output-dir=" + testFolder.getRoot().getPath());
-    File gotReportFile =
+    File actualReportFile =
         new File(Paths.get(testFolder.getRoot().getPath(), "report.json").toString());
-    File gotGeneratedMcfFile =
-        new File(Paths.get(testFolder.getRoot().getPath(), "generated.mcf").toString());
-    File wantReportFile =
+    File expectedReportFile =
         new File(this.getClass().getResource("GenMcfTest_FatalTmcfReport.json").getPath());
-    assertEquals(
-        FileUtils.readFileToString(wantReportFile, StandardCharsets.UTF_8),
-        FileUtils.readFileToString(gotReportFile, StandardCharsets.UTF_8));
-    assertTrue(FileUtils.readFileToString(gotGeneratedMcfFile, StandardCharsets.UTF_8).isEmpty());
+    File actualGeneratedMcfFile =
+        new File(Paths.get(testFolder.getRoot().getPath(), "generated.mcf").toString());
+    TestUtil.assertReportFilesAreSimilar(expectedReportFile, actualReportFile);
+    assertTrue(FileUtils.readFileToString(actualGeneratedMcfFile, StandardCharsets.UTF_8).isEmpty());
   }
 
   @Test
@@ -59,17 +56,15 @@ public class GenMcfTest {
     String csv = resourceFile("Csv1.csv");
     CommandLine cmd = new CommandLine(app);
     cmd.execute("genmcf", tmcf, csv, "--output-dir=" + testFolder.getRoot().getPath());
-    File gotReportFile =
+    File actualReportFile =
         new File(Paths.get(testFolder.getRoot().getPath(), "report.json").toString());
-    File wantReportFile =
+    File expectedReportFile =
         new File(this.getClass().getResource("GenMcfTest_SuccessTmcfReport.json").getPath());
     Path actualGeneratedFilePath = Paths.get(testFolder.getRoot().getPath(), "generated.mcf");
     Path expectedGeneratedFilePath =
         Paths.get(this.getClass().getResource("GenMcfTest_SuccessTmcfGenerated.mcf").getPath());
+    TestUtil.assertReportFilesAreSimilar(expectedReportFile, actualReportFile);
     assertTrue(areSimilarGeneratedMcf(expectedGeneratedFilePath, actualGeneratedFilePath));
-    assertEquals(
-        FileUtils.readFileToString(wantReportFile, StandardCharsets.UTF_8),
-        FileUtils.readFileToString(gotReportFile, StandardCharsets.UTF_8));
   }
 
   private String resourceFile(String resource) {

--- a/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
+++ b/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
@@ -1,0 +1,97 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.datacommons.tool;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import picocli.CommandLine;
+
+public class GenMcfTest {
+
+  @Rule public TemporaryFolder testFolder = new TemporaryFolder();
+
+  @Test
+  public void GenMcfTest_FatalTmcf() throws IOException {
+    Main app = new Main();
+    String tmcf = resourceFile("TmcfWithErrors.tmcf");
+    String csv = resourceFile("Csv1.csv");
+    CommandLine cmd = new CommandLine(app);
+    cmd.execute("genmcf", tmcf, csv, "--output-dir=" + testFolder.getRoot().getPath());
+    File gotReportFile =
+        new File(Paths.get(testFolder.getRoot().getPath(), "report.json").toString());
+    File gotGeneratedMcfFile =
+        new File(Paths.get(testFolder.getRoot().getPath(), "generated.mcf").toString());
+    File wantReportFile =
+        new File(this.getClass().getResource("GenMcfTest_FatalTmcfReport.json").getPath());
+    System.out.println(FileUtils.readFileToString(wantReportFile, StandardCharsets.UTF_8));
+    System.out.println(FileUtils.readFileToString(gotReportFile, StandardCharsets.UTF_8));
+    assertEquals(
+        FileUtils.readFileToString(wantReportFile, StandardCharsets.UTF_8),
+        FileUtils.readFileToString(gotReportFile, StandardCharsets.UTF_8));
+    assertTrue(FileUtils.readFileToString(gotGeneratedMcfFile, StandardCharsets.UTF_8).isEmpty());
+  }
+
+  @Test
+  public void GenMcfTest_SuccessTmcf() throws IOException {
+    Main app = new Main();
+    String tmcf = resourceFile("Tmcf1.tmcf");
+    String csv = resourceFile("Csv1.csv");
+    CommandLine cmd = new CommandLine(app);
+    cmd.execute("genmcf", tmcf, csv, "--output-dir=" + testFolder.getRoot().getPath());
+    File gotReportFile =
+        new File(Paths.get(testFolder.getRoot().getPath(), "report.json").toString());
+    File wantReportFile =
+        new File(this.getClass().getResource("GenMcfTest_SuccessTmcfReport.json").getPath());
+    Path actualGeneratedFilePath = Paths.get(testFolder.getRoot().getPath(), "generated.mcf");
+    Path expectedGeneratedFilePath =
+        Paths.get(this.getClass().getResource("GenMcfTest_SuccessTmcfGenerated.mcf").getPath());
+    assertTrue(areSimilarGeneratedMcf(expectedGeneratedFilePath, actualGeneratedFilePath));
+    assertEquals(
+        FileUtils.readFileToString(wantReportFile, StandardCharsets.UTF_8),
+        FileUtils.readFileToString(gotReportFile, StandardCharsets.UTF_8));
+  }
+
+  private String resourceFile(String resource) {
+    return this.getClass().getResource(resource).getPath();
+  }
+
+  private boolean areSimilarGeneratedMcf(Path expectedFilePath, Path actualFilePath)
+      throws IOException {
+    Iterator<String> expectedFileLines = Files.lines(expectedFilePath).iterator();
+    Iterator<String> actualFileLines = Files.lines(actualFilePath).iterator();
+    while (expectedFileLines.hasNext() && actualFileLines.hasNext()) {
+      String expectedLine = expectedFileLines.next();
+      String actualLine = actualFileLines.next();
+      if (expectedLine.contains("Node") && !expectedLine.contains("dcid")) {
+        continue;
+      }
+      if (!actualLine.trim().equals(expectedLine.trim())) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
+++ b/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
@@ -46,8 +46,6 @@ public class GenMcfTest {
         new File(Paths.get(testFolder.getRoot().getPath(), "generated.mcf").toString());
     File wantReportFile =
         new File(this.getClass().getResource("GenMcfTest_FatalTmcfReport.json").getPath());
-    System.out.println(FileUtils.readFileToString(wantReportFile, StandardCharsets.UTF_8));
-    System.out.println(FileUtils.readFileToString(gotReportFile, StandardCharsets.UTF_8));
     assertEquals(
         FileUtils.readFileToString(wantReportFile, StandardCharsets.UTF_8),
         FileUtils.readFileToString(gotReportFile, StandardCharsets.UTF_8));

--- a/tool/src/test/java/org/datacommons/tool/LintTest.java
+++ b/tool/src/test/java/org/datacommons/tool/LintTest.java
@@ -1,9 +1,6 @@
 package org.datacommons.tool;
 
-
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -19,11 +16,10 @@ public class LintTest {
     String mcf = resourceFile("LintTest.mcf");
     CommandLine cmd = new CommandLine(app);
     cmd.execute("lint", mcf, tmcf, "--output-dir=" + testFolder.getRoot().getPath());
-    File actualReportFile =
-        new File(Paths.get(testFolder.getRoot().getPath(), "report.json").toString());
-    File expectedReportFile =
-        new File(this.getClass().getResource("LintTest_McfAndTmcfReport.json").getPath());
-    TestUtil.assertReportFilesAreSimilar(expectedReportFile, actualReportFile);
+    String actualReportString = TestUtil.getStringFromTestFile(testFolder, "report.json");
+    String expectedReportString =
+        TestUtil.getStringFromResource(this.getClass(), "LintTest_McfAndTmcfReport.json");
+    TestUtil.assertReportFilesAreSimilar(expectedReportString, actualReportString);
   }
 
   @Test
@@ -34,11 +30,10 @@ public class LintTest {
     String csv = resourceFile("Csv1.csv");
     CommandLine cmd = new CommandLine(app);
     cmd.execute("lint", mcf, tmcf, csv, "--output-dir=" + testFolder.getRoot().getPath());
-    File actualReportFile =
-        new File(Paths.get(testFolder.getRoot().getPath(), "report.json").toString());
-    File expectedReportFile =
-        new File(this.getClass().getResource("LintTest_AllThreeFilesReport.json").getPath());
-    TestUtil.assertReportFilesAreSimilar(expectedReportFile, actualReportFile);
+    String actualReportString = TestUtil.getStringFromTestFile(testFolder, "report.json");
+    String expectedReportString =
+        TestUtil.getStringFromResource(this.getClass(), "LintTest_AllThreeFilesReport.json");
+    TestUtil.assertReportFilesAreSimilar(expectedReportString, actualReportString);
   }
 
   private String resourceFile(String resource) {

--- a/tool/src/test/java/org/datacommons/tool/LintTest.java
+++ b/tool/src/test/java/org/datacommons/tool/LintTest.java
@@ -1,12 +1,9 @@
 package org.datacommons.tool;
 
-import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
-import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -22,13 +19,11 @@ public class LintTest {
     String mcf = resourceFile("LintTest.mcf");
     CommandLine cmd = new CommandLine(app);
     cmd.execute("lint", mcf, tmcf, "--output-dir=" + testFolder.getRoot().getPath());
-    File gotReportFile =
+    File actualReportFile =
         new File(Paths.get(testFolder.getRoot().getPath(), "report.json").toString());
-    File wantReportFile =
+    File expectedReportFile =
         new File(this.getClass().getResource("LintTest_McfAndTmcfReport.json").getPath());
-    assertEquals(
-        FileUtils.readFileToString(wantReportFile, StandardCharsets.UTF_8),
-        FileUtils.readFileToString(gotReportFile, StandardCharsets.UTF_8));
+    TestUtil.assertReportFilesAreSimilar(expectedReportFile, actualReportFile);
   }
 
   @Test
@@ -39,13 +34,11 @@ public class LintTest {
     String csv = resourceFile("Csv1.csv");
     CommandLine cmd = new CommandLine(app);
     cmd.execute("lint", mcf, tmcf, csv, "--output-dir=" + testFolder.getRoot().getPath());
-    File gotReportFile =
+    File actualReportFile =
         new File(Paths.get(testFolder.getRoot().getPath(), "report.json").toString());
-    File wantReportFile =
+    File expectedReportFile =
         new File(this.getClass().getResource("LintTest_AllThreeFilesReport.json").getPath());
-    assertEquals(
-        FileUtils.readFileToString(wantReportFile, StandardCharsets.UTF_8),
-        FileUtils.readFileToString(gotReportFile, StandardCharsets.UTF_8));
+    TestUtil.assertReportFilesAreSimilar(expectedReportFile, actualReportFile);
   }
 
   private String resourceFile(String resource) {

--- a/tool/src/test/java/org/datacommons/tool/LintTest.java
+++ b/tool/src/test/java/org/datacommons/tool/LintTest.java
@@ -1,0 +1,54 @@
+package org.datacommons.tool;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import picocli.CommandLine;
+
+public class LintTest {
+  @Rule public TemporaryFolder testFolder = new TemporaryFolder();
+
+  @Test
+  public void LintTest_McfAndTmcf() throws IOException {
+    Main app = new Main();
+    String tmcf = resourceFile("TmcfWithErrors.tmcf");
+    String mcf = resourceFile("LintTest.mcf");
+    CommandLine cmd = new CommandLine(app);
+    cmd.execute("lint", mcf, tmcf, "--output-dir=" + testFolder.getRoot().getPath());
+    File gotReportFile =
+        new File(Paths.get(testFolder.getRoot().getPath(), "report.json").toString());
+    File wantReportFile =
+        new File(this.getClass().getResource("LintTest_McfAndTmcfReport.json").getPath());
+    assertEquals(
+        FileUtils.readFileToString(wantReportFile, StandardCharsets.UTF_8),
+        FileUtils.readFileToString(gotReportFile, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void LintTest_AllThreeFiles() throws IOException {
+    Main app = new Main();
+    String tmcf = resourceFile("Tmcf1.tmcf");
+    String mcf = resourceFile("LintTest.mcf");
+    String csv = resourceFile("Csv1.csv");
+    CommandLine cmd = new CommandLine(app);
+    cmd.execute("lint", mcf, tmcf, csv, "--output-dir=" + testFolder.getRoot().getPath());
+    File gotReportFile =
+        new File(Paths.get(testFolder.getRoot().getPath(), "report.json").toString());
+    File wantReportFile =
+        new File(this.getClass().getResource("LintTest_AllThreeFilesReport.json").getPath());
+    assertEquals(
+        FileUtils.readFileToString(wantReportFile, StandardCharsets.UTF_8),
+        FileUtils.readFileToString(gotReportFile, StandardCharsets.UTF_8));
+  }
+
+  private String resourceFile(String resource) {
+    return this.getClass().getResource(resource).getPath();
+  }
+}

--- a/tool/src/test/java/org/datacommons/tool/TestUtil.java
+++ b/tool/src/test/java/org/datacommons/tool/TestUtil.java
@@ -1,0 +1,43 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.datacommons.tool;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.Gson;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.FileUtils;
+import org.datacommons.proto.Debug;
+
+// Common set of utils used in e2e tests.
+public class TestUtil {
+  public static void assertReportFilesAreSimilar(File expected, File actual) throws IOException {
+    Debug.Log expectedLog =
+        new Gson()
+            .fromJson(
+                FileUtils.readFileToString(expected, StandardCharsets.UTF_8), Debug.Log.class);
+    Debug.Log actualLog =
+        new Gson()
+            .fromJson(
+                FileUtils.readFileToString(actual, StandardCharsets.UTF_8), Debug.Log.class);
+    assertEquals(expectedLog.getCounterSet(), actualLog.getCounterSet());
+    assertEquals(expectedLog.getLevelSummaryMap(), actualLog.getLevelSummaryMap());
+    assertTrue(actualLog.getEntriesList().containsAll(expectedLog.getEntriesList()));
+    assertTrue(expectedLog.getEntriesList().containsAll(actualLog.getEntriesList()));
+  }
+}

--- a/tool/src/test/java/org/datacommons/tool/TestUtil.java
+++ b/tool/src/test/java/org/datacommons/tool/TestUtil.java
@@ -21,23 +21,32 @@ import com.google.gson.Gson;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import org.apache.commons.io.FileUtils;
 import org.datacommons.proto.Debug;
+import org.junit.rules.TemporaryFolder;
 
 // Common set of utils used in e2e tests.
 public class TestUtil {
-  public static void assertReportFilesAreSimilar(File expected, File actual) throws IOException {
-    Debug.Log expectedLog =
-        new Gson()
-            .fromJson(
-                FileUtils.readFileToString(expected, StandardCharsets.UTF_8), Debug.Log.class);
-    Debug.Log actualLog =
-        new Gson()
-            .fromJson(
-                FileUtils.readFileToString(actual, StandardCharsets.UTF_8), Debug.Log.class);
+  public static void assertReportFilesAreSimilar(String expected, String actual)
+      throws IOException {
+    Debug.Log expectedLog = new Gson().fromJson(expected, Debug.Log.class);
+    Debug.Log actualLog = new Gson().fromJson(actual, Debug.Log.class);
     assertEquals(expectedLog.getCounterSet(), actualLog.getCounterSet());
     assertEquals(expectedLog.getLevelSummaryMap(), actualLog.getLevelSummaryMap());
     assertTrue(actualLog.getEntriesList().containsAll(expectedLog.getEntriesList()));
     assertTrue(expectedLog.getEntriesList().containsAll(actualLog.getEntriesList()));
+  }
+
+  public static String getStringFromTestFile(TemporaryFolder testFolder, String fileName)
+      throws IOException {
+    File file = new File(Paths.get(testFolder.getRoot().getPath(), fileName).toString());
+    return FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+  }
+
+  public static String getStringFromResource(Class resourceClass, String fileName)
+      throws IOException {
+    File file = new File(resourceClass.getResource(fileName).getPath());
+    return FileUtils.readFileToString(file, StandardCharsets.UTF_8);
   }
 }

--- a/tool/src/test/resources/org/datacommons/tool/Csv1.csv
+++ b/tool/src/test/resources/org/datacommons/tool/Csv1.csv
@@ -2,7 +2,7 @@ Year,Place_Id,Place_Name,Place_Type,LatLong,SV1,SV2
 19,US- CA,California,State,[LatLong 36N 1194W],1,2
 2019,"CA-BC,Canada",British–Columbia,AdministrativeArea1,[LatLong 53W 127N],1,2
 2019,CA-AB,Alberta,Administrative–Area1,[Lat Long 539 116],1,2
-2019,US-SF,San\nFrancisco,,[LatLong 37],1,2
+2019,US-SF,"San,Francisco",,[LatLong 37],1,2
 2019,US-WA,Washington,State,[LatLong 48, 120],1,2
 "2018, 2019",CA-VN,Vancouver,City,[],1,2
 2019,,Toronto,City,[LatLong 43, 116],1,2,

--- a/tool/src/test/resources/org/datacommons/tool/Csv1.csv
+++ b/tool/src/test/resources/org/datacommons/tool/Csv1.csv
@@ -1,0 +1,12 @@
+Year,Place_Id,Place_Name,Place_Type,LatLong,SV1,SV2
+19,US- CA,California,State,[LatLong 36N 1194W],1,2
+2019,"CA-BC,Canada",British–Columbia,AdministrativeArea1,[LatLong 53W 127N],1,2
+2019,CA-AB,Alberta,Administrative–Area1,[Lat Long 539 116],1,2
+2019,US-SF,San\nFrancisco,,[LatLong 37],1,2
+2019,US-WA,Washington,State,[LatLong 48, 120],1,2
+"2018, 2019",CA-VN,Vancouver,City,[],1,2
+2019,,Toronto,City,[LatLong 43, 116],1,2,
+2019,CH-SH,Shanghai,City,[,1,2
+2019,123,testPlace,AdministrativeArea1,[LatLong 53W 127N],1,2
+2019,veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongdcid,testPlace,AdministrativeArea1,[LatLong 53W 127N],1,2
+2019,CA-MN,Manitoba,Province,[Lat Long],1,2

--- a/tool/src/test/resources/org/datacommons/tool/GenMcfTest_FatalTmcfReport.json
+++ b/tool/src/test/resources/org/datacommons/tool/GenMcfTest_FatalTmcfReport.json
@@ -1,0 +1,196 @@
+{
+  "levelSummary": {
+    "LEVEL_ERROR": "19",
+    "LEVEL_WARNING": "1",
+    "LEVEL_FATAL": "1"
+  },
+  "counterSet": {
+    "counters": {
+      "MCF_UnexpectedProperty": "1",
+      "MCF_MalformedColonLessLine": "1",
+      "MCF_MalformedNodeName": "2",
+      "TMCF_MalformedSchemaTerm": "1",
+      "TMCF_MalformedEntity": "1",
+      "TMCF_UnsupportedColumnNameInProperty": "1",
+      "MCF_MalformedComplexValue": "1",
+      "Sanity_NotInitLowerPropName": "2",
+      "Sanity_MultipleDcidValues": "1",
+      "Sanity_TmcfMissingEntityDef": "4",
+      "Sanity_TmcfMissingColumn": "1",
+      "Sanity_MissingOrEmpty_typeOf": "1",
+      "Sanity_DcidTableEntity": "1",
+      "Sanity_MultipleVals_observationAbout": "1",
+      "Sanity_MultipleVals_value": "1",
+      "CSV_TmcfCheckFailure": "1"
+    }
+  },
+  "entries": [{
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "1"
+    },
+    "userMessage": "Property found without a preceding line with 'Node' :: line: 'typeOf dcs:StatVarObservation'",
+    "counterKey": "MCF_UnexpectedProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "5"
+    },
+    "userMessage": "Malformed line without a colon delimiter :: line: ': dcs:SV1'",
+    "counterKey": "MCF_MalformedColonLessLine"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "11"
+    },
+    "userMessage": "Found malformed Node value with quotes; must be a non-quoted value :: node: '"E:SVTest->E1"'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "22"
+    },
+    "userMessage": "Malformed column value; must have a '->' delimiter :: value: 'C:SVTest>Place_Name', property: 'name', node: 'E:SVTest->E3'",
+    "counterKey": "TMCF_MalformedSchemaTerm"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "25"
+    },
+    "userMessage": "Found malformed entity name that is not an entity prefix (E:) :: name: 'C:SVTest->NodeDcid'",
+    "counterKey": "TMCF_MalformedEntity"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "27"
+    },
+    "userMessage": "TMCF properties cannot refer to CSV columns yet :: value: 'SVTest->Property: C:SVTest->Property_Value', property: 'C', node: 'E:SVTest->E3'",
+    "counterKey": "TMCF_UnsupportedColumnNameInProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "29"
+    },
+    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'E:SVTest->E5,E:SVTest->E6'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "34"
+    },
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[', property: 'age', node: 'E:SVTest->E4'",
+    "counterKey": "MCF_MalformedComplexValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "Found property name that does not start with a lower-case :: property: 'C', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_NotInitLowerPropName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "Found dcid with more than one value :: count: 3, node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_MultipleDcidValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "Found property name that does not start with a lower-case :: property: 'Dcid', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_NotInitLowerPropName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E10', property: 'dcid' node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_TmcfMissingEntityDef"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "Column referred to in TMCF is missing from CSV header :: column: 'dcid1', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_TmcfMissingColumn"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_TmcfMissingEntityDef"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "32"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'E:SVTest->E4', type: 'Thing'",
+    "counterKey": "Sanity_MissingOrEmpty_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "32"
+    },
+    "userMessage": "Value of dcid property must not be an 'E:' reference :: value: 'E:SVTest->E1', node: 'E:SVTest->E4'",
+    "counterKey": "Sanity_DcidTableEntity"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "32"
+    },
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E1', property: 'dcid' node: 'E:SVTest->E4'",
+    "counterKey": "Sanity_TmcfMissingEntityDef"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Found multiple values for single-value property :: property: 'observationAbout', node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_MultipleVals_observationAbout"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Found multiple values for single-value property :: property: 'value', node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_MultipleVals_value"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E30', property: 'observationAbout' node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_TmcfMissingEntityDef"
+  }, {
+    "level": "LEVEL_FATAL",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "0"
+    },
+    "userMessage": "Found fatal sanity error in TMCF; check Sanity_ counter messages :: TMCF-file: TmcfWithErrors.tmcf",
+    "counterKey": "CSV_TmcfCheckFailure"
+  }]
+}

--- a/tool/src/test/resources/org/datacommons/tool/GenMcfTest_FatalTmcfReport.json
+++ b/tool/src/test/resources/org/datacommons/tool/GenMcfTest_FatalTmcfReport.json
@@ -46,7 +46,7 @@
       "file": "TmcfWithErrors.tmcf",
       "lineNumber": "11"
     },
-    "userMessage": "Found malformed Node value with quotes; must be a non-quoted value :: node: '"E:SVTest->E1"'",
+    "userMessage": "Found malformed Node value with quotes; must be a non-quoted value :: node: '\"E:SVTest->E1\"'",
     "counterKey": "MCF_MalformedNodeName"
   }, {
     "level": "LEVEL_ERROR",

--- a/tool/src/test/resources/org/datacommons/tool/GenMcfTest_SuccessTmcfGenerated.mcf
+++ b/tool/src/test/resources/org/datacommons/tool/GenMcfTest_SuccessTmcfGenerated.mcf
@@ -1,0 +1,113 @@
+Node: SVTest/E0/04a64232-2423-4949-adba-503331f4001e
+observationDate: 2019
+observationAbout: dcid:CA-BC
+variableMeasured: dcid:SV1
+measurementMethod: dcid:SVTest
+value: 1
+typeOf: dcid:StatVarObservation
+
+Node: SVTest/E1/04a64232-2423-4949-adba-503331f4001e
+observationDate: 2019
+observationAbout: dcid:CA-BC
+variableMeasured: dcid:SV2
+measurementMethod: dcid:SVTest
+value: 2
+typeOf: dcid:StatVarObservation
+
+Node: SVTest/E0/b3f3bbf0-caab-413c-9796-bfc35b76a48a
+observationDate: 2019
+observationAbout: dcid:CA-AB
+variableMeasured: dcid:SV1
+measurementMethod: dcid:SVTest
+value: 1
+typeOf: dcid:StatVarObservation
+
+Node: SVTest/E1/b3f3bbf0-caab-413c-9796-bfc35b76a48a
+observationDate: 2019
+observationAbout: dcid:CA-AB
+variableMeasured: dcid:SV2
+measurementMethod: dcid:SVTest
+value: 2
+typeOf: dcid:StatVarObservation
+
+Node: SVTest/E0/af2bbc95-8880-45a1-b31d-9bfcc9397a68
+observationDate: 2019
+observationAbout: dcid:US-SF
+variableMeasured: dcid:SV1
+measurementMethod: dcid:SVTest
+value: 1
+typeOf: dcid:StatVarObservation
+
+Node: SVTest/E1/af2bbc95-8880-45a1-b31d-9bfcc9397a68
+observationDate: 2019
+observationAbout: dcid:US-SF
+variableMeasured: dcid:SV2
+measurementMethod: dcid:SVTest
+value: 2
+typeOf: dcid:StatVarObservation
+
+Node: dcid:CA-VN
+dcid: "CA-VN"
+name: "Vancouver"
+location: []
+typeOf: dcid:City
+
+Node: dcid:CH-SH
+dcid: "CH-SH"
+name: "Shanghai"
+location:
+typeOf: dcid:City
+
+Node: SVTest/E0/59cb14d4-02a1-458c-ac1c-92289df189da
+observationDate: 2019
+observationAbout: dcid:CH-SH
+variableMeasured: dcid:SV1
+measurementMethod: dcid:SVTest
+value: 1
+typeOf: dcid:StatVarObservation
+
+Node: SVTest/E1/59cb14d4-02a1-458c-ac1c-92289df189da
+observationDate: 2019
+observationAbout: dcid:CH-SH
+variableMeasured: dcid:SV2
+measurementMethod: dcid:SVTest
+value: 2
+typeOf: dcid:StatVarObservation
+
+Node: SVTest/E0/f49ca47f-902d-469f-a345-cc6ef310416d
+observationDate: 2019
+observationAbout: dcid:veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongdcid
+variableMeasured: dcid:SV1
+measurementMethod: dcid:SVTest
+value: 1
+typeOf: dcid:StatVarObservation
+
+Node: SVTest/E1/f49ca47f-902d-469f-a345-cc6ef310416d
+observationDate: 2019
+observationAbout: dcid:veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongdcid
+variableMeasured: dcid:SV2
+measurementMethod: dcid:SVTest
+value: 2
+typeOf: dcid:StatVarObservation
+
+Node: dcid:CA-MN
+dcid: "CA-MN"
+name: "Manitoba"
+location: [Lat Long]
+typeOf: dcid:Province
+
+Node: SVTest/E0/1495a9f5-1f3a-4acc-bc82-022e5195d2dd
+observationDate: 2019
+observationAbout: dcid:CA-MN
+variableMeasured: dcid:SV1
+measurementMethod: dcid:SVTest
+value: 1
+typeOf: dcid:StatVarObservation
+
+Node: SVTest/E1/1495a9f5-1f3a-4acc-bc82-022e5195d2dd
+observationDate: 2019
+observationAbout: dcid:CA-MN
+variableMeasured: dcid:SV2
+measurementMethod: dcid:SVTest
+value: 2
+typeOf: dcid:StatVarObservation

--- a/tool/src/test/resources/org/datacommons/tool/GenMcfTest_SuccessTmcfReport.json
+++ b/tool/src/test/resources/org/datacommons/tool/GenMcfTest_SuccessTmcfReport.json
@@ -74,15 +74,6 @@
       "file": "Csv1.csv",
       "lineNumber": "5"
     },
-    "userMessage": "Found a new-line in value :: value: 'San
-Francisco', column: 'Place_Name', property: 'name', node: 'E:SVTest->E3'",
-    "counterKey": "StrSplit_MultiToken_name"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "Csv1.csv",
-      "lineNumber": "5"
-    },
     "userMessage": "Empty value found :: value: '', column: 'Place_Type', property: 'typeOf', node: 'E:SVTest->E3'",
     "counterKey": "StrSplit_EmptyToken_typeOf"
   }, {

--- a/tool/src/test/resources/org/datacommons/tool/GenMcfTest_SuccessTmcfReport.json
+++ b/tool/src/test/resources/org/datacommons/tool/GenMcfTest_SuccessTmcfReport.json
@@ -1,0 +1,209 @@
+{
+  "levelSummary": {
+    "LEVEL_ERROR": "17",
+    "LEVEL_WARNING": "5"
+  },
+  "counterSet": {
+    "counters": {
+      "Sanity_SpaceInDcid": "1",
+      "Sanity_InvalidObsDate": "2",
+      "NumRowSuccesses": "11",
+      "Sanity_MultipleDcidValues": "1",
+      "NumNodeSuccesses": "15",
+      "NumPVSuccesses": "84",
+      "Sanity_NonAsciiValueInNonText": "1",
+      "StrSplit_MultiToken_name": "1",
+      "StrSplit_EmptyToken_typeOf": "1",
+      "Sanity_MissingOrEmpty_typeOf": "1",
+      "CSV_InconsistentRows": "2",
+      "Sanity_MultipleVals_observationDate": "2",
+      "StrSplit_EmptyToken_location": "1",
+      "MCF_MalformedComplexValueParts": "1",
+      "MCF_MalformedComplexValue": "1",
+      "CSV_MalformedDCIDFailures": "1",
+      "CSV_MalformedDCIDPVFailures": "4",
+      "CSV_EmptyDcidReferences": "2",
+      "Sanity_MissingOrEmpty_observationAbout": "2",
+      "Sanity_VeryLongDcid": "1",
+      "MCF_QuantityMalformedValue": "1"
+    }
+  },
+  "entries": [{
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "2"
+    },
+    "userMessage": "Found a whitespace in dcid value :: value: 'US- CA', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_SpaceInDcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "2"
+    },
+    "userMessage": "Found a non-ISO8601 compliant date value :: value: '19', property: 'observationDate', node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_InvalidObsDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "2"
+    },
+    "userMessage": "Found a non-ISO8601 compliant date value :: value: '19', property: 'observationDate', node: 'E:SVTest->E1'",
+    "counterKey": "Sanity_InvalidObsDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Found dcid with more than one value :: count: 2, node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_MultipleDcidValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'Administrative–Area1', type: 'RESOLVED_REF', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_NonAsciiValueInNonText"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Found a new-line in value :: value: 'San
+Francisco', column: 'Place_Name', property: 'name', node: 'E:SVTest->E3'",
+    "counterKey": "StrSplit_MultiToken_name"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Empty value found :: value: '', column: 'Place_Type', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "StrSplit_EmptyToken_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'E:SVTest->E3', type: 'Thing'",
+    "counterKey": "Sanity_MissingOrEmpty_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "6"
+    },
+    "userMessage": "Found CSV row with different number of columns",
+    "counterKey": "CSV_InconsistentRows"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "7"
+    },
+    "userMessage": "Found multiple values for single-value property :: property: 'observationDate', column: 'Year', node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_MultipleVals_observationDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "7"
+    },
+    "userMessage": "Found multiple values for single-value property :: property: 'observationDate', column: 'Year', node: 'E:SVTest->E1'",
+    "counterKey": "Sanity_MultipleVals_observationDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "7"
+    },
+    "userMessage": "Empty value found :: value: '[]', property: 'location', node: 'dcid:CA-VN'",
+    "counterKey": "StrSplit_EmptyToken_location"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "7"
+    },
+    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[]', components: 0, property: 'location', node: 'dcid:CA-VN'",
+    "counterKey": "MCF_MalformedComplexValueParts"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "8"
+    },
+    "userMessage": "Found CSV row with different number of columns",
+    "counterKey": "CSV_InconsistentRows"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[', property: 'location', node: 'E:SVTest->E3'",
+    "counterKey": "MCF_MalformedComplexValue"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "Malformed CSV value for dcid property; must be a text or reference :: value: '123', node: 'E:SVTest->E3'",
+    "counterKey": "CSV_MalformedDCIDFailures"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "In dcid:{entity} reference, found {entity} to be empty :: property: 'observationAbout', node: 'E:SVTest->E0'",
+    "counterKey": "CSV_EmptyDcidReferences"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'observationAbout', node: 'E:SVTest->E0', type: 'StatVarObservation'",
+    "counterKey": "Sanity_MissingOrEmpty_observationAbout"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "In dcid:{entity} reference, found {entity} to be empty :: property: 'observationAbout', node: 'E:SVTest->E1'",
+    "counterKey": "CSV_EmptyDcidReferences"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'observationAbout', node: 'E:SVTest->E1', type: 'StatVarObservation'",
+    "counterKey": "Sanity_MissingOrEmpty_observationAbout"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Found a very long dcid value; must be less than 256 :: node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_VeryLongDcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Quantity value must be a number :: value: '[Lat Long]', property: 'location', node: 'dcid:CA-MN'",
+    "counterKey": "MCF_QuantityMalformedValue"
+  }]
+}

--- a/tool/src/test/resources/org/datacommons/tool/LintTest.mcf
+++ b/tool/src/test/resources/org/datacommons/tool/LintTest.mcf
@@ -1,0 +1,128 @@
+typeOf: State
+
+Node: dcid:geoId/la
+typeOf: City
+containedIn: 90062
+
+Node: dcid:geoId/CA
+: State
+
+Node: CityStats/E2/2
+typeOf: City
+name: San,Francisco
+containedIn: dcid:geoId/CA
+
+Node: CityStats/E3/2
+typeOf: "Statistical\nPopulation"
+populationType: "Person"
+location: l:CityStats/E2/2
+gender: dcs:Female
+nationality: ""
+age: [20 30 Years]
+
+Node: CityStats/E4/2
+typeOf: Observation
+populationType: Person
+observedNode: l:CityStats/E3/2
+measuredProperty: count
+measuredValue: 10000000.0
+observationDate: 7
+observationPeriod: "P5Y"
+
+Node: CityStats/E4/3
+typeOf: Observation
+populationType: Person
+observedNode: l:CityStats/E3/2
+measuredProperty: count
+measuredValue: one thousand
+observationDate: 2007
+observationPeriod: "5"
+
+Node: CityStats/E4/4
+typeOf: Observation
+populationType: Person
+observedNode: l:CityStats/E3/2
+measuredProperty: count
+observationDate: 2007
+observationPeriod: "5"
+
+Node: CityStats/E5/2
+typeOf: StatisticalPopulation
+populationType: Person
+location: dcid:geoId–SFCounty
+
+Node: USA,Country
+typeOf: schema:Country
+name: "United States Of America"
+dcid: dc/ 2sffw13
+
+Node: dcid:dc/mx44
+typeOf: "City"
+name: Mountain View
+containedInPlace: dc/4fef4e, l:USACountry
+population: 81438
+area: 31.788
+inCounty: true
+
+Node: "CANCountry"
+typeOf: schema:Country
+name: "Canada"
+dcid: dc/2312ca,Canada
+location: [LatLong -100 10]
+
+Node: dcid:geoId/sf
+typeOf: City
+location: [LatLong -20 181]
+
+Node: dcid:Count_Death_10To12
+typeOf: dcs:StatisticalVariable
+age: [10 12
+
+Node: dcid:Count_Death_10YearsPlus
+typeOf: dcs:StatisticalVariable
+age: [10]
+populationType: dcs:Person
+measuredProperty: dcs:count
+statType: dcs:MeasuredValue
+
+Node: dcid:Count_Death_5To10
+typeOf: dcs:StatisticalVariable
+age: [5Years 10Years]
+populationType: dcs:Person
+measuredProperty: dcs:count
+statType: dcs:MeasuredValue
+
+Node: dcid:Count_Death_YearsLessThan5
+typeOf: dcs:StatisticalVariable
+age: [years less 5]
+populationType: dcs:Person
+measuredProperty: dcs:count
+statType: dcs:MeasuredValue
+
+Node: dcid:Count_Death_5YearsPlus
+typeOf: dcs:StatisticalVariable
+age: [5 years -]
+populationType: dcs:Person
+measuredProperty: dcs:count
+statType: dcs:MeasuredValue
+
+Node: dcid:Count_Death_15YearsPlus
+typeOf: dcs:StatisticalVariable
+age: [- - 15]
+PopulationType: dcs:Person
+measuredProperty: dcs:count
+statType: dcs:MeasuredValue
+
+Node: dcid:beverageType
+typeOf: dcs:Property
+subClassOf: dcid:substanceType
+name: "Beverage–type"
+label: BeverageType
+domainIncludes:""
+
+Node: dcid:Pop
+typeOf: dcs:Class
+domainIncludes: dcs:PopEnums
+name: "pop"
+
+inCounty: false

--- a/tool/src/test/resources/org/datacommons/tool/LintTest.mcf
+++ b/tool/src/test/resources/org/datacommons/tool/LintTest.mcf
@@ -64,7 +64,7 @@ population: 81438
 area: 31.788
 inCounty: true
 
-Node: "CANCountry"
+Node: \"CANCountry\"
 typeOf: schema:Country
 name: "Canada"
 dcid: dc/2312ca,Canada

--- a/tool/src/test/resources/org/datacommons/tool/LintTest_AllThreeFilesReport.json
+++ b/tool/src/test/resources/org/datacommons/tool/LintTest_AllThreeFilesReport.json
@@ -1,0 +1,485 @@
+{
+  "levelSummary": {
+    "LEVEL_ERROR": "48",
+    "LEVEL_WARNING": "6"
+  },
+  "counterSet": {
+    "counters": {
+      "MCF_UnexpectedProperty": "1",
+      "MCF_MalformedColonLessLine": "1",
+      "Mutator_MissingTypeOf": "1",
+      "Sanity_MissingOrEmpty_typeOf": "2",
+      "Sanity_InvalidObsDate": "3",
+      "Sanity_NonDoubleObsValue": "1",
+      "Sanity_ObsMissingValueProp": "1",
+      "MCF_MalformedNodeName": "2",
+      "Sanity_SpaceInDcid": "2",
+      "Sanity_NonAsciiValueInNonText": "2",
+      "MCF_InvalidLatitude": "1",
+      "Sanity_MultipleDcidValues": "2",
+      "MCF_InvalidLongitude": "1",
+      "MCF_MalformedComplexValue": "2",
+      "Sanity_MissingOrEmpty_populationType": "2",
+      "Sanity_MissingOrEmpty_measuredProperty": "1",
+      "Sanity_MissingOrEmpty_statType": "1",
+      "Sanity_UnknownStatType": "1",
+      "MCF_MalformedComplexValueParts": "2",
+      "MCF_QuantityMalformedValue": "2",
+      "MCF_QuantityRangeMalformedValues": "3",
+      "Sanity_NotInitLowerPropName": "1",
+      "Sanity_UnexpectedPropInProperty": "1",
+      "Sanity_NonAsciiValueInSchema": "1",
+      "Sanity_NotInitLower_labelInProperty": "1",
+      "Sanity_UnexpectedPropInClass": "1",
+      "Sanity_NotInitUpper_nameInClass": "1",
+      "Sanity_MissingOrEmpty_subClassOf": "1",
+      "NumRowSuccesses": "11",
+      "NumNodeSuccesses": "15",
+      "NumPVSuccesses": "84",
+      "StrSplit_MultiToken_name": "1",
+      "StrSplit_EmptyToken_typeOf": "1",
+      "CSV_InconsistentRows": "2",
+      "Sanity_MultipleVals_observationDate": "2",
+      "StrSplit_EmptyToken_location": "1",
+      "CSV_MalformedDCIDFailures": "1",
+      "CSV_MalformedDCIDPVFailures": "4",
+      "CSV_EmptyDcidReferences": "2",
+      "Sanity_MissingOrEmpty_observationAbout": "2",
+      "Sanity_VeryLongDcid": "1"
+    }
+  },
+  "entries": [{
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "1"
+    },
+    "userMessage": "Property found without a preceding line with 'Node' :: line: 'typeOf: State'",
+    "counterKey": "MCF_UnexpectedProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "8"
+    },
+    "userMessage": "Malformed line without a colon delimiter :: line: ': State'",
+    "counterKey": "MCF_MalformedColonLessLine"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "7"
+    },
+    "userMessage": "Missing typeOf value for node :: node: 'dcid:geoId/CA'",
+    "counterKey": "Mutator_MissingTypeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "7"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'dcid:geoId/CA', type: 'Thing'",
+    "counterKey": "Sanity_MissingOrEmpty_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "23"
+    },
+    "userMessage": "Found a non-ISO8601 compliant date value :: value: '7', property: 'observationDate', node: 'CityStats/E4/2'",
+    "counterKey": "Sanity_InvalidObsDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "32"
+    },
+    "userMessage": "Found a non-double Observation value :: value: 'onethousand', property: 'measuredValue', node: 'CityStats/E4/3'",
+    "counterKey": "Sanity_NonDoubleObsValue"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "41"
+    },
+    "userMessage": "Observation node missing value property :: node: 'CityStats/E4/4'",
+    "counterKey": "Sanity_ObsMissingValueProp"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "54"
+    },
+    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'USA,Country'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "49"
+    },
+    "userMessage": "Found a whitespace in dcid value :: value: 'dc/ 2sffw13', node: 'CityStats/E5/2'",
+    "counterKey": "Sanity_SpaceInDcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "49"
+    },
+    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'geoId–SFCounty', type: 'RESOLVED_REF', property: 'location', node: 'CityStats/E5/2'",
+    "counterKey": "Sanity_NonAsciiValueInNonText"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "67"
+    },
+    "userMessage": "Found malformed Node value with quotes; must be a non-quoted value :: node: '"CANCountry"'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Invalid latitude value; must be decimal degrees with an optional N/S suffix :: value: '-100', property: 'location', node: 'dcid:dc/mx44'",
+    "counterKey": "MCF_InvalidLatitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Found dcid with more than one value :: count: 2, node: 'dcid:dc/mx44'",
+    "counterKey": "Sanity_MultipleDcidValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "73"
+    },
+    "userMessage": "Invalid longitude value; must be decimal degrees with an optional E/W suffix :: value: '181', property: 'location', node: 'dcid:geoId/sf'",
+    "counterKey": "MCF_InvalidLongitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "79"
+    },
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[10 12', property: 'age', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "MCF_MalformedComplexValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_populationType"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'measuredProperty', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_measuredProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_statType"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found an unknown statType value :: value: '', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "Sanity_UnknownStatType"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "81"
+    },
+    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[10]', components: 1, property: 'age', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "MCF_MalformedComplexValueParts"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "88"
+    },
+    "userMessage": "Quantity value must be a number :: value: '[5Years 10Years]', property: 'age', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "MCF_QuantityMalformedValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "95"
+    },
+    "userMessage": "Malformed start component in QuantityRange value; must be a number or '-' :: value: 'less', property: 'age', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "102"
+    },
+    "userMessage": "Malformed end component in QuantityRange value; must be a number or '-' :: value: 'years', property: 'age', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Found property name that does not start with a lower-case :: property: 'PopulationType', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "Sanity_NotInitLowerPropName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_15YearsPlus', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_populationType"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Unexpected property in Property node :: property: 'subClassOf', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_UnexpectedPropInProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Schema node has property values with non-ascii characters :: value: 'Beverage–type', property: 'name', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_NonAsciiValueInSchema"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Found a property reference that does not start with a lower-case :: reference: 'BeverageType', property: 'label, node: 'dcid:beverageType'",
+    "counterKey": "Sanity_NotInitLower_labelInProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Unexpected property in Class node :: property: 'domainIncludes', node: 'dcid:Pop'",
+    "counterKey": "Sanity_UnexpectedPropInClass"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Found a class reference that does not start with an upper-case :: reference: 'pop', property: 'name, node: 'dcid:Pop'",
+    "counterKey": "Sanity_NotInitUpper_nameInClass"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'subClassOf', node: 'dcid:Pop', type: 'Class'",
+    "counterKey": "Sanity_MissingOrEmpty_subClassOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "2"
+    },
+    "userMessage": "Found a whitespace in dcid value :: value: 'US- CA', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_SpaceInDcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "2"
+    },
+    "userMessage": "Found a non-ISO8601 compliant date value :: value: '19', property: 'observationDate', node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_InvalidObsDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "2"
+    },
+    "userMessage": "Found a non-ISO8601 compliant date value :: value: '19', property: 'observationDate', node: 'E:SVTest->E1'",
+    "counterKey": "Sanity_InvalidObsDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Found dcid with more than one value :: count: 2, node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_MultipleDcidValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'Administrative–Area1', type: 'RESOLVED_REF', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_NonAsciiValueInNonText"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Found a new-line in value :: value: 'San
+Francisco', column: 'Place_Name', property: 'name', node: 'E:SVTest->E3'",
+    "counterKey": "StrSplit_MultiToken_name"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Empty value found :: value: '', column: 'Place_Type', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "StrSplit_EmptyToken_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'E:SVTest->E3', type: 'Thing'",
+    "counterKey": "Sanity_MissingOrEmpty_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "6"
+    },
+    "userMessage": "Found CSV row with different number of columns",
+    "counterKey": "CSV_InconsistentRows"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "7"
+    },
+    "userMessage": "Found multiple values for single-value property :: property: 'observationDate', column: 'Year', node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_MultipleVals_observationDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "7"
+    },
+    "userMessage": "Found multiple values for single-value property :: property: 'observationDate', column: 'Year', node: 'E:SVTest->E1'",
+    "counterKey": "Sanity_MultipleVals_observationDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "7"
+    },
+    "userMessage": "Empty value found :: value: '[]', property: 'location', node: 'dcid:CA-VN'",
+    "counterKey": "StrSplit_EmptyToken_location"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "7"
+    },
+    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[]', components: 0, property: 'location', node: 'dcid:CA-VN'",
+    "counterKey": "MCF_MalformedComplexValueParts"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "8"
+    },
+    "userMessage": "Found CSV row with different number of columns",
+    "counterKey": "CSV_InconsistentRows"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[', property: 'location', node: 'E:SVTest->E3'",
+    "counterKey": "MCF_MalformedComplexValue"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "Malformed CSV value for dcid property; must be a text or reference :: value: '123', node: 'E:SVTest->E3'",
+    "counterKey": "CSV_MalformedDCIDFailures"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "In dcid:{entity} reference, found {entity} to be empty :: property: 'observationAbout', node: 'E:SVTest->E0'",
+    "counterKey": "CSV_EmptyDcidReferences"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'observationAbout', node: 'E:SVTest->E0', type: 'StatVarObservation'",
+    "counterKey": "Sanity_MissingOrEmpty_observationAbout"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "In dcid:{entity} reference, found {entity} to be empty :: property: 'observationAbout', node: 'E:SVTest->E1'",
+    "counterKey": "CSV_EmptyDcidReferences"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'observationAbout', node: 'E:SVTest->E1', type: 'StatVarObservation'",
+    "counterKey": "Sanity_MissingOrEmpty_observationAbout"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Found a very long dcid value; must be less than 256 :: node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_VeryLongDcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "Csv1.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Quantity value must be a number :: value: '[Lat Long]', property: 'location', node: 'dcid:CA-MN'",
+    "counterKey": "MCF_QuantityMalformedValue"
+  }]
+}

--- a/tool/src/test/resources/org/datacommons/tool/LintTest_AllThreeFilesReport.json
+++ b/tool/src/test/resources/org/datacommons/tool/LintTest_AllThreeFilesReport.json
@@ -134,7 +134,7 @@
       "file": "LintTest.mcf",
       "lineNumber": "67"
     },
-    "userMessage": "Found malformed Node value with quotes; must be a non-quoted value :: node: '"CANCountry"'",
+    "userMessage": "Found malformed Node value with quotes; must be a non-quoted value :: node: '\"CANCountry\"'",
     "counterKey": "MCF_MalformedNodeName"
   }, {
     "level": "LEVEL_ERROR",
@@ -344,15 +344,6 @@
     },
     "userMessage": "Found non-ascii characters in a value that is not text :: value: 'Administrative–Area1', type: 'RESOLVED_REF', property: 'typeOf', node: 'E:SVTest->E3'",
     "counterKey": "Sanity_NonAsciiValueInNonText"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "Csv1.csv",
-      "lineNumber": "5"
-    },
-    "userMessage": "Found a new-line in value :: value: 'San
-Francisco', column: 'Place_Name', property: 'name', node: 'E:SVTest->E3'",
-    "counterKey": "StrSplit_MultiToken_name"
   }, {
     "level": "LEVEL_WARNING",
     "location": {

--- a/tool/src/test/resources/org/datacommons/tool/LintTest_McfAndTmcfReport.json
+++ b/tool/src/test/resources/org/datacommons/tool/LintTest_McfAndTmcfReport.json
@@ -127,7 +127,7 @@
       "file": "LintTest.mcf",
       "lineNumber": "67"
     },
-    "userMessage": "Found malformed Node value with quotes; must be a non-quoted value :: node: '"CANCountry"'",
+    "userMessage": "Found malformed Node value with quotes; must be a non-quoted value :: node: '\"CANCountry\"'",
     "counterKey": "MCF_MalformedNodeName"
   }, {
     "level": "LEVEL_ERROR",
@@ -319,7 +319,7 @@
       "file": "TmcfWithErrors.tmcf",
       "lineNumber": "11"
     },
-    "userMessage": "Found malformed Node value with quotes; must be a non-quoted value :: node: '"E:SVTest->E1"'",
+    "userMessage": "Found malformed Node value with quotes; must be a non-quoted value :: node: '\"E:SVTest->E1\"'",
     "counterKey": "MCF_MalformedNodeName"
   }, {
     "level": "LEVEL_ERROR",

--- a/tool/src/test/resources/org/datacommons/tool/LintTest_McfAndTmcfReport.json
+++ b/tool/src/test/resources/org/datacommons/tool/LintTest_McfAndTmcfReport.json
@@ -1,0 +1,437 @@
+{
+  "levelSummary": {
+    "LEVEL_ERROR": "47",
+    "LEVEL_WARNING": "2"
+  },
+  "counterSet": {
+    "counters": {
+      "MCF_UnexpectedProperty": "2",
+      "MCF_MalformedColonLessLine": "2",
+      "Mutator_MissingTypeOf": "2",
+      "Sanity_MissingOrEmpty_typeOf": "2",
+      "Sanity_InvalidObsDate": "2",
+      "Sanity_NonDoubleObsValue": "1",
+      "Sanity_ObsMissingValueProp": "1",
+      "MCF_MalformedNodeName": "4",
+      "Sanity_SpaceInDcid": "1",
+      "Sanity_NonAsciiValueInNonText": "1",
+      "MCF_InvalidLatitude": "1",
+      "Sanity_MultipleDcidValues": "2",
+      "MCF_InvalidLongitude": "1",
+      "MCF_MalformedComplexValue": "2",
+      "Sanity_MissingOrEmpty_populationType": "2",
+      "Sanity_MissingOrEmpty_measuredProperty": "1",
+      "Sanity_MissingOrEmpty_statType": "1",
+      "Sanity_UnknownStatType": "1",
+      "MCF_MalformedComplexValueParts": "1",
+      "MCF_QuantityMalformedValue": "1",
+      "MCF_QuantityRangeMalformedValues": "3",
+      "Sanity_NotInitLowerPropName": "3",
+      "Sanity_UnexpectedPropInProperty": "1",
+      "Sanity_NonAsciiValueInSchema": "1",
+      "Sanity_NotInitLower_labelInProperty": "1",
+      "Sanity_UnexpectedPropInClass": "1",
+      "Sanity_NotInitUpper_nameInClass": "1",
+      "Sanity_MissingOrEmpty_subClassOf": "1",
+      "Sanity_MultipleVals_observationAbout": "1",
+      "Sanity_MultipleVals_value": "1",
+      "TMCF_MalformedSchemaTerm": "1",
+      "TMCF_MalformedEntity": "1",
+      "TMCF_UnsupportedColumnNameInProperty": "1",
+      "Sanity_DcidTableEntity": "1"
+    }
+  },
+  "entries": [{
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "1"
+    },
+    "userMessage": "Property found without a preceding line with 'Node' :: line: 'typeOf: State'",
+    "counterKey": "MCF_UnexpectedProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "8"
+    },
+    "userMessage": "Malformed line without a colon delimiter :: line: ': State'",
+    "counterKey": "MCF_MalformedColonLessLine"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "7"
+    },
+    "userMessage": "Missing typeOf value for node :: node: 'dcid:geoId/CA'",
+    "counterKey": "Mutator_MissingTypeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "7"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'dcid:geoId/CA', type: 'Thing'",
+    "counterKey": "Sanity_MissingOrEmpty_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "23"
+    },
+    "userMessage": "Found a non-ISO8601 compliant date value :: value: '7', property: 'observationDate', node: 'CityStats/E4/2'",
+    "counterKey": "Sanity_InvalidObsDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "32"
+    },
+    "userMessage": "Found a non-double Observation value :: value: 'onethousand', property: 'measuredValue', node: 'CityStats/E4/3'",
+    "counterKey": "Sanity_NonDoubleObsValue"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "41"
+    },
+    "userMessage": "Observation node missing value property :: node: 'CityStats/E4/4'",
+    "counterKey": "Sanity_ObsMissingValueProp"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "54"
+    },
+    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'USA,Country'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "49"
+    },
+    "userMessage": "Found a whitespace in dcid value :: value: 'dc/ 2sffw13', node: 'CityStats/E5/2'",
+    "counterKey": "Sanity_SpaceInDcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "49"
+    },
+    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'geoId–SFCounty', type: 'RESOLVED_REF', property: 'location', node: 'CityStats/E5/2'",
+    "counterKey": "Sanity_NonAsciiValueInNonText"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "67"
+    },
+    "userMessage": "Found malformed Node value with quotes; must be a non-quoted value :: node: '"CANCountry"'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Invalid latitude value; must be decimal degrees with an optional N/S suffix :: value: '-100', property: 'location', node: 'dcid:dc/mx44'",
+    "counterKey": "MCF_InvalidLatitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Found dcid with more than one value :: count: 2, node: 'dcid:dc/mx44'",
+    "counterKey": "Sanity_MultipleDcidValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "73"
+    },
+    "userMessage": "Invalid longitude value; must be decimal degrees with an optional E/W suffix :: value: '181', property: 'location', node: 'dcid:geoId/sf'",
+    "counterKey": "MCF_InvalidLongitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "79"
+    },
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[10 12', property: 'age', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "MCF_MalformedComplexValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_populationType"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'measuredProperty', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_measuredProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_statType"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found an unknown statType value :: value: '', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "Sanity_UnknownStatType"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "81"
+    },
+    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[10]', components: 1, property: 'age', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "MCF_MalformedComplexValueParts"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "88"
+    },
+    "userMessage": "Quantity value must be a number :: value: '[5Years 10Years]', property: 'age', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "MCF_QuantityMalformedValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "95"
+    },
+    "userMessage": "Malformed start component in QuantityRange value; must be a number or '-' :: value: 'less', property: 'age', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "102"
+    },
+    "userMessage": "Malformed end component in QuantityRange value; must be a number or '-' :: value: 'years', property: 'age', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Found property name that does not start with a lower-case :: property: 'PopulationType', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "Sanity_NotInitLowerPropName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_15YearsPlus', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_populationType"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Unexpected property in Property node :: property: 'subClassOf', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_UnexpectedPropInProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Schema node has property values with non-ascii characters :: value: 'Beverage–type', property: 'name', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_NonAsciiValueInSchema"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Found a property reference that does not start with a lower-case :: reference: 'BeverageType', property: 'label, node: 'dcid:beverageType'",
+    "counterKey": "Sanity_NotInitLower_labelInProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Unexpected property in Class node :: property: 'domainIncludes', node: 'dcid:Pop'",
+    "counterKey": "Sanity_UnexpectedPropInClass"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Found a class reference that does not start with an upper-case :: reference: 'pop', property: 'name, node: 'dcid:Pop'",
+    "counterKey": "Sanity_NotInitUpper_nameInClass"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "LintTest.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'subClassOf', node: 'dcid:Pop', type: 'Class'",
+    "counterKey": "Sanity_MissingOrEmpty_subClassOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "1"
+    },
+    "userMessage": "Property found without a preceding line with 'Node' :: line: 'typeOf dcs:StatVarObservation'",
+    "counterKey": "MCF_UnexpectedProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "5"
+    },
+    "userMessage": "Malformed line without a colon delimiter :: line: ': dcs:SV1'",
+    "counterKey": "MCF_MalformedColonLessLine"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "11"
+    },
+    "userMessage": "Found malformed Node value with quotes; must be a non-quoted value :: node: '"E:SVTest->E1"'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Found multiple values for single-value property :: property: 'observationAbout', node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_MultipleVals_observationAbout"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Found a non-ISO8601 compliant date value :: value: 'C:SVTest->Year', property: 'observationDate', node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_InvalidObsDate"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Found multiple values for single-value property :: property: 'value', node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_MultipleVals_value"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "22"
+    },
+    "userMessage": "Malformed column value; must have a '->' delimiter :: value: 'C:SVTest>Place_Name', property: 'name', node: 'E:SVTest->E3'",
+    "counterKey": "TMCF_MalformedSchemaTerm"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "25"
+    },
+    "userMessage": "Found malformed entity name that is not an entity prefix (E:) :: name: 'C:SVTest->NodeDcid'",
+    "counterKey": "TMCF_MalformedEntity"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "27"
+    },
+    "userMessage": "TMCF properties cannot refer to CSV columns yet :: value: 'SVTest->Property: C:SVTest->Property_Value', property: 'C', node: 'E:SVTest->E3'",
+    "counterKey": "TMCF_UnsupportedColumnNameInProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "29"
+    },
+    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'E:SVTest->E5,E:SVTest->E6'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "Found property name that does not start with a lower-case :: property: 'C', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_NotInitLowerPropName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "Found dcid with more than one value :: count: 3, node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_MultipleDcidValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "Found property name that does not start with a lower-case :: property: 'Dcid', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_NotInitLowerPropName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "34"
+    },
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[', property: 'age', node: 'E:SVTest->E4'",
+    "counterKey": "MCF_MalformedComplexValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "32"
+    },
+    "userMessage": "Missing typeOf value for node :: node: 'E:SVTest->E4'",
+    "counterKey": "Mutator_MissingTypeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "32"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'E:SVTest->E4', type: 'Thing'",
+    "counterKey": "Sanity_MissingOrEmpty_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "TmcfWithErrors.tmcf",
+      "lineNumber": "32"
+    },
+    "userMessage": "Value of dcid property must not be an 'E:' reference :: value: 'E:SVTest->E1', node: 'E:SVTest->E4'",
+    "counterKey": "Sanity_DcidTableEntity"
+  }]
+}

--- a/tool/src/test/resources/org/datacommons/tool/Tmcf1.tmcf
+++ b/tool/src/test/resources/org/datacommons/tool/Tmcf1.tmcf
@@ -1,0 +1,21 @@
+Node: E:SVTest->E0
+typeOf: dcs:StatVarObservation
+variableMeasured: dcs:SV1
+measurementMethod: dcs:SVTest
+observationAbout: E:SVTest->E3
+observationDate: C:SVTest->Year
+value: C:SVTest->SV1
+
+Node: E:SVTest->E1
+typeOf: dcs:StatVarObservation
+variableMeasured: dcs:SV2
+measurementMethod: dcs:SVTest
+observationAbout: E:SVTest->E3
+observationDate: C:SVTest->Year
+value: C:SVTest->SV2
+
+Node: E:SVTest->E3
+typeOf: C:SVTest->Place_Type
+dcid: C:SVTest->Place_Id
+name: C:SVTest->Place_Name
+location: C:SVTest->LatLong

--- a/tool/src/test/resources/org/datacommons/tool/TmcfWithErrors.tmcf
+++ b/tool/src/test/resources/org/datacommons/tool/TmcfWithErrors.tmcf
@@ -1,0 +1,34 @@
+typeOf dcs:StatVarObservation
+
+Node: E:SVTest->E0
+typeOf: dcs:StatVarObservation
+: dcs:SV1
+measurementMethod: dcs:SVTest
+observationAbout: E:SVTest->E3
+observationDate: C:SVTest->Year
+value: C:SVTest->SV1
+
+Node: "E:SVTest->E1"
+typeOf: dcs:StatVarObservation
+variableMeasured: dcs:SV2
+measurementMethod: dcs:SVTest
+observationAbout: E:SVTest->E30
+observationDate: C:SVTest->Year
+value: C:SVTest->SV2
+
+Node: E:SVTest->E3
+typeOf: C:SVTest->Place_Type
+Dcid: C:SVTest->Place_Id
+name: C:SVTest>Place_Name
+location: C:SVTest->LatLong
+
+Node: C:SVTest->NodeDcid
+dcid: E:SVTest->E10,E:SVTest->E13
+C:SVTest->Property: C:SVTest->Property_Value
+
+Node: E:SVTest->E5,E:SVTest->E6
+dcid: C:SVTest->dcid1
+
+Node: E:SVTest->E4
+dcid: E:SVTest->E1
+age: [

--- a/tool/src/test/resources/org/datacommons/tool/TmcfWithErrors.tmcf
+++ b/tool/src/test/resources/org/datacommons/tool/TmcfWithErrors.tmcf
@@ -8,7 +8,7 @@ observationAbout: E:SVTest->E3
 observationDate: C:SVTest->Year
 value: C:SVTest->SV1
 
-Node: "E:SVTest->E1"
+Node: \"E:SVTest->E1\"
 typeOf: dcs:StatVarObservation
 variableMeasured: dcs:SV2
 measurementMethod: dcs:SVTest

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -128,7 +128,7 @@ public class LogWrapper {
       return true;
     }
     if (countersWithErrors.size() > MAX_ERROR_COUNTERS_LIMIT) {
-      logger.error("Found too failure types. Quitting!");
+      logger.error("Found too many failure types. Quitting!");
       return true;
     }
     return false;

--- a/util/src/main/java/org/datacommons/util/McfMutator.java
+++ b/util/src/main/java/org/datacommons/util/McfMutator.java
@@ -35,6 +35,8 @@ public class McfMutator {
     McfMutator m = new McfMutator();
     m.graph = graph;
     m.logCtx = logCtx;
+    // Make a list of node names because we don't want to be iterating over the map while mutating
+    // it.
     List<String> nodeIdList = new ArrayList<>();
     graph.getNodesMap().forEach((k, v) -> nodeIdList.add(k));
     for (String nodeId : nodeIdList) {

--- a/util/src/main/java/org/datacommons/util/McfMutator.java
+++ b/util/src/main/java/org/datacommons/util/McfMutator.java
@@ -16,6 +16,7 @@ package org.datacommons.util;
 
 import static org.datacommons.util.McfUtil.getPropVals;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.datacommons.proto.Debug;
@@ -32,11 +33,12 @@ public class McfMutator {
 
   public static Mcf.McfGraph mutate(Mcf.McfGraph.Builder graph, LogWrapper logCtx) {
     McfMutator m = new McfMutator();
-    m.graph = Mcf.McfGraph.newBuilder();
+    m.graph = graph;
     m.logCtx = logCtx;
-    Map test = graph.getNodesMap();
-    for (String nodeId : graph.getNodesMap().keySet()) {
-      m.graph.putNodes(nodeId, m.mutateNode(nodeId, graph.getNodesOrThrow(nodeId).toBuilder()));
+    List<String> nodeIdList = new ArrayList<>();
+    graph.getNodesMap().forEach((k, v) -> nodeIdList.add(k));
+    for (String nodeId : nodeIdList) {
+      m.graph.putNodes(nodeId, m.mutateNode(nodeId, m.graph.getNodesOrThrow(nodeId).toBuilder()));
     }
     return m.graph.build();
   }

--- a/util/src/main/java/org/datacommons/util/McfMutator.java
+++ b/util/src/main/java/org/datacommons/util/McfMutator.java
@@ -34,6 +34,7 @@ public class McfMutator {
     McfMutator m = new McfMutator();
     m.graph = Mcf.McfGraph.newBuilder();
     m.logCtx = logCtx;
+    Map test = graph.getNodesMap();
     for (String nodeId : graph.getNodesMap().keySet()) {
       m.graph.putNodes(nodeId, m.mutateNode(nodeId, graph.getNodesOrThrow(nodeId).toBuilder()));
     }

--- a/util/src/main/java/org/datacommons/util/McfMutator.java
+++ b/util/src/main/java/org/datacommons/util/McfMutator.java
@@ -32,10 +32,10 @@ public class McfMutator {
 
   public static Mcf.McfGraph mutate(Mcf.McfGraph.Builder graph, LogWrapper logCtx) {
     McfMutator m = new McfMutator();
-    m.graph = graph;
+    m.graph = Mcf.McfGraph.newBuilder();
     m.logCtx = logCtx;
     for (String nodeId : graph.getNodesMap().keySet()) {
-      m.graph.putNodes(nodeId, m.mutateNode(nodeId, m.graph.getNodesOrThrow(nodeId).toBuilder()));
+      m.graph.putNodes(nodeId, m.mutateNode(nodeId, graph.getNodesOrThrow(nodeId).toBuilder()));
     }
     return m.graph.build();
   }
@@ -43,7 +43,7 @@ public class McfMutator {
   private Mcf.McfGraph.PropertyValues mutateNode(
       String nodeId, Mcf.McfGraph.PropertyValues.Builder node) {
     List<String> types = getPropVals(node.build(), Vocabulary.TYPE_OF);
-    if (types == null) {
+    if (types == null || types.isEmpty()) {
       logCtx.addEntry(
           Debug.Log.Level.LEVEL_ERROR,
           "Mutator_MissingTypeOf",

--- a/util/src/main/java/org/datacommons/util/McfParser.java
+++ b/util/src/main/java/org/datacommons/util/McfParser.java
@@ -95,7 +95,9 @@ public class McfParser {
       }
     }
     // End of file.
-    return McfUtil.mergeGraphs(Collections.singletonList(finish()));
+    McfGraph g = finish();
+    if (g == null) return null;
+    return McfUtil.mergeGraphs(Collections.singletonList(g));
   }
 
   // Parse a line of MCF file.
@@ -336,6 +338,7 @@ public class McfParser {
         return;
       }
       SchemaTerm term = parseSchemaTerm(val, logCb);
+      if (term == null) return;
       if (term.type == SchemaTerm.Type.ENTITY) {
         tval.setValue(val);
         tval.setType(Mcf.ValueType.TABLE_ENTITY);
@@ -455,7 +458,7 @@ public class McfParser {
       if (delimiter == -1) {
         logCb.logError(
             "TMCF_MalformedSchemaTerm",
-            "Malformed " + (isEntity ? "entity" : "column") + " value; must have a ':' delimiter");
+            "Malformed " + (isEntity ? "entity" : "column") + " value; must have a '->' delimiter");
         return null;
       }
       term.table = strippedValue.substring(0, delimiter);

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -75,6 +75,7 @@ public class TmcfCsvParser {
         McfChecker.check(
             tmcfCsvParser.tmcf, tmcfCsvParser.csvParser.getHeaderMap().keySet(), logCtx);
     if (!success) {
+      tmcfCsvParser.logCtx.setLocationFile(tmcfFile);
       tmcfCsvParser.logCtx.addEntry(
           Debug.Log.Level.LEVEL_FATAL,
           "CSV_TmcfCheckFailure",

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -75,6 +75,7 @@ public class TmcfCsvParser {
         McfChecker.check(
             tmcfCsvParser.tmcf, tmcfCsvParser.csvParser.getHeaderMap().keySet(), logCtx);
     if (!success) {
+      // Set location file to make sure log entry refers to the tmcf file.
       tmcfCsvParser.logCtx.setLocationFile(tmcfFile);
       tmcfCsvParser.logCtx.addEntry(
           Debug.Log.Level.LEVEL_FATAL,


### PR DESCRIPTION
- Added end to end tests that invoke GenMcf and Lint
- Fixed a few small bugs along the way
   -  output log when there is a fatal tmcf failure during genmcf
   -  handle ConcurrentModificationException thrown by McfMutator.mutate
   -  log Mutator_MissingTypeOf counter when typeOf is missing
   -  handle some NullPointerExceptions
   -  Small message fixes