### PR TITLE
Implement existence checks by calling DC API (needs to be enabled by -e)

### DIFF
--- a/tool/src/main/java/org/datacommons/tool/GenMcf.java
+++ b/tool/src/main/java/org/datacommons/tool/GenMcf.java
@@ -97,11 +97,11 @@ class GenMcf implements Callable<Integer> {
     BufferedWriter writer = new BufferedWriter(new FileWriter(outPath.toString()));
 
     LogWrapper logCtx = new LogWrapper(Debug.Log.newBuilder(), parent.outputDir.toPath());
-    Processor processor = new Processor(logCtx);
+    Processor processor = new Processor(false, logCtx);
     Integer retVal = 0;
     try {
       processor.processTables(tmcfFiles.get(0), csvFiles, delimiter, writer);
-    } catch (DCTooManyFailuresException ex) {
+    } catch (DCTooManyFailuresException | InterruptedException ex) {
       // Regardless of the failures, we will dump the logCtx and exit.
       retVal = -1;
     }

--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -49,12 +49,13 @@ class Lint implements Callable<Integer> {
   private Character delimiter;
 
   @CommandLine.Option(
-      names = {"-r", "--do_reference_checks"},
+      names = {"-e", "--existence_checks"},
       defaultValue = "false",
       description =
-          "Check DCID references against the KG and locally. If set, then calls "
-              + "will be made to the KG and instance MCFs are fully loaded into memory.")
-  private boolean doRefChecks;
+          "Check DCID references to schema nodes against the KG and locally. If set, then "
+              + "calls will be made to the Staging API server, and instance MCFs get fully "
+              + "loaded into memory.")
+  private boolean doExistenceChecks;
 
   @CommandLine.ParentCommand private Main parent;
 
@@ -100,12 +101,15 @@ class Lint implements Callable<Integer> {
           spec.commandLine(), "Please provide one .tmcf file with CSV/TSV files");
     }
     LogWrapper logCtx = new LogWrapper(Debug.Log.newBuilder(), parent.outputDir.toPath());
-    Processor processor = new Processor(doRefChecks, logCtx);
+    Processor processor = new Processor(doExistenceChecks, logCtx);
     Integer retVal = 0;
     try {
       // Process all the instance MCF first, so that we can add the nodes for Existence Check.
       for (File f : mcfFiles) {
         processor.processNodes(Mcf.McfType.INSTANCE_MCF, f);
+      }
+      if (doExistenceChecks) {
+        processor.checkAllNodes();
       }
       if (!csvFiles.isEmpty()) {
         processor.processTables(tmcfFiles.get(0), csvFiles, delimiter, null);

--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -79,7 +79,7 @@ class Lint implements Callable<Integer> {
       if (doExistenceChecks) {
         processor.checkAllNodes();
       }
-      if (!csvFiles.isEmpty()) {
+      if (!fg.GetCsv().isEmpty()) {
         processor.processTables(fg.GetTmcf(), fg.GetCsv(), delimiter, null);
       } else {
         processor.processNodes(Mcf.McfType.TEMPLATE_MCF, fg.GetTmcf());

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -42,7 +42,7 @@ public class Processor {
   // NOTE: If doExistenceChecks is true, then it is important that the caller perform a
   // checkAllNodes() call *after* all instance MCF files are processed (via processNodes). This is
   // so that the newly added schema, StatVar, etc. are fully known to the Existence Checker first,
-  // before existene checks are performed.
+  // before existence checks are performed.
   public Processor(boolean doExistenceChecks, LogWrapper logCtx) {
     this.logCtx = logCtx;
     if (doExistenceChecks) {

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -14,17 +14,16 @@
 
 package org.datacommons.tool;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.datacommons.proto.Mcf;
-import org.datacommons.util.*;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.datacommons.proto.Mcf;
+import org.datacommons.util.*;
 
 class DCTooManyFailuresException extends Exception {
   public DCTooManyFailuresException() {}

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -14,16 +14,17 @@
 
 package org.datacommons.tool;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.datacommons.proto.Mcf;
+import org.datacommons.util.*;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.datacommons.proto.Mcf;
-import org.datacommons.util.*;
 
 class DCTooManyFailuresException extends Exception {
   public DCTooManyFailuresException() {}
@@ -40,9 +41,9 @@ public class Processor {
   private List<Mcf.McfGraph> nodesForExistenceCheck;
 
   // NOTE: If doExistenceChecks is true, then it is important that the caller perform a
-  // checkAllNodes() call *after* all instance MCF files are process (via processNodes). This is
+  // checkAllNodes() call *after* all instance MCF files are processed (via processNodes). This is
   // so that the newly added schema, StatVar, etc. are fully known to the Existence Checker first,
-  // and then the check is performed.
+  // before existene checks are performed.
   public Processor(boolean doExistenceChecks, LogWrapper logCtx) {
     this.logCtx = logCtx;
     if (doExistenceChecks) {

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -39,6 +39,10 @@ public class Processor {
   private ExistenceChecker existenceChecker;
   private List<Mcf.McfGraph> nodesForExistenceCheck;
 
+  // NOTE: If doExistenceChecks is true, then it is important that the caller perform a
+  // checkAllNodes() call *after* all instance MCF files are process (via processNodes). This is
+  // so that the newly added schema, StatVar, etc. are fully known to the Existence Checker first,
+  // and then the check is performed.
   public Processor(boolean doExistenceChecks, LogWrapper logCtx) {
     this.logCtx = logCtx;
     if (doExistenceChecks) {
@@ -59,12 +63,11 @@ public class Processor {
       n = McfMutator.mutate(n.toBuilder(), logCtx);
 
       if (existenceChecker != null && type == Mcf.McfType.INSTANCE_MCF) {
-        // Add instance MCF nodes to ExistenceChecker.  The idea is to load all StatVar and schema
-        // nodes which tend to be instance MCF, and then check them.
+        // Add instance MCF nodes to ExistenceChecker.  We load all the nodes up first
+        // before we check them later in checkAllNodes().
         existenceChecker.addLocalGraph(n);
         nodesForExistenceCheck.add(n);
       } else {
-        // Otherwise, check immediately.
         McfChecker.check(n, existenceChecker, logCtx);
       }
 

--- a/tool/src/test/java/org/datacommons/tool/LintTest.java
+++ b/tool/src/test/java/org/datacommons/tool/LintTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import picocli.CommandLine;
 
+// TODO(shanth): Incorporate e2e test-cases for existence checks once this is generalized.
 public class LintTest {
   @Rule public TemporaryFolder testFolder = new TemporaryFolder();
 

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -67,5 +67,11 @@
             <version>3.7.1</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.9.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/util/src/main/java/org/datacommons/util/ExistenceChecker.java
+++ b/util/src/main/java/org/datacommons/util/ExistenceChecker.java
@@ -28,7 +28,7 @@ public class ExistenceChecker {
   private HttpClient httpClient;
 
   // This is a combination of local KG data and prior cached checks.
-  // Node is just the DCID. Triple is "s,p,o" and the property just includes CACHED_PROPERTIES.
+  // Node is just the DCID. Triple is "s,p,o" and the property just includes SCHEMA_PROPERTIES.
   private Set<String> existingNodesOrTriples; // Existence cache
   private Set<String> missingNodesOrTriples; // Absence cache
   private LogWrapper logCtx;
@@ -99,7 +99,7 @@ public class ExistenceChecker {
     }
     if (dataJson.entrySet().size() != 1) {
       throw new IOException(
-          "Invalid payload content from Staging DC API endpoint for: '"
+          "Invalid results payload from Staging DC API endpoint for: '"
               + sub
               + "',"
               + " '"

--- a/util/src/main/java/org/datacommons/util/ExistenceChecker.java
+++ b/util/src/main/java/org/datacommons/util/ExistenceChecker.java
@@ -1,0 +1,131 @@
+package org.datacommons.util;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.datacommons.proto.Mcf;
+
+// This class checks the existence of typically schema-related, nodes or (select types of)
+// triples in the KG or local graph.
+// TODO: Consider changing callers to batch calls.
+public class ExistenceChecker {
+  // Use the staging end-point to not impact prod.
+  private static final String API_ROOT = "https://staging.api.datacommons.org/node/property-values";
+  // For now we only need checks for certain Property/Class props.
+  private static final Set<String> SCHEMA_PROPERTIES =
+      Set.of(Vocabulary.DOMAIN_INCLUDES, Vocabulary.RANGE_INCLUDES, Vocabulary.SUB_CLASS_OF);
+  // Useful for mocking.
+  private HttpClient httpClient;
+
+  // This is a combination of local KG data and prior cached checks.
+  // Node is just the DCID. Triple is "s,p,o" and the property just includes CACHED_PROPERTIES.
+  private Set<String> existingNodesOrTriples; // Existence cache
+  private Set<String> missingNodesOrTriples; // Absence cache
+  private LogWrapper logCtx;
+
+  public ExistenceChecker(HttpClient httpClient, LogWrapper logCtx) {
+    this.httpClient = httpClient;
+    this.logCtx = logCtx;
+    existingNodesOrTriples = new HashSet<>();
+    missingNodesOrTriples = new HashSet<>();
+  }
+
+  public void addLocalGraph(Mcf.McfGraph graph) {
+    for (Map.Entry<String, Mcf.McfGraph.PropertyValues> node : graph.getNodesMap().entrySet()) {
+      // Skip doing anything with StatVarObs.
+      String typeOf = McfUtil.getPropVal(node.getValue(), Vocabulary.TYPE_OF);
+      if (typeOf.equals(Vocabulary.STAT_VAR_OBSERVATION_TYPE)
+          || typeOf.equals(Vocabulary.LEGACY_OBSERVATION_TYPE_SUFFIX)) {
+        continue;
+      }
+
+      String dcid = McfUtil.getPropVal(node.getValue(), Vocabulary.DCID);
+      if (dcid.isEmpty()) {
+        continue;
+      }
+
+      existingNodesOrTriples.add(dcid);
+      if (missingNodesOrTriples.contains(dcid)) {
+        missingNodesOrTriples.remove(dcid);
+      }
+
+      if (!typeOf.equals(Vocabulary.CLASS_TYPE) && !typeOf.equals(Vocabulary.PROPERTY_TYPE)) {
+        continue;
+      }
+      for (Map.Entry<String, Mcf.McfGraph.Values> pv : node.getValue().getPvsMap().entrySet()) {
+        if (SCHEMA_PROPERTIES.contains(pv.getKey())) {
+          for (Mcf.McfGraph.TypedValue tv : pv.getValue().getTypedValuesList()) {
+            var key = makeKey(dcid, pv.getKey(), tv.getValue());
+            existingNodesOrTriples.add(key);
+            if (missingNodesOrTriples.contains(key)) {
+              missingNodesOrTriples.remove(key);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  public boolean checkNode(String node) throws IOException, InterruptedException {
+    return checkCommon(node, Vocabulary.TYPE_OF, "", node);
+  }
+
+  public boolean checkTriple(String sub, String pred, String obj)
+      throws IOException, InterruptedException {
+    return checkCommon(sub, pred, obj, makeKey(sub, pred, obj));
+  }
+
+  public boolean checkCommon(String sub, String pred, String obj, String key)
+      throws IOException, InterruptedException {
+    logCtx.incrementCounterBy("Existence_NumChecks", 1);
+    if (existingNodesOrTriples.contains(key)) return true;
+    if (missingNodesOrTriples.contains(key)) return false;
+
+    var dataJson = callDc(sub, pred);
+    logCtx.incrementCounterBy("Existence_NumDcCalls", 1);
+
+    var nodeJson = dataJson.getAsJsonObject(sub);
+    if (nodeJson.has("out")) {
+      if (obj.isEmpty()) {
+        // Node existence check case.
+        if (nodeJson.getAsJsonArray("out").size() > 0) {
+          existingNodesOrTriples.add(key);
+          return true;
+        }
+      } else {
+        // Triple existence check case.
+        for (var objVal : nodeJson.getAsJsonArray("out")) {
+          if (objVal.getAsJsonObject().getAsJsonPrimitive("dcid").getAsString().equals(obj)) {
+            existingNodesOrTriples.add(key);
+            return true;
+          }
+        }
+      }
+    }
+    missingNodesOrTriples.add(key);
+    return false;
+  }
+
+  private JsonObject callDc(String node, String property) throws IOException, InterruptedException {
+    List<String> args = List.of("dcids=" + node, "property=" + property, "direction=out");
+    var url = API_ROOT + "?" + String.join("&", args);
+
+    var request =
+        HttpRequest.newBuilder(URI.create(url)).header("accept", "application/json").build();
+    var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    var payloadJson = new JsonParser().parse(response.body()).getAsJsonObject();
+    return new JsonParser().parse(payloadJson.get("payload").getAsString()).getAsJsonObject();
+  }
+
+  private static String makeKey(String s, String p, String o) {
+    return s + "," + p + "," + o;
+  }
+}

--- a/util/src/main/java/org/datacommons/util/ExistenceChecker.java
+++ b/util/src/main/java/org/datacommons/util/ExistenceChecker.java
@@ -40,6 +40,15 @@ public class ExistenceChecker {
     missingNodesOrTriples = new HashSet<>();
   }
 
+  public boolean checkNode(String node) throws IOException, InterruptedException {
+    return checkCommon(node, Vocabulary.TYPE_OF, "", node);
+  }
+
+  public boolean checkTriple(String sub, String pred, String obj)
+      throws IOException, InterruptedException {
+    return checkCommon(sub, pred, obj, makeKey(sub, pred, obj));
+  }
+
   public void addLocalGraph(Mcf.McfGraph graph) {
     for (Map.Entry<String, Mcf.McfGraph.PropertyValues> node : graph.getNodesMap().entrySet()) {
       // Skip doing anything with StatVarObs.
@@ -76,16 +85,7 @@ public class ExistenceChecker {
     }
   }
 
-  public boolean checkNode(String node) throws IOException, InterruptedException {
-    return checkCommon(node, Vocabulary.TYPE_OF, "", node);
-  }
-
-  public boolean checkTriple(String sub, String pred, String obj)
-      throws IOException, InterruptedException {
-    return checkCommon(sub, pred, obj, makeKey(sub, pred, obj));
-  }
-
-  public boolean checkCommon(String sub, String pred, String obj, String key)
+  private boolean checkCommon(String sub, String pred, String obj, String key)
       throws IOException, InterruptedException {
     logCtx.incrementCounterBy("Existence_NumChecks", 1);
     if (existingNodesOrTriples.contains(key)) return true;

--- a/util/src/main/java/org/datacommons/util/ExistenceChecker.java
+++ b/util/src/main/java/org/datacommons/util/ExistenceChecker.java
@@ -2,8 +2,6 @@ package org.datacommons.util;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import org.datacommons.proto.Mcf;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -15,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.datacommons.proto.Mcf;
 
 // This class checks the existence of typically schema-related, nodes or (select types of)
 // triples in the KG or local graph.

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -186,7 +186,7 @@ public class McfChecker {
     if (existenceChecker != null
         && !existenceChecker.checkTriple(mProp, Vocabulary.DOMAIN_INCLUDES, popType)) {
       addLog(
-          "Sanity_DomainCheckFailed_measuredProperty",
+          "Existence_MissingPropertyDomain",
           "Class not in the domain of Property :: property: '"
               + mProp
               + "', class: '"
@@ -216,8 +216,8 @@ public class McfChecker {
     // For SVObs, the only ref check we do is the existence of StatVar, and its an error if missing.
     if (existenceChecker != null && !existenceChecker.checkNode(statVar)) {
       addLog(
-          "Sanity_RefCheckFailed_variableMeasured",
-          "Missing StatisticalVariable reference :: reference: '"
+          "Existence_MissingRef_variableMeasured",
+          "Failed StatVar existence check :: reference: '"
               + statVar
               + "', property: '"
               + Vocabulary.VARIABLE_MEASURED
@@ -448,8 +448,8 @@ public class McfChecker {
           // Mark reference check misses as warnings to flag the user to add schema.
           addLog(
               Debug.Log.Level.LEVEL_WARNING,
-              "Sanity_RefCheckFailed_" + prop,
-              "Failed node reference check :: reference: '"
+              "Existence_MissingRef_" + prop,
+              "Failed reference existence check :: reference: '"
                   + tv.getValue()
                   + "', property: '"
                   + prop

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -43,7 +43,8 @@ public class TmcfCsvParser {
 
   // Build a parser given a TMCF file, CSV file, CSV delimiter and a log context.
   public static TmcfCsvParser init(
-      String tmcfFile, String csvFile, char delimiter, LogWrapper logCtx) throws IOException {
+      String tmcfFile, String csvFile, char delimiter, LogWrapper logCtx)
+      throws IOException, InterruptedException {
     TmcfCsvParser tmcfCsvParser = new TmcfCsvParser();
     logCtx.setLocationFile(tmcfFile);
     tmcfCsvParser.tmcf = McfParser.parseTemplateMcfFile(tmcfFile, logCtx);
@@ -94,7 +95,7 @@ public class TmcfCsvParser {
   }
 
   // Parse the next row from the CSV. Returns null on EOF.
-  public Mcf.McfGraph parseNextRow() {
+  public Mcf.McfGraph parseNextRow() throws IOException, InterruptedException {
     if (!csvParser.iterator().hasNext()) {
       return null;
     }
@@ -125,7 +126,7 @@ public class TmcfCsvParser {
       return instanceMcf.build();
     }
 
-    public void process(CSVRecord dataRow) {
+    public void process(CSVRecord dataRow) throws IOException, InterruptedException {
       if (!dataRow.isConsistent()) {
         addLog(
             Debug.Log.Level.LEVEL_ERROR,

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -74,7 +74,7 @@ public class TmcfCsvParser {
     // Check TMCF.
     boolean success =
         McfChecker.check(
-            tmcfCsvParser.tmcf, tmcfCsvParser.csvParser.getHeaderMap().keySet(), logCtx);
+            tmcfCsvParser.tmcf, tmcfCsvParser.csvParser.getHeaderMap().keySet(), null, logCtx);
     if (!success) {
       // Set location file to make sure log entry refers to the tmcf file.
       tmcfCsvParser.logCtx.setLocationFile(tmcfFile);

--- a/util/src/test/java/org/datacommons/util/ExistenceCheckerTest.java
+++ b/util/src/test/java/org/datacommons/util/ExistenceCheckerTest.java
@@ -1,0 +1,87 @@
+package org.datacommons.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ExistenceCheckerTest {
+  private static final String NONEXISTING_LAT = "{ \"payload\": \"{\\\"latitude\\\":{}}\" }";
+  private static final String EXISTING_GENDER =
+      "{ \"payload\": \"{\\\"gender\\\":{\\\"out"
+          + "\\\":[{\\\"dcid\\\":\\\"Person\\\",\\\"name\\\":\\\"Person\\\","
+          + "\\\"provenanceId\\\":\\\"dc/5l5zxr1\\\",\\\"types\\\":[\\\"Class\\\"]}]}}\" }";
+  private static final String LOCAL_KG_NODE =
+      "Node: dcid:latitude\n"
+          + "typeOf: schema:Property\n"
+          + "name: \"latitude\"\n"
+          + "rangeIncludes: schema:Place\n";
+
+  @Test
+  public void testNode() throws IOException, InterruptedException {
+    var mockHttp = Mockito.mock(HttpClient.class);
+    var mockResp = Mockito.mock(HttpResponse.class);
+    when(mockHttp.send(any(), any())).thenReturn(mockResp);
+
+    var checker = new ExistenceChecker(mockHttp, TestUtil.newLogCtx("inmem"));
+
+    // Caching for miss.
+    when(mockResp.body()).thenReturn(NONEXISTING_LAT);
+    assertFalse(checker.checkNode("latitude"));
+    verify(mockHttp, times(1)).send(any(), any());
+    assertFalse(checker.checkNode("latitude"));
+    verify(mockHttp, times(1)).send(any(), any());
+
+    // Caching for hit.
+    when(mockResp.body()).thenReturn(EXISTING_GENDER);
+    assertTrue(checker.checkNode("gender"));
+    verify(mockHttp, times(2)).send(any(), any());
+    assertTrue(checker.checkNode("gender"));
+    verify(mockHttp, times(2)).send(any(), any());
+
+    // Local KG hit.
+    checker.addLocalGraph(TestUtil.graphFromMcf(LOCAL_KG_NODE));
+    assertTrue(checker.checkNode("latitude"));
+  }
+
+  @Test
+  public void testTriple() throws IOException, InterruptedException {
+    var mockHttp = Mockito.mock(HttpClient.class);
+    var mockResp = Mockito.mock(HttpResponse.class);
+    when(mockHttp.send(any(), any())).thenReturn(mockResp);
+
+    var checker = new ExistenceChecker(mockHttp, TestUtil.newLogCtx("inmem"));
+
+    when(mockResp.body()).thenReturn(NONEXISTING_LAT);
+    assertFalse(checker.checkTriple("latitude", "rangeIncludes", "Place"));
+    assertFalse(checker.checkTriple("latitude", "rangeIncludes", "Place"));
+    verify(mockHttp, times(1)).send(any(), any());
+
+    when(mockResp.body()).thenReturn(EXISTING_GENDER);
+    assertTrue(checker.checkTriple("gender", "domainIncludes", "Person"));
+    assertTrue(checker.checkTriple("gender", "domainIncludes", "Person"));
+    verify(mockHttp, times(2)).send(any(), any());
+
+    // Local KG hit.
+    checker.addLocalGraph(TestUtil.graphFromMcf(LOCAL_KG_NODE));
+    assertTrue(checker.checkTriple("latitude", "rangeIncludes", "Place"));
+  }
+
+  @Test
+  public void endToEnd() throws IOException, InterruptedException {
+    var checker = new ExistenceChecker(HttpClient.newHttpClient(), TestUtil.newLogCtx("inmem"));
+    assertTrue(checker.checkNode("gender"));
+    assertFalse(checker.checkNode("Nope"));
+    assertTrue(checker.checkTriple("gender", "domainIncludes", "Person"));
+    assertTrue(checker.checkTriple("gender", "rangeIncludes", "GenderType"));
+    assertTrue(checker.checkNode("Count_Person"));
+    assertTrue(checker.checkNode("minimumWage"));
+    assertFalse(checker.checkNode("UnemploymentRate")); // must be unemploymentRate
+  }
+}

--- a/util/src/test/java/org/datacommons/util/McfCheckerTest.java
+++ b/util/src/test/java/org/datacommons/util/McfCheckerTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class McfCheckerTest {
 
   @Test
-  public void checkBasic() throws IOException {
+  public void checkBasic() throws IOException, InterruptedException {
     // Missing typeOf.
     String mcf = "Node: USState\n" + "name: \"California\"";
     assertTrue(failure(mcf, "Sanity_MissingOrEmpty_typeOf", "'typeOf', node: 'USState'"));
@@ -57,7 +57,7 @@ public class McfCheckerTest {
   }
 
   @Test
-  public void checkDcid() throws IOException {
+  public void checkDcid() throws IOException, InterruptedException {
     // DCID must have exactly one value.
     String mcf = "Node: USState\n" + "typeOf: schema:State\n" + "dcid: geoId/06, geoId/07\n";
     assertTrue(failure(mcf, "Sanity_MultipleDcidValues", "dcid with more than one value"));
@@ -80,7 +80,7 @@ public class McfCheckerTest {
   }
 
   @Test
-  public void checkPopObs() throws IOException {
+  public void checkPopObs() throws IOException, InterruptedException {
     // A valid Pop node.
     String mcf =
         "Node: USState\n"
@@ -156,7 +156,7 @@ public class McfCheckerTest {
   }
 
   @Test
-  public void checkStatVar() throws IOException {
+  public void checkStatVar() throws IOException, InterruptedException {
     // Missing popType
     String mcf =
         "Node: SV\n"
@@ -207,7 +207,7 @@ public class McfCheckerTest {
   }
 
   @Test
-  public void checkSVObs() throws IOException {
+  public void checkSVObs() throws IOException, InterruptedException {
     // A good StatVarObs node with double value.
     String mcf =
         "Node: SFWomenIncome2020\n"
@@ -292,7 +292,7 @@ public class McfCheckerTest {
   }
 
   @Test
-  public void checkSchema() throws IOException {
+  public void checkSchema() throws IOException, InterruptedException {
     // Property names must start with lower case.
     String mcf =
         "Node: dcid:Place\n"
@@ -381,7 +381,7 @@ public class McfCheckerTest {
   }
 
   @Test
-  public void checkTemplate() throws IOException {
+  public void checkTemplate() throws IOException, InterruptedException {
     // Incorrect column name.
     String mcf =
         "Node: E:CityStats->E1\n"
@@ -428,7 +428,8 @@ public class McfCheckerTest {
   }
 
   private static boolean failure(
-      String mcfString, String counter, String message, Set<String> columns) throws IOException {
+      String mcfString, String counter, String message, Set<String> columns)
+      throws IOException, InterruptedException {
     Debug.Log.Builder log = Debug.Log.newBuilder();
     LogWrapper lw = new LogWrapper(log, Path.of("InMemory"));
     Mcf.McfGraph graph;
@@ -445,11 +446,12 @@ public class McfCheckerTest {
   }
 
   private static boolean failure(String mcfString, String counter, String message)
-      throws IOException {
+      throws IOException, InterruptedException {
     return failure(mcfString, counter, message, null);
   }
 
-  private static boolean success(String mcfString, Set<String> columns) throws IOException {
+  private static boolean success(String mcfString, Set<String> columns)
+      throws IOException, InterruptedException {
     Debug.Log.Builder log = Debug.Log.newBuilder();
     LogWrapper lw = new LogWrapper(log, Path.of("InMemory"));
     Mcf.McfGraph graph;
@@ -465,7 +467,7 @@ public class McfCheckerTest {
     return true;
   }
 
-  private static boolean success(String mcfString) throws IOException {
+  private static boolean success(String mcfString) throws IOException, InterruptedException {
     return success(mcfString, null);
   }
 }

--- a/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
+++ b/util/src/test/java/org/datacommons/util/TmcfCsvParserTest.java
@@ -39,7 +39,7 @@ public class TmcfCsvParserTest {
   }
 
   @Test
-  public void statVarObs() throws IOException, URISyntaxException {
+  public void statVarObs() throws IOException, URISyntaxException, InterruptedException {
     String want = TestUtil.mcfFromFile(resourceFile("TmcfCsvParser_SVO.mcf"));
     String got = run("TmcfCsvParser_SVO.tmcf", "TmcfCsvParser_SVO.csv");
     assertEquals(want, got);
@@ -61,21 +61,21 @@ public class TmcfCsvParserTest {
   }
 
   @Test
-  public void popObs() throws IOException, URISyntaxException {
+  public void popObs() throws IOException, URISyntaxException, InterruptedException {
     String want = TestUtil.mcfFromFile(resourceFile("TmcfCsvParser_PopObs.mcf"));
     String got = run("TmcfCsvParser_PopObs.tmcf", "TmcfCsvParser_PopObs.csv");
     assertEquals(want, got);
   }
 
   @Test
-  public void multiValue() throws IOException, URISyntaxException {
+  public void multiValue() throws IOException, URISyntaxException, InterruptedException {
     String want = TestUtil.mcfFromFile(resourceFile("TmcfCsvParser_MultiValue.mcf"));
     String got = run("TmcfCsvParser_MultiValue.tmcf", "TmcfCsvParser_MultiValue.csv");
     assertEquals(want, got);
   }
 
   @Test
-  public void tmcfFailure() throws IOException, URISyntaxException {
+  public void tmcfFailure() throws IOException, URISyntaxException, InterruptedException {
     LogWrapper logCtx = new LogWrapper(log, Paths.get("."));
     TmcfCsvParser parser =
         TmcfCsvParser.init(
@@ -89,7 +89,8 @@ public class TmcfCsvParserTest {
             log.build(), "Sanity_TmcfMissingColumn", "Count_CriminalActivities_Missing"));
   }
 
-  private String run(String mcfFile, String csvFile) throws IOException, URISyntaxException {
+  private String run(String mcfFile, String csvFile)
+      throws IOException, URISyntaxException, InterruptedException {
     LogWrapper logCtx = new LogWrapper(log, Paths.get("."));
     logCtx.setLocationFile(csvFile);
     TmcfCsvParser parser =


### PR DESCRIPTION
This checks that references to schema-like things exist in the KG or the local graph (i.e., other provided MCFs).

Notably, for performance reasons, for now it does not validate references to place entities (`observationAbout` value).

Existence check results are cached locally to avoid future calls.  Batching would be nice, but that would be a more significant refactor to the call-sites (e.g., we need to save the per-reference context required for logging), so we can consider in future.

Testing: there's a unit test for ExistenceChecker and another to confirm that individual nodes are existence-checked in McfChecker. Plan to add an e2e once the LintTest is generalized.

TODO: get some real testing and enable `-e` by default...