### PR TITLE
Enable existence checks by default

### DIFF
--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -49,7 +49,7 @@ class Lint implements Callable<Integer> {
 
   @CommandLine.Option(
       names = {"-e", "--existence_checks"},
-      defaultValue = "false",
+      defaultValue = "true",
       description =
           "Check DCID references to schema nodes against the KG and locally. If set, then "
               + "calls will be made to the Staging API server, and instance MCFs get fully "

--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
@@ -1,47 +1,58 @@
 {
   "levelSummary": {
-    "LEVEL_ERROR": "56",
-    "LEVEL_WARNING": "5"
+    "LEVEL_ERROR": "57",
+    "LEVEL_WARNING": "42"
   },
   "counterSet": {
     "counters": {
       "MCF_UnexpectedProperty": "1",
       "MCF_MalformedColonLessLine": "1",
       "Mutator_MissingTypeOf": "1",
+      "MCF_MalformedNodeName": "1",
+      "MCF_InvalidLatitude": "1",
+      "MCF_InvalidLongitude": "1",
+      "MCF_MalformedComplexValue": "2",
+      "MCF_MalformedComplexValueParts": "2",
+      "MCF_QuantityMalformedValue": "2",
+      "MCF_QuantityRangeMalformedValues": "3",
+      "Existence_NumChecks": "249",
+      "Existence_NumDcCalls": "50",
+      "Existence_MissingValueRef_containedIn": "1",
       "Sanity_MissingOrEmpty_typeOf": "2",
       "Sanity_InvalidChars_typeOf": "2",
       "Sanity_InvalidObsDate": "3",
       "Sanity_NonDoubleObsValue": "1",
       "Sanity_ObsMissingValueProp": "1",
-      "MCF_MalformedNodeName": "1",
       "Sanity_InvalidChars_dcid": "2",
       "Sanity_NonAsciiValueInNonText": "2",
       "Sanity_InvalidChars_location": "1",
-      "MCF_InvalidLatitude": "1",
+      "Existence_MissingValueRef_containedInPlace": "1",
+      "Existence_MissingPropertyRef": "4",
       "Sanity_MultipleDcidValues": "2",
-      "MCF_InvalidLongitude": "1",
-      "MCF_MalformedComplexValue": "2",
       "Sanity_MissingOrEmpty_populationType": "2",
       "Sanity_MissingOrEmpty_measuredProperty": "1",
+      "Existence_MissingPropertyDomainDefinition": "1",
       "Sanity_MissingOrEmpty_statType": "1",
       "Sanity_UnknownStatType": "1",
-      "MCF_MalformedComplexValueParts": "2",
-      "MCF_QuantityMalformedValue": "2",
-      "MCF_QuantityRangeMalformedValues": "3",
+      "Existence_MissingValueRef_statType": "5",
       "Sanity_NotInitLowerPropName": "1",
+      "Existence_MissingValueRef_subClassOf": "1",
       "Sanity_InvalidChars_domainIncludes": "1",
       "Sanity_UnexpectedPropInProperty": "1",
       "Sanity_NonAsciiValueInSchema": "1",
       "Sanity_NotInitLower_labelInProperty": "1",
       "Sanity_EmptySchemaValue": "1",
       "Sanity_DcidNameMismatchInSchema": "2",
+      "Existence_MissingValueRef_domainIncludes": "1",
       "Sanity_UnexpectedPropInClass": "1",
       "Sanity_NotInitUpper_nameInClass": "1",
       "Sanity_MissingOrEmpty_subClassOf": "1",
       "Sanity_InvalidChars_observationAbout": "2",
-      "NumRowSuccesses": "11",
+      "NumRowSuccesses": "5",
       "NumNodeSuccesses": "15",
       "NumPVSuccesses": "83",
+      "Existence_MissingValueRef_variableMeasured": "12",
+      "Existence_MissingValueRef_measurementMethod": "12",
       "StrSplit_EmptyToken_typeOf": "1",
       "CSV_InconsistentRows": "2",
       "Sanity_MultipleVals_observationDate": "2",
@@ -77,6 +88,86 @@
     },
     "userMessage": "Missing typeOf value for node :: node: 'dcid:geoId/CA'",
     "counterKey": "Mutator_MissingTypeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "54"
+    },
+    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'USA,Country'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "67"
+    },
+    "userMessage": "Invalid latitude value; must be decimal degrees with an optional N/S suffix :: value: '-100', property: 'location', node: '\"CANCountry\"'",
+    "counterKey": "MCF_InvalidLatitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "73"
+    },
+    "userMessage": "Invalid longitude value; must be decimal degrees with an optional E/W suffix :: value: '181', property: 'location', node: 'dcid:geoId/sf'",
+    "counterKey": "MCF_InvalidLongitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "79"
+    },
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[10 12', property: 'age', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "MCF_MalformedComplexValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "81"
+    },
+    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[10]', components: 1, property: 'age', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "MCF_MalformedComplexValueParts"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "88"
+    },
+    "userMessage": "Quantity value must be a number :: value: '[5Years 10Years]', property: 'age', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "MCF_QuantityMalformedValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "95"
+    },
+    "userMessage": "Malformed start component in QuantityRange value; must be a number or '-' :: value: 'less', property: 'age', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "102"
+    },
+    "userMessage": "Malformed end component in QuantityRange value; must be a number or '-' :: value: 'years', property: 'age', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed existence check :: reference: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
+    "counterKey": "Existence_MissingValueRef_containedIn"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -121,14 +212,6 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.mcf",
-      "lineNumber": "54"
-    },
-    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'USA,Country'",
-    "counterKey": "MCF_MalformedNodeName"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
       "lineNumber": "49"
     },
     "userMessage": "Found invalid chars in dcid value :: value: 'dc/ 2sffw13', invalid-chars: ' ', property: 'dcid', node: 'CityStats/E5/2'",
@@ -150,13 +233,29 @@
     "userMessage": "Found invalid chars in dcid value :: value: 'geoId–SFCounty', invalid-chars: '–', property: 'location', node: 'CityStats/E5/2'",
     "counterKey": "Sanity_InvalidChars_location"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.mcf",
-      "lineNumber": "67"
+      "lineNumber": "59"
     },
-    "userMessage": "Invalid latitude value; must be decimal degrees with an optional N/S suffix :: value: '-100', property: 'location', node: '\"CANCountry\"'",
-    "counterKey": "MCF_InvalidLatitude"
+    "userMessage": "Failed existence check :: reference: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingValueRef_containedInPlace"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed existence check :: property: 'population', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingPropertyRef"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed existence check :: property: 'inCounty', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingPropertyRef"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -165,22 +264,6 @@
     },
     "userMessage": "Found dcid with more than one value :: count: 2, node: '\"CANCountry\"'",
     "counterKey": "Sanity_MultipleDcidValues"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "73"
-    },
-    "userMessage": "Invalid longitude value; must be decimal degrees with an optional E/W suffix :: value: '181', property: 'location', node: 'dcid:geoId/sf'",
-    "counterKey": "MCF_InvalidLongitude"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "79"
-    },
-    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[10 12', property: 'age', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "MCF_MalformedComplexValue"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -203,6 +286,14 @@
       "file": "AllFileTypes.mcf",
       "lineNumber": "77"
     },
+    "userMessage": "Class not in the domain of Property used in StatVar :: property: '', class: '', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "Existence_MissingPropertyDomainDefinition"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "77"
+    },
     "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_statType"
   }, {
@@ -214,45 +305,45 @@
     "userMessage": "Found an unknown statType value :: value: '', node: 'dcid:Count_Death_10To12'",
     "counterKey": "Sanity_UnknownStatType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.mcf",
       "lineNumber": "81"
     },
-    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[10]', components: 1, property: 'age', node: 'dcid:Count_Death_10YearsPlus'",
-    "counterKey": "MCF_MalformedComplexValueParts"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.mcf",
       "lineNumber": "88"
     },
-    "userMessage": "Quantity value must be a number :: value: '[5Years 10Years]', property: 'age', node: 'dcid:Count_Death_5To10'",
-    "counterKey": "MCF_QuantityMalformedValue"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.mcf",
       "lineNumber": "95"
     },
-    "userMessage": "Malformed start component in QuantityRange value; must be a number or '-' :: value: 'less', property: 'age', node: 'dcid:Count_Death_YearsLessThan5'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.mcf",
       "lineNumber": "102"
     },
-    "userMessage": "Malformed end component in QuantityRange value; must be a number or '-' :: value: 'years', property: 'age', node: 'dcid:Count_Death_5YearsPlus'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.mcf",
       "lineNumber": "109"
     },
-    "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -269,6 +360,22 @@
     },
     "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_15YearsPlus', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_populationType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Failed existence check :: property: 'label', node: 'dcid:beverageType'",
+    "counterKey": "Existence_MissingPropertyRef"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Failed existence check :: reference: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
+    "counterKey": "Existence_MissingValueRef_subClassOf"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -317,6 +424,22 @@
     },
     "userMessage": "Schema node with dcid/name mismatch :: name: 'Beverage–type', dcid: 'beverageType', node: 'dcid:beverageType'",
     "counterKey": "Sanity_DcidNameMismatchInSchema"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed existence check :: reference: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingValueRef_domainIncludes"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed existence check :: property: 'inCounty', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingPropertyRef"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -398,6 +521,38 @@
     "userMessage": "Found dcid with more than one value :: count: 2, node: 'E:SVTest->E3'",
     "counterKey": "Sanity_MultipleDcidValues"
   }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed existence check :: reference: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingValueRef_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingValueRef_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed existence check :: reference: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingValueRef_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingValueRef_measurementMethod"
+  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.csv",
@@ -417,6 +572,38 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed existence check :: reference: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingValueRef_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingValueRef_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed existence check :: reference: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingValueRef_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingValueRef_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
       "lineNumber": "5"
     },
     "userMessage": "Empty value found :: value: '', column: 'Place_Type', property: 'typeOf', node: 'E:SVTest->E3'",
@@ -429,6 +616,38 @@
     },
     "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'E:SVTest->E3', type: 'Thing'",
     "counterKey": "Sanity_MissingOrEmpty_typeOf"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed existence check :: reference: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingValueRef_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingValueRef_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed existence check :: reference: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingValueRef_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingValueRef_measurementMethod"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -489,6 +708,38 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed existence check :: reference: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingValueRef_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingValueRef_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed existence check :: reference: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingValueRef_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingValueRef_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
       "lineNumber": "10"
     },
     "userMessage": "Malformed CSV value for dcid property; must be a text or reference :: value: '123', node: 'E:SVTest->E3'",
@@ -534,6 +785,38 @@
     "userMessage": "Found a very long dcid value; must be less than 256 :: node: 'E:SVTest->E3'",
     "counterKey": "Sanity_VeryLongDcid"
   }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed existence check :: reference: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingValueRef_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingValueRef_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed existence check :: reference: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingValueRef_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingValueRef_measurementMethod"
+  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.csv",
@@ -541,5 +824,37 @@
     },
     "userMessage": "Quantity value must be a number :: value: '[Lat Long]', property: 'location', node: 'dcid:CA-MN'",
     "counterKey": "MCF_QuantityMalformedValue"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed existence check :: reference: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingValueRef_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingValueRef_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed existence check :: reference: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingValueRef_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingValueRef_measurementMethod"
   }]
 }

--- a/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
@@ -1,40 +1,49 @@
 {
   "levelSummary": {
-    "LEVEL_ERROR": "36",
-    "LEVEL_WARNING": "1"
+    "LEVEL_ERROR": "37",
+    "LEVEL_WARNING": "15"
   },
   "counterSet": {
     "counters": {
       "MCF_UnexpectedProperty": "1",
       "MCF_MalformedColonLessLine": "1",
       "Mutator_MissingTypeOf": "1",
+      "MCF_MalformedNodeName": "1",
+      "MCF_InvalidLatitude": "1",
+      "MCF_InvalidLongitude": "1",
+      "MCF_MalformedComplexValue": "1",
+      "MCF_MalformedComplexValueParts": "1",
+      "MCF_QuantityMalformedValue": "1",
+      "MCF_QuantityRangeMalformedValues": "3",
+      "Existence_NumChecks": "149",
+      "Existence_NumDcCalls": "42",
+      "Existence_MissingValueRef_containedIn": "1",
       "Sanity_MissingOrEmpty_typeOf": "1",
       "Sanity_InvalidChars_typeOf": "1",
       "Sanity_InvalidObsDate": "1",
       "Sanity_NonDoubleObsValue": "1",
       "Sanity_ObsMissingValueProp": "1",
-      "MCF_MalformedNodeName": "1",
       "Sanity_InvalidChars_dcid": "1",
       "Sanity_NonAsciiValueInNonText": "1",
       "Sanity_InvalidChars_location": "1",
-      "MCF_InvalidLatitude": "1",
+      "Existence_MissingValueRef_containedInPlace": "1",
+      "Existence_MissingPropertyRef": "4",
       "Sanity_MultipleDcidValues": "1",
-      "MCF_InvalidLongitude": "1",
-      "MCF_MalformedComplexValue": "1",
       "Sanity_MissingOrEmpty_populationType": "2",
       "Sanity_MissingOrEmpty_measuredProperty": "1",
+      "Existence_MissingPropertyDomainDefinition": "1",
       "Sanity_MissingOrEmpty_statType": "1",
       "Sanity_UnknownStatType": "1",
-      "MCF_MalformedComplexValueParts": "1",
-      "MCF_QuantityMalformedValue": "1",
-      "MCF_QuantityRangeMalformedValues": "3",
+      "Existence_MissingValueRef_statType": "6",
       "Sanity_NotInitLowerPropName": "1",
+      "Existence_MissingValueRef_subClassOf": "1",
       "Sanity_InvalidChars_domainIncludes": "1",
       "Sanity_UnexpectedPropInProperty": "1",
       "Sanity_NonAsciiValueInSchema": "1",
       "Sanity_NotInitLower_labelInProperty": "1",
       "Sanity_EmptySchemaValue": "1",
       "Sanity_DcidNameMismatchInSchema": "2",
+      "Existence_MissingValueRef_domainIncludes": "1",
       "Sanity_UnexpectedPropInClass": "1",
       "Sanity_NotInitUpper_nameInClass": "1",
       "Sanity_MissingOrEmpty_subClassOf": "1"
@@ -64,6 +73,86 @@
     },
     "userMessage": "Missing typeOf value for node :: node: 'dcid:geoId/CA'",
     "counterKey": "Mutator_MissingTypeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "54"
+    },
+    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'USA,Country'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "67"
+    },
+    "userMessage": "Invalid latitude value; must be decimal degrees with an optional N/S suffix :: value: '-100', property: 'location', node: '\"CANCountry\"'",
+    "counterKey": "MCF_InvalidLatitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "73"
+    },
+    "userMessage": "Invalid longitude value; must be decimal degrees with an optional E/W suffix :: value: '181', property: 'location', node: 'dcid:geoId/sf'",
+    "counterKey": "MCF_InvalidLongitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "79"
+    },
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[10 12', property: 'age', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "MCF_MalformedComplexValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "81"
+    },
+    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[10]', components: 1, property: 'age', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "MCF_MalformedComplexValueParts"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "88"
+    },
+    "userMessage": "Quantity value must be a number :: value: '[5Years 10Years]', property: 'age', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "MCF_QuantityMalformedValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "95"
+    },
+    "userMessage": "Malformed start component in QuantityRange value; must be a number or '-' :: value: 'less', property: 'age', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "102"
+    },
+    "userMessage": "Malformed end component in QuantityRange value; must be a number or '-' :: value: 'years', property: 'age', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed existence check :: reference: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
+    "counterKey": "Existence_MissingValueRef_containedIn"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -108,14 +197,6 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "McfOnly.mcf",
-      "lineNumber": "54"
-    },
-    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'USA,Country'",
-    "counterKey": "MCF_MalformedNodeName"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
       "lineNumber": "49"
     },
     "userMessage": "Found invalid chars in dcid value :: value: 'dc/ 2sffw13', invalid-chars: ' ', property: 'dcid', node: 'CityStats/E5/2'",
@@ -137,13 +218,29 @@
     "userMessage": "Found invalid chars in dcid value :: value: 'geoId–SFCounty', invalid-chars: '–', property: 'location', node: 'CityStats/E5/2'",
     "counterKey": "Sanity_InvalidChars_location"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "McfOnly.mcf",
-      "lineNumber": "67"
+      "lineNumber": "59"
     },
-    "userMessage": "Invalid latitude value; must be decimal degrees with an optional N/S suffix :: value: '-100', property: 'location', node: '\"CANCountry\"'",
-    "counterKey": "MCF_InvalidLatitude"
+    "userMessage": "Failed existence check :: reference: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingValueRef_containedInPlace"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed existence check :: property: 'population', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingPropertyRef"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed existence check :: property: 'inCounty', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingPropertyRef"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -152,22 +249,6 @@
     },
     "userMessage": "Found dcid with more than one value :: count: 2, node: '\"CANCountry\"'",
     "counterKey": "Sanity_MultipleDcidValues"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "73"
-    },
-    "userMessage": "Invalid longitude value; must be decimal degrees with an optional E/W suffix :: value: '181', property: 'location', node: 'dcid:geoId/sf'",
-    "counterKey": "MCF_InvalidLongitude"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "79"
-    },
-    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[10 12', property: 'age', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "MCF_MalformedComplexValue"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -190,6 +271,14 @@
       "file": "McfOnly.mcf",
       "lineNumber": "77"
     },
+    "userMessage": "Class not in the domain of Property used in StatVar :: property: '', class: '', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "Existence_MissingPropertyDomainDefinition"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "77"
+    },
     "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_statType"
   }, {
@@ -201,45 +290,45 @@
     "userMessage": "Found an unknown statType value :: value: '', node: 'dcid:Count_Death_10To12'",
     "counterKey": "Sanity_UnknownStatType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "McfOnly.mcf",
       "lineNumber": "81"
     },
-    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[10]', components: 1, property: 'age', node: 'dcid:Count_Death_10YearsPlus'",
-    "counterKey": "MCF_MalformedComplexValueParts"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "McfOnly.mcf",
       "lineNumber": "88"
     },
-    "userMessage": "Quantity value must be a number :: value: '[5Years 10Years]', property: 'age', node: 'dcid:Count_Death_5To10'",
-    "counterKey": "MCF_QuantityMalformedValue"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "McfOnly.mcf",
       "lineNumber": "95"
     },
-    "userMessage": "Malformed start component in QuantityRange value; must be a number or '-' :: value: 'less', property: 'age', node: 'dcid:Count_Death_YearsLessThan5'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "McfOnly.mcf",
       "lineNumber": "102"
     },
-    "userMessage": "Malformed end component in QuantityRange value; must be a number or '-' :: value: 'years', property: 'age', node: 'dcid:Count_Death_5YearsPlus'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "McfOnly.mcf",
       "lineNumber": "109"
     },
-    "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -256,6 +345,22 @@
     },
     "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_15YearsPlus', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_populationType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Failed existence check :: property: 'label', node: 'dcid:beverageType'",
+    "counterKey": "Existence_MissingPropertyRef"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Failed existence check :: reference: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
+    "counterKey": "Existence_MissingValueRef_subClassOf"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -305,6 +410,22 @@
     "userMessage": "Schema node with dcid/name mismatch :: name: 'Beverage–type', dcid: 'beverageType', node: 'dcid:beverageType'",
     "counterKey": "Sanity_DcidNameMismatchInSchema"
   }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed existence check :: reference: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingValueRef_domainIncludes"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed existence check :: property: 'inCounty', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingPropertyRef"
+  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "McfOnly.mcf",
@@ -336,5 +457,13 @@
     },
     "userMessage": "Found a missing or empty property value :: property: 'subClassOf', node: 'dcid:Pop', type: 'Class'",
     "counterKey": "Sanity_MissingOrEmpty_subClassOf"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "130"
+    },
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }]
 }

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
@@ -1,44 +1,55 @@
 {
   "levelSummary": {
-    "LEVEL_ERROR": "55",
-    "LEVEL_WARNING": "2"
+    "LEVEL_ERROR": "56",
+    "LEVEL_WARNING": "17"
   },
   "counterSet": {
     "counters": {
       "MCF_UnexpectedProperty": "2",
       "MCF_MalformedColonLessLine": "2",
       "Mutator_MissingTypeOf": "2",
+      "MCF_MalformedNodeName": "2",
+      "MCF_InvalidLatitude": "1",
+      "MCF_InvalidLongitude": "1",
+      "MCF_MalformedComplexValue": "2",
+      "MCF_MalformedComplexValueParts": "1",
+      "MCF_QuantityMalformedValue": "1",
+      "MCF_QuantityRangeMalformedValues": "3",
+      "Existence_NumChecks": "149",
+      "Existence_NumDcCalls": "48",
+      "Existence_MissingValueRef_containedIn": "1",
       "Sanity_MissingOrEmpty_typeOf": "2",
       "Sanity_InvalidChars_typeOf": "1",
       "Sanity_InvalidObsDate": "1",
       "Sanity_NonDoubleObsValue": "1",
       "Sanity_ObsMissingValueProp": "1",
-      "MCF_MalformedNodeName": "2",
       "Sanity_InvalidChars_dcid": "1",
       "Sanity_NonAsciiValueInNonText": "1",
       "Sanity_InvalidChars_location": "1",
-      "MCF_InvalidLatitude": "1",
+      "Existence_MissingValueRef_containedInPlace": "1",
+      "Existence_MissingPropertyRef": "4",
       "Sanity_MultipleDcidValues": "2",
-      "MCF_InvalidLongitude": "1",
-      "MCF_MalformedComplexValue": "2",
       "Sanity_MissingOrEmpty_populationType": "2",
       "Sanity_MissingOrEmpty_measuredProperty": "1",
+      "Existence_MissingPropertyDomainDefinition": "1",
       "Sanity_MissingOrEmpty_statType": "1",
       "Sanity_UnknownStatType": "1",
-      "MCF_MalformedComplexValueParts": "1",
-      "MCF_QuantityMalformedValue": "1",
-      "MCF_QuantityRangeMalformedValues": "3",
+      "Existence_MissingValueRef_statType": "5",
       "Sanity_NotInitLowerPropName": "2",
+      "Existence_MissingValueRef_subClassOf": "1",
       "Sanity_InvalidChars_domainIncludes": "1",
       "Sanity_UnexpectedPropInProperty": "1",
       "Sanity_NonAsciiValueInSchema": "1",
       "Sanity_NotInitLower_labelInProperty": "1",
       "Sanity_EmptySchemaValue": "1",
       "Sanity_DcidNameMismatchInSchema": "2",
+      "Existence_MissingValueRef_domainIncludes": "1",
       "Sanity_UnexpectedPropInClass": "1",
       "Sanity_NotInitUpper_nameInClass": "1",
       "Sanity_MissingOrEmpty_subClassOf": "1",
       "TMCF_MalformedEntity": "2",
+      "Existence_MissingValueRef_variableMeasured": "1",
+      "Existence_MissingValueRef_measurementMethod": "1",
       "Sanity_MultipleVals_observationAbout": "1",
       "Sanity_MultipleVals_value": "1",
       "Sanity_TmcfMissingEntityDef": "5",
@@ -71,6 +82,86 @@
     },
     "userMessage": "Missing typeOf value for node :: node: 'dcid:geoId/CA'",
     "counterKey": "Mutator_MissingTypeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "54"
+    },
+    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'USA,Country'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "67"
+    },
+    "userMessage": "Invalid latitude value; must be decimal degrees with an optional N/S suffix :: value: '-100', property: 'location', node: '\"CANCountry\"'",
+    "counterKey": "MCF_InvalidLatitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "73"
+    },
+    "userMessage": "Invalid longitude value; must be decimal degrees with an optional E/W suffix :: value: '181', property: 'location', node: 'dcid:geoId/sf'",
+    "counterKey": "MCF_InvalidLongitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "79"
+    },
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[10 12', property: 'age', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "MCF_MalformedComplexValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "81"
+    },
+    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[10]', components: 1, property: 'age', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "MCF_MalformedComplexValueParts"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "88"
+    },
+    "userMessage": "Quantity value must be a number :: value: '[5Years 10Years]', property: 'age', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "MCF_QuantityMalformedValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "95"
+    },
+    "userMessage": "Malformed start component in QuantityRange value; must be a number or '-' :: value: 'less', property: 'age', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "102"
+    },
+    "userMessage": "Malformed end component in QuantityRange value; must be a number or '-' :: value: 'years', property: 'age', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed existence check :: reference: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
+    "counterKey": "Existence_MissingValueRef_containedIn"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -115,14 +206,6 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "NoCsv.mcf",
-      "lineNumber": "54"
-    },
-    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'USA,Country'",
-    "counterKey": "MCF_MalformedNodeName"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
       "lineNumber": "49"
     },
     "userMessage": "Found invalid chars in dcid value :: value: 'dc/ 2sffw13', invalid-chars: ' ', property: 'dcid', node: 'CityStats/E5/2'",
@@ -144,13 +227,29 @@
     "userMessage": "Found invalid chars in dcid value :: value: 'geoId–SFCounty', invalid-chars: '–', property: 'location', node: 'CityStats/E5/2'",
     "counterKey": "Sanity_InvalidChars_location"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "NoCsv.mcf",
-      "lineNumber": "67"
+      "lineNumber": "59"
     },
-    "userMessage": "Invalid latitude value; must be decimal degrees with an optional N/S suffix :: value: '-100', property: 'location', node: '\"CANCountry\"'",
-    "counterKey": "MCF_InvalidLatitude"
+    "userMessage": "Failed existence check :: reference: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingValueRef_containedInPlace"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed existence check :: property: 'population', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingPropertyRef"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed existence check :: property: 'inCounty', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingPropertyRef"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -159,22 +258,6 @@
     },
     "userMessage": "Found dcid with more than one value :: count: 2, node: '\"CANCountry\"'",
     "counterKey": "Sanity_MultipleDcidValues"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "73"
-    },
-    "userMessage": "Invalid longitude value; must be decimal degrees with an optional E/W suffix :: value: '181', property: 'location', node: 'dcid:geoId/sf'",
-    "counterKey": "MCF_InvalidLongitude"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "79"
-    },
-    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[10 12', property: 'age', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "MCF_MalformedComplexValue"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -197,6 +280,14 @@
       "file": "NoCsv.mcf",
       "lineNumber": "77"
     },
+    "userMessage": "Class not in the domain of Property used in StatVar :: property: '', class: '', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "Existence_MissingPropertyDomainDefinition"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "77"
+    },
     "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_statType"
   }, {
@@ -208,45 +299,45 @@
     "userMessage": "Found an unknown statType value :: value: '', node: 'dcid:Count_Death_10To12'",
     "counterKey": "Sanity_UnknownStatType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "NoCsv.mcf",
       "lineNumber": "81"
     },
-    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[10]', components: 1, property: 'age', node: 'dcid:Count_Death_10YearsPlus'",
-    "counterKey": "MCF_MalformedComplexValueParts"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "NoCsv.mcf",
       "lineNumber": "88"
     },
-    "userMessage": "Quantity value must be a number :: value: '[5Years 10Years]', property: 'age', node: 'dcid:Count_Death_5To10'",
-    "counterKey": "MCF_QuantityMalformedValue"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "NoCsv.mcf",
       "lineNumber": "95"
     },
-    "userMessage": "Malformed start component in QuantityRange value; must be a number or '-' :: value: 'less', property: 'age', node: 'dcid:Count_Death_YearsLessThan5'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "NoCsv.mcf",
       "lineNumber": "102"
     },
-    "userMessage": "Malformed end component in QuantityRange value; must be a number or '-' :: value: 'years', property: 'age', node: 'dcid:Count_Death_5YearsPlus'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "NoCsv.mcf",
       "lineNumber": "109"
     },
-    "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
+    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "Existence_MissingValueRef_statType"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -263,6 +354,22 @@
     },
     "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_15YearsPlus', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_populationType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Failed existence check :: property: 'label', node: 'dcid:beverageType'",
+    "counterKey": "Existence_MissingPropertyRef"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Failed existence check :: reference: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
+    "counterKey": "Existence_MissingValueRef_subClassOf"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -311,6 +418,22 @@
     },
     "userMessage": "Schema node with dcid/name mismatch :: name: 'Beverage–type', dcid: 'beverageType', node: 'dcid:beverageType'",
     "counterKey": "Sanity_DcidNameMismatchInSchema"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed existence check :: reference: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingValueRef_domainIncludes"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed existence check :: property: 'inCounty', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingPropertyRef"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -368,6 +491,22 @@
     "userMessage": "Found malformed entity name that is not an entity prefix (E:) :: name: '\"E:SVTest->E1\"'",
     "counterKey": "TMCF_MalformedEntity"
   }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.tmcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed existence check :: reference: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingValueRef_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.tmcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingValueRef_measurementMethod"
+  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "NoCsv.tmcf",
@@ -389,7 +528,7 @@
       "file": "NoCsv.tmcf",
       "lineNumber": "3"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E30', property: 'observationAbout' node: 'E:SVTest->E0'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E3', property: 'observationAbout' node: 'E:SVTest->E0'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",
@@ -397,7 +536,7 @@
       "file": "NoCsv.tmcf",
       "lineNumber": "3"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E3', property: 'observationAbout' node: 'E:SVTest->E0'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E30', property: 'observationAbout' node: 'E:SVTest->E0'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",
@@ -453,7 +592,7 @@
       "file": "NoCsv.tmcf",
       "lineNumber": "19"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E10', property: 'dcid' node: 'E:SVTest->E3'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",
@@ -461,7 +600,7 @@
       "file": "NoCsv.tmcf",
       "lineNumber": "19"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E10', property: 'dcid' node: 'E:SVTest->E3'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",


### PR DESCRIPTION
Ran this against all schema MCF, feels reasonably usable, though I'm sure there are uncovered bugs. At this point it might be more useful than without it.