### PR TITLE
Batch existence check requests to DC

### DIFF
--- a/server/src/main/java/org/datacommons/server/ServerCommand.java
+++ b/server/src/main/java/org/datacommons/server/ServerCommand.java
@@ -14,11 +14,7 @@
 
 package org.datacommons.server;
 
-import com.google.cloud.storage.Blob;
-import com.google.cloud.storage.BlobId;
-import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
-import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.*;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -31,11 +27,8 @@ import org.datacommons.util.FileGroup;
 import org.datacommons.util.LogWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Model;
+import picocli.CommandLine.*;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.Parameters;
-import picocli.CommandLine.Spec;
 
 // Defines the command line argument and execute startup operations.
 @Component
@@ -71,7 +64,7 @@ public class ServerCommand implements Callable<Integer> {
     FileGroup fg = FileGroup.Build(files, spec, logger);
     LogWrapper logCtx = new LogWrapper(Debug.Log.newBuilder(), new File(".").toPath());
     Processor processor = new Processor(logCtx);
-    processor.processTables(fg.GetTmcf(), fg.GetCsv(), ',', observationRepository);
+    processor.processTables(fg.GetTmcf(), fg.GetCsvs(), ',', observationRepository);
     return 0;
   }
 

--- a/tool/src/main/java/org/datacommons/tool/GenMcf.java
+++ b/tool/src/main/java/org/datacommons/tool/GenMcf.java
@@ -71,7 +71,7 @@ class GenMcf implements Callable<Integer> {
     Processor processor = new Processor(false, parent.verbose, logCtx);
     Integer retVal = 0;
     try {
-      processor.processTables(fg.GetTmcf(), fg.GetCsv(), delimiter, writer);
+      processor.processTables(fg.GetTmcf(), fg.GetCsvs(), delimiter, writer);
     } catch (DCTooManyFailuresException | InterruptedException ex) {
       // Regardless of the failures, we will dump the logCtx and exit.
       retVal = -1;

--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -73,16 +73,18 @@ class Lint implements Callable<Integer> {
     Integer retVal = 0;
     try {
       // Process all the instance MCF first, so that we can add the nodes for Existence Check.
-      for (File f : fg.GetMcf()) {
+      for (File f : fg.GetMcfs()) {
         processor.processNodes(Mcf.McfType.INSTANCE_MCF, f);
       }
       if (doExistenceChecks) {
         processor.checkAllNodes();
       }
-      if (!fg.GetCsv().isEmpty()) {
-        processor.processTables(fg.GetTmcf(), fg.GetCsv(), delimiter, null);
-      } else if (fg.GetTmcf() != null) {
-        processor.processNodes(Mcf.McfType.TEMPLATE_MCF, fg.GetTmcf());
+      if (!fg.GetCsvs().isEmpty()) {
+        processor.processTables(fg.GetTmcf(), fg.GetCsvs(), delimiter, null);
+      } else if (fg.GetTmcfs() != null) {
+        for (File f : fg.GetTmcfs()) {
+          processor.processNodes(Mcf.McfType.TEMPLATE_MCF, f);
+        }
       }
     } catch (DCTooManyFailuresException | InterruptedException ex) {
       // Regardless of the failures, we will dump the logCtx and exit.

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -139,5 +139,6 @@ public class Processor {
         throw new DCTooManyFailuresException("checkNodes encountered too many failures");
       }
     }
+    existenceChecker.drainRemoteCalls();
   }
 }

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -123,6 +123,7 @@ public class Processor {
           numRowsProcessed,
           numNodesProcessed);
     }
+    if (existenceChecker != null) existenceChecker.drainRemoteCalls();
   }
 
   // Called only when existenceChecker is enabled.

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/report.json
@@ -110,14 +110,6 @@
       "file": "FatalTmcf.tmcf",
       "lineNumber": "19"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_TmcfMissingEntityDef"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "FatalTmcf.tmcf",
-      "lineNumber": "19"
-    },
     "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E10', property: 'dcid' node: 'E:SVTest->E3'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
@@ -128,6 +120,14 @@
     },
     "userMessage": "Column referred to in TMCF is missing from CSV header :: column: 'dcid1', node: 'E:SVTest->E3'",
     "counterKey": "Sanity_TmcfMissingColumn"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "FatalTmcf.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",
     "location": {

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/report.json
@@ -110,6 +110,14 @@
       "file": "FatalTmcf.tmcf",
       "lineNumber": "19"
     },
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_TmcfMissingEntityDef"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "FatalTmcf.tmcf",
+      "lineNumber": "19"
+    },
     "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E10', property: 'dcid' node: 'E:SVTest->E3'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
@@ -120,14 +128,6 @@
     },
     "userMessage": "Column referred to in TMCF is missing from CSV header :: column: 'dcid1', node: 'E:SVTest->E3'",
     "counterKey": "Sanity_TmcfMissingColumn"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "FatalTmcf.tmcf",
-      "lineNumber": "19"
-    },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",
     "location": {

--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
@@ -1,7 +1,7 @@
 {
   "levelSummary": {
     "LEVEL_ERROR": "56",
-    "LEVEL_WARNING": "19"
+    "LEVEL_WARNING": "43"
   },
   "counterSet": {
     "counters": {
@@ -39,7 +39,7 @@
       "Sanity_UnexpectedPropInClass": "1",
       "Sanity_NotInitUpper_nameInClass": "1",
       "Sanity_MissingOrEmpty_subClassOf": "1",
-      "Existence_NumDcCalls": "2",
+      "Existence_NumDcCalls": "3",
       "Existence_MissingReference_containedIn": "1",
       "Existence_MissingReference_statType": "5",
       "Existence_MissingReference_domainIncludes": "2",
@@ -58,7 +58,9 @@
       "CSV_MalformedDCIDPVFailures": "4",
       "CSV_EmptyDcidReferences": "2",
       "Sanity_MissingOrEmpty_observationAbout": "2",
-      "Sanity_VeryLongDcid": "1"
+      "Sanity_VeryLongDcid": "1",
+      "Existence_MissingReference_variableMeasured": "12",
+      "Existence_MissingReference_measurementMethod": "12"
     }
   },
   "entries": [{
@@ -661,5 +663,197 @@
     },
     "userMessage": "Quantity value must be a number :: value: '[Lat Long]', property: 'location', node: 'dcid:CA-MN'",
     "counterKey": "MCF_QuantityMalformedValue"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
   }]
 }

--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
@@ -1,7 +1,7 @@
 {
   "levelSummary": {
-    "LEVEL_ERROR": "57",
-    "LEVEL_WARNING": "42"
+    "LEVEL_ERROR": "56",
+    "LEVEL_WARNING": "19"
   },
   "counterSet": {
     "counters": {
@@ -16,8 +16,6 @@
       "MCF_QuantityMalformedValue": "2",
       "MCF_QuantityRangeMalformedValues": "3",
       "Existence_NumChecks": "249",
-      "Existence_NumDcCalls": "50",
-      "Existence_MissingValueRef_containedIn": "1",
       "Sanity_MissingOrEmpty_typeOf": "2",
       "Sanity_InvalidChars_typeOf": "2",
       "Sanity_InvalidObsDate": "3",
@@ -26,33 +24,32 @@
       "Sanity_InvalidChars_dcid": "2",
       "Sanity_NonAsciiValueInNonText": "2",
       "Sanity_InvalidChars_location": "1",
-      "Existence_MissingValueRef_containedInPlace": "1",
-      "Existence_MissingPropertyRef": "4",
       "Sanity_MultipleDcidValues": "2",
       "Sanity_MissingOrEmpty_populationType": "2",
       "Sanity_MissingOrEmpty_measuredProperty": "1",
-      "Existence_MissingPropertyDomainDefinition": "1",
       "Sanity_MissingOrEmpty_statType": "1",
       "Sanity_UnknownStatType": "1",
-      "Existence_MissingValueRef_statType": "5",
       "Sanity_NotInitLowerPropName": "1",
-      "Existence_MissingValueRef_subClassOf": "1",
       "Sanity_InvalidChars_domainIncludes": "1",
       "Sanity_UnexpectedPropInProperty": "1",
       "Sanity_NonAsciiValueInSchema": "1",
       "Sanity_NotInitLower_labelInProperty": "1",
       "Sanity_EmptySchemaValue": "1",
       "Sanity_DcidNameMismatchInSchema": "2",
-      "Existence_MissingValueRef_domainIncludes": "1",
       "Sanity_UnexpectedPropInClass": "1",
       "Sanity_NotInitUpper_nameInClass": "1",
       "Sanity_MissingOrEmpty_subClassOf": "1",
+      "Existence_NumDcCalls": "2",
+      "Existence_MissingReference_containedIn": "1",
+      "Existence_MissingReference_statType": "5",
+      "Existence_MissingReference_domainIncludes": "2",
+      "Existence_MissingReference_containedInPlace": "1",
+      "Existence_MissingReference_Property": "4",
+      "Existence_MissingReference_subClassOf": "1",
       "Sanity_InvalidChars_observationAbout": "2",
-      "NumRowSuccesses": "5",
+      "NumRowSuccesses": "11",
       "NumNodeSuccesses": "15",
       "NumPVSuccesses": "83",
-      "Existence_MissingValueRef_variableMeasured": "12",
-      "Existence_MissingValueRef_measurementMethod": "12",
       "StrSplit_EmptyToken_typeOf": "1",
       "CSV_InconsistentRows": "2",
       "Sanity_MultipleVals_observationDate": "2",
@@ -161,14 +158,6 @@
     "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
     "counterKey": "MCF_QuantityRangeMalformedValues"
   }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed existence check :: reference: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
-    "counterKey": "Existence_MissingValueRef_containedIn"
-  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.mcf",
@@ -233,30 +222,6 @@
     "userMessage": "Found invalid chars in dcid value :: value: 'geoId–SFCounty', invalid-chars: '–', property: 'location', node: 'CityStats/E5/2'",
     "counterKey": "Sanity_InvalidChars_location"
   }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "59"
-    },
-    "userMessage": "Failed existence check :: reference: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingValueRef_containedInPlace"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "59"
-    },
-    "userMessage": "Failed existence check :: property: 'population', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingPropertyRef"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "59"
-    },
-    "userMessage": "Failed existence check :: property: 'inCounty', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingPropertyRef"
-  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.mcf",
@@ -286,14 +251,6 @@
       "file": "AllFileTypes.mcf",
       "lineNumber": "77"
     },
-    "userMessage": "Class not in the domain of Property used in StatVar :: property: '', class: '', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "Existence_MissingPropertyDomainDefinition"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "77"
-    },
     "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_statType"
   }, {
@@ -304,46 +261,6 @@
     },
     "userMessage": "Found an unknown statType value :: value: '', node: 'dcid:Count_Death_10To12'",
     "counterKey": "Sanity_UnknownStatType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "81"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
-    "counterKey": "Existence_MissingValueRef_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "88"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
-    "counterKey": "Existence_MissingValueRef_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "95"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
-    "counterKey": "Existence_MissingValueRef_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "102"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
-    "counterKey": "Existence_MissingValueRef_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "Existence_MissingValueRef_statType"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -360,22 +277,6 @@
     },
     "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_15YearsPlus', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_populationType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Failed existence check :: property: 'label', node: 'dcid:beverageType'",
-    "counterKey": "Existence_MissingPropertyRef"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Failed existence check :: reference: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
-    "counterKey": "Existence_MissingValueRef_subClassOf"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -425,22 +326,6 @@
     "userMessage": "Schema node with dcid/name mismatch :: name: 'Beverage–type', dcid: 'beverageType', node: 'dcid:beverageType'",
     "counterKey": "Sanity_DcidNameMismatchInSchema"
   }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Failed existence check :: reference: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
-    "counterKey": "Existence_MissingValueRef_domainIncludes"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Failed existence check :: property: 'inCounty', node: 'dcid:Pop'",
-    "counterKey": "Existence_MissingPropertyRef"
-  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.mcf",
@@ -472,6 +357,118 @@
     },
     "userMessage": "Found a missing or empty property value :: property: 'subClassOf', node: 'dcid:Pop', type: 'Class'",
     "counterKey": "Sanity_MissingOrEmpty_subClassOf"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
+    "counterKey": "Existence_MissingReference_containedIn"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "81"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "88"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "95"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "102"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingReference_domainIncludes"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingReference_containedInPlace"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingReference_Property"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingReference_Property"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Failed reference existence check :: property-ref: 'label', node: 'dcid:beverageType'",
+    "counterKey": "Existence_MissingReference_Property"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed reference existence check :: property-ref: 'population', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingReference_Property"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
+    "counterKey": "Existence_MissingReference_subClassOf"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Failed reference existence check :: subject: '', predicate: 'domainIncludes', object: '', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "Existence_MissingReference_domainIncludes"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -521,38 +518,6 @@
     "userMessage": "Found dcid with more than one value :: count: 2, node: 'E:SVTest->E3'",
     "counterKey": "Sanity_MultipleDcidValues"
   }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed existence check :: reference: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingValueRef_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingValueRef_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed existence check :: reference: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingValueRef_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingValueRef_measurementMethod"
-  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.csv",
@@ -572,38 +537,6 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.csv",
-      "lineNumber": "4"
-    },
-    "userMessage": "Failed existence check :: reference: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingValueRef_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "4"
-    },
-    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingValueRef_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "4"
-    },
-    "userMessage": "Failed existence check :: reference: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingValueRef_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "4"
-    },
-    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingValueRef_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
       "lineNumber": "5"
     },
     "userMessage": "Empty value found :: value: '', column: 'Place_Type', property: 'typeOf', node: 'E:SVTest->E3'",
@@ -616,38 +549,6 @@
     },
     "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'E:SVTest->E3', type: 'Thing'",
     "counterKey": "Sanity_MissingOrEmpty_typeOf"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "5"
-    },
-    "userMessage": "Failed existence check :: reference: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingValueRef_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "5"
-    },
-    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingValueRef_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "5"
-    },
-    "userMessage": "Failed existence check :: reference: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingValueRef_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "5"
-    },
-    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingValueRef_measurementMethod"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -708,38 +609,6 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.csv",
-      "lineNumber": "9"
-    },
-    "userMessage": "Failed existence check :: reference: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingValueRef_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "9"
-    },
-    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingValueRef_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "9"
-    },
-    "userMessage": "Failed existence check :: reference: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingValueRef_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "9"
-    },
-    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingValueRef_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
       "lineNumber": "10"
     },
     "userMessage": "Malformed CSV value for dcid property; must be a text or reference :: value: '123', node: 'E:SVTest->E3'",
@@ -785,38 +654,6 @@
     "userMessage": "Found a very long dcid value; must be less than 256 :: node: 'E:SVTest->E3'",
     "counterKey": "Sanity_VeryLongDcid"
   }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed existence check :: reference: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingValueRef_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingValueRef_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed existence check :: reference: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingValueRef_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingValueRef_measurementMethod"
-  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.csv",
@@ -824,37 +661,5 @@
     },
     "userMessage": "Quantity value must be a number :: value: '[Lat Long]', property: 'location', node: 'dcid:CA-MN'",
     "counterKey": "MCF_QuantityMalformedValue"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed existence check :: reference: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingValueRef_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingValueRef_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed existence check :: reference: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingValueRef_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingValueRef_measurementMethod"
   }]
 }

--- a/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
@@ -1,7 +1,7 @@
 {
   "levelSummary": {
-    "LEVEL_ERROR": "37",
-    "LEVEL_WARNING": "15"
+    "LEVEL_ERROR": "36",
+    "LEVEL_WARNING": "16"
   },
   "counterSet": {
     "counters": {
@@ -16,8 +16,6 @@
       "MCF_QuantityMalformedValue": "1",
       "MCF_QuantityRangeMalformedValues": "3",
       "Existence_NumChecks": "149",
-      "Existence_NumDcCalls": "42",
-      "Existence_MissingValueRef_containedIn": "1",
       "Sanity_MissingOrEmpty_typeOf": "1",
       "Sanity_InvalidChars_typeOf": "1",
       "Sanity_InvalidObsDate": "1",
@@ -26,27 +24,28 @@
       "Sanity_InvalidChars_dcid": "1",
       "Sanity_NonAsciiValueInNonText": "1",
       "Sanity_InvalidChars_location": "1",
-      "Existence_MissingValueRef_containedInPlace": "1",
-      "Existence_MissingPropertyRef": "4",
       "Sanity_MultipleDcidValues": "1",
       "Sanity_MissingOrEmpty_populationType": "2",
       "Sanity_MissingOrEmpty_measuredProperty": "1",
-      "Existence_MissingPropertyDomainDefinition": "1",
       "Sanity_MissingOrEmpty_statType": "1",
       "Sanity_UnknownStatType": "1",
-      "Existence_MissingValueRef_statType": "6",
       "Sanity_NotInitLowerPropName": "1",
-      "Existence_MissingValueRef_subClassOf": "1",
       "Sanity_InvalidChars_domainIncludes": "1",
       "Sanity_UnexpectedPropInProperty": "1",
       "Sanity_NonAsciiValueInSchema": "1",
       "Sanity_NotInitLower_labelInProperty": "1",
       "Sanity_EmptySchemaValue": "1",
       "Sanity_DcidNameMismatchInSchema": "2",
-      "Existence_MissingValueRef_domainIncludes": "1",
       "Sanity_UnexpectedPropInClass": "1",
       "Sanity_NotInitUpper_nameInClass": "1",
-      "Sanity_MissingOrEmpty_subClassOf": "1"
+      "Sanity_MissingOrEmpty_subClassOf": "1",
+      "Existence_NumDcCalls": "2",
+      "Existence_MissingReference_containedIn": "1",
+      "Existence_MissingReference_statType": "6",
+      "Existence_MissingReference_domainIncludes": "2",
+      "Existence_MissingReference_containedInPlace": "1",
+      "Existence_MissingReference_Property": "4",
+      "Existence_MissingReference_subClassOf": "1"
     }
   },
   "entries": [{
@@ -146,14 +145,6 @@
     "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
     "counterKey": "MCF_QuantityRangeMalformedValues"
   }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed existence check :: reference: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
-    "counterKey": "Existence_MissingValueRef_containedIn"
-  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "McfOnly.mcf",
@@ -218,30 +209,6 @@
     "userMessage": "Found invalid chars in dcid value :: value: 'geoId–SFCounty', invalid-chars: '–', property: 'location', node: 'CityStats/E5/2'",
     "counterKey": "Sanity_InvalidChars_location"
   }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "59"
-    },
-    "userMessage": "Failed existence check :: reference: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingValueRef_containedInPlace"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "59"
-    },
-    "userMessage": "Failed existence check :: property: 'population', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingPropertyRef"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "59"
-    },
-    "userMessage": "Failed existence check :: property: 'inCounty', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingPropertyRef"
-  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "McfOnly.mcf",
@@ -271,14 +238,6 @@
       "file": "McfOnly.mcf",
       "lineNumber": "77"
     },
-    "userMessage": "Class not in the domain of Property used in StatVar :: property: '', class: '', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "Existence_MissingPropertyDomainDefinition"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "77"
-    },
     "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_statType"
   }, {
@@ -289,46 +248,6 @@
     },
     "userMessage": "Found an unknown statType value :: value: '', node: 'dcid:Count_Death_10To12'",
     "counterKey": "Sanity_UnknownStatType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "81"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
-    "counterKey": "Existence_MissingValueRef_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "88"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
-    "counterKey": "Existence_MissingValueRef_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "95"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
-    "counterKey": "Existence_MissingValueRef_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "102"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
-    "counterKey": "Existence_MissingValueRef_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "Existence_MissingValueRef_statType"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -345,22 +264,6 @@
     },
     "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_15YearsPlus', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_populationType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Failed existence check :: property: 'label', node: 'dcid:beverageType'",
-    "counterKey": "Existence_MissingPropertyRef"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Failed existence check :: reference: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
-    "counterKey": "Existence_MissingValueRef_subClassOf"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -410,22 +313,6 @@
     "userMessage": "Schema node with dcid/name mismatch :: name: 'Beverage–type', dcid: 'beverageType', node: 'dcid:beverageType'",
     "counterKey": "Sanity_DcidNameMismatchInSchema"
   }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Failed existence check :: reference: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
-    "counterKey": "Existence_MissingValueRef_domainIncludes"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Failed existence check :: property: 'inCounty', node: 'dcid:Pop'",
-    "counterKey": "Existence_MissingPropertyRef"
-  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "McfOnly.mcf",
@@ -461,9 +348,121 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "McfOnly.mcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
+    "counterKey": "Existence_MissingReference_containedIn"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "81"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "88"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "95"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "102"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
       "lineNumber": "130"
     },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
-    "counterKey": "Existence_MissingValueRef_statType"
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingReference_domainIncludes"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingReference_containedInPlace"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingReference_Property"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingReference_Property"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Failed reference existence check :: property-ref: 'label', node: 'dcid:beverageType'",
+    "counterKey": "Existence_MissingReference_Property"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed reference existence check :: property-ref: 'population', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingReference_Property"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
+    "counterKey": "Existence_MissingReference_subClassOf"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Failed reference existence check :: subject: '', predicate: 'domainIncludes', object: '', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "Existence_MissingReference_domainIncludes"
   }]
 }

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
@@ -509,7 +509,7 @@
       "file": "NoCsv.tmcf",
       "lineNumber": "3"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E3', property: 'observationAbout' node: 'E:SVTest->E0'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E30', property: 'observationAbout' node: 'E:SVTest->E0'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",
@@ -517,7 +517,7 @@
       "file": "NoCsv.tmcf",
       "lineNumber": "3"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E30', property: 'observationAbout' node: 'E:SVTest->E0'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E3', property: 'observationAbout' node: 'E:SVTest->E0'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",
@@ -573,7 +573,7 @@
       "file": "NoCsv.tmcf",
       "lineNumber": "19"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E10', property: 'dcid' node: 'E:SVTest->E3'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",
@@ -581,7 +581,7 @@
       "file": "NoCsv.tmcf",
       "lineNumber": "19"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E10', property: 'dcid' node: 'E:SVTest->E3'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
@@ -1,7 +1,7 @@
 {
   "levelSummary": {
-    "LEVEL_ERROR": "56",
-    "LEVEL_WARNING": "17"
+    "LEVEL_ERROR": "55",
+    "LEVEL_WARNING": "16"
   },
   "counterSet": {
     "counters": {
@@ -16,8 +16,6 @@
       "MCF_QuantityMalformedValue": "1",
       "MCF_QuantityRangeMalformedValues": "3",
       "Existence_NumChecks": "149",
-      "Existence_NumDcCalls": "48",
-      "Existence_MissingValueRef_containedIn": "1",
       "Sanity_MissingOrEmpty_typeOf": "2",
       "Sanity_InvalidChars_typeOf": "1",
       "Sanity_InvalidObsDate": "1",
@@ -26,30 +24,29 @@
       "Sanity_InvalidChars_dcid": "1",
       "Sanity_NonAsciiValueInNonText": "1",
       "Sanity_InvalidChars_location": "1",
-      "Existence_MissingValueRef_containedInPlace": "1",
-      "Existence_MissingPropertyRef": "4",
       "Sanity_MultipleDcidValues": "2",
       "Sanity_MissingOrEmpty_populationType": "2",
       "Sanity_MissingOrEmpty_measuredProperty": "1",
-      "Existence_MissingPropertyDomainDefinition": "1",
       "Sanity_MissingOrEmpty_statType": "1",
       "Sanity_UnknownStatType": "1",
-      "Existence_MissingValueRef_statType": "5",
       "Sanity_NotInitLowerPropName": "2",
-      "Existence_MissingValueRef_subClassOf": "1",
       "Sanity_InvalidChars_domainIncludes": "1",
       "Sanity_UnexpectedPropInProperty": "1",
       "Sanity_NonAsciiValueInSchema": "1",
       "Sanity_NotInitLower_labelInProperty": "1",
       "Sanity_EmptySchemaValue": "1",
       "Sanity_DcidNameMismatchInSchema": "2",
-      "Existence_MissingValueRef_domainIncludes": "1",
       "Sanity_UnexpectedPropInClass": "1",
       "Sanity_NotInitUpper_nameInClass": "1",
       "Sanity_MissingOrEmpty_subClassOf": "1",
+      "Existence_NumDcCalls": "2",
+      "Existence_MissingReference_containedIn": "1",
+      "Existence_MissingReference_statType": "5",
+      "Existence_MissingReference_domainIncludes": "2",
+      "Existence_MissingReference_containedInPlace": "1",
+      "Existence_MissingReference_Property": "4",
+      "Existence_MissingReference_subClassOf": "1",
       "TMCF_MalformedEntity": "2",
-      "Existence_MissingValueRef_variableMeasured": "1",
-      "Existence_MissingValueRef_measurementMethod": "1",
       "Sanity_MultipleVals_observationAbout": "1",
       "Sanity_MultipleVals_value": "1",
       "Sanity_TmcfMissingEntityDef": "5",
@@ -155,14 +152,6 @@
     "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
     "counterKey": "MCF_QuantityRangeMalformedValues"
   }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed existence check :: reference: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
-    "counterKey": "Existence_MissingValueRef_containedIn"
-  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "NoCsv.mcf",
@@ -227,30 +216,6 @@
     "userMessage": "Found invalid chars in dcid value :: value: 'geoId–SFCounty', invalid-chars: '–', property: 'location', node: 'CityStats/E5/2'",
     "counterKey": "Sanity_InvalidChars_location"
   }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "59"
-    },
-    "userMessage": "Failed existence check :: reference: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingValueRef_containedInPlace"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "59"
-    },
-    "userMessage": "Failed existence check :: property: 'population', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingPropertyRef"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "59"
-    },
-    "userMessage": "Failed existence check :: property: 'inCounty', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingPropertyRef"
-  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "NoCsv.mcf",
@@ -280,14 +245,6 @@
       "file": "NoCsv.mcf",
       "lineNumber": "77"
     },
-    "userMessage": "Class not in the domain of Property used in StatVar :: property: '', class: '', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "Existence_MissingPropertyDomainDefinition"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "77"
-    },
     "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_statType"
   }, {
@@ -298,46 +255,6 @@
     },
     "userMessage": "Found an unknown statType value :: value: '', node: 'dcid:Count_Death_10To12'",
     "counterKey": "Sanity_UnknownStatType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "81"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
-    "counterKey": "Existence_MissingValueRef_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "88"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
-    "counterKey": "Existence_MissingValueRef_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "95"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
-    "counterKey": "Existence_MissingValueRef_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "102"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
-    "counterKey": "Existence_MissingValueRef_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Failed existence check :: reference: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "Existence_MissingValueRef_statType"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -354,22 +271,6 @@
     },
     "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_15YearsPlus', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_populationType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Failed existence check :: property: 'label', node: 'dcid:beverageType'",
-    "counterKey": "Existence_MissingPropertyRef"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Failed existence check :: reference: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
-    "counterKey": "Existence_MissingValueRef_subClassOf"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -419,22 +320,6 @@
     "userMessage": "Schema node with dcid/name mismatch :: name: 'Beverage–type', dcid: 'beverageType', node: 'dcid:beverageType'",
     "counterKey": "Sanity_DcidNameMismatchInSchema"
   }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Failed existence check :: reference: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
-    "counterKey": "Existence_MissingValueRef_domainIncludes"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Failed existence check :: property: 'inCounty', node: 'dcid:Pop'",
-    "counterKey": "Existence_MissingPropertyRef"
-  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "NoCsv.mcf",
@@ -467,6 +352,118 @@
     "userMessage": "Found a missing or empty property value :: property: 'subClassOf', node: 'dcid:Pop', type: 'Class'",
     "counterKey": "Sanity_MissingOrEmpty_subClassOf"
   }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
+    "counterKey": "Existence_MissingReference_containedIn"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "81"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "88"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "95"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "102"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingReference_domainIncludes"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingReference_containedInPlace"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingReference_Property"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingReference_Property"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Failed reference existence check :: property-ref: 'label', node: 'dcid:beverageType'",
+    "counterKey": "Existence_MissingReference_Property"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed reference existence check :: property-ref: 'population', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingReference_Property"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
+    "counterKey": "Existence_MissingReference_subClassOf"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Failed reference existence check :: subject: '', predicate: 'domainIncludes', object: '', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "Existence_MissingReference_domainIncludes"
+  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "NoCsv.tmcf",
@@ -490,22 +487,6 @@
     },
     "userMessage": "Found malformed entity name that is not an entity prefix (E:) :: name: '\"E:SVTest->E1\"'",
     "counterKey": "TMCF_MalformedEntity"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.tmcf",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed existence check :: reference: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingValueRef_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.tmcf",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed existence check :: reference: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingValueRef_measurementMethod"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -592,7 +573,7 @@
       "file": "NoCsv.tmcf",
       "lineNumber": "19"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E10', property: 'dcid' node: 'E:SVTest->E3'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",
@@ -600,7 +581,7 @@
       "file": "NoCsv.tmcf",
       "lineNumber": "19"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E10', property: 'dcid' node: 'E:SVTest->E3'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",

--- a/util/src/main/java/org/datacommons/util/ExistenceChecker.java
+++ b/util/src/main/java/org/datacommons/util/ExistenceChecker.java
@@ -132,8 +132,7 @@ public class ExistenceChecker {
     List<String> preds = new ArrayList<>(remoteBatchMap.keySet());
     for (var pred : preds) {
       if (verbose) {
-        logger.info(
-            "Draining " + remoteBatchMap.get(pred).size() + " dcids for " + "predicate " + pred);
+        logger.info("Draining " + remoteBatchMap.get(pred).size() + " dcids for predicate " + pred);
       }
       drainRemoteCallsForPredicate(pred, remoteBatchMap.get(pred));
       remoteBatchMap.remove(pred);
@@ -180,7 +179,7 @@ public class ExistenceChecker {
             "Draining due to batching limit with "
                 + subMap.size()
                 + " dcids for "
-                + "predicate"
+                + "predicate "
                 + pred);
       }
       drainRemoteCallsForPredicate(pred, subMap);

--- a/util/src/main/java/org/datacommons/util/ExistenceChecker.java
+++ b/util/src/main/java/org/datacommons/util/ExistenceChecker.java
@@ -17,6 +17,8 @@ import org.datacommons.proto.Mcf;
 
 // This class checks the existence of typically schema-related, nodes or (select types of)
 // triples in the KG or local graph.
+// TODO: Use POST instead of GET while calling DC so we won't run into URL limits and can batch
+//  even more.
 public class ExistenceChecker {
   private static final Logger logger = LogManager.getLogger(ExistenceChecker.class);
   // Use the staging end-point to not impact prod.
@@ -26,7 +28,7 @@ public class ExistenceChecker {
       Set.of(Vocabulary.DOMAIN_INCLUDES, Vocabulary.RANGE_INCLUDES, Vocabulary.SUB_CLASS_OF);
 
   // Batching thresholds.  Allow tests to set this.
-  public static int DC_CALL_BATCH_LIMIT = 500;
+  public static int DC_CALL_BATCH_LIMIT = 100;
   public static int MAX_PENDING_CALLS = 100000;
 
   // Useful for mocking.
@@ -303,7 +305,7 @@ public class ExistenceChecker {
     var request =
         HttpRequest.newBuilder(URI.create(url)).header("accept", "application/json").build();
     var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-    var payloadJson = new JsonParser().parse(response.body()).getAsJsonObject();
+    var payloadJson = new JsonParser().parse(response.body().trim()).getAsJsonObject();
     if (payloadJson == null || !payloadJson.has("payload")) return null;
     return new JsonParser().parse(payloadJson.get("payload").getAsString()).getAsJsonObject();
   }

--- a/util/src/main/java/org/datacommons/util/ExistenceChecker.java
+++ b/util/src/main/java/org/datacommons/util/ExistenceChecker.java
@@ -281,18 +281,6 @@ public class ExistenceChecker {
     return false;
   }
 
-  private static void logEntry(LogCb logCb, String obj) {
-    String message, counter;
-    if (obj.isEmpty()) {
-      counter = "Existence_MissingReference";
-      message = "Failed reference existence check";
-    } else {
-      counter = "Existence_MissingTriple";
-      message = "Failed triple existence check";
-    }
-    logCb.logError(counter, message);
-  }
-
   private JsonObject callDc(List<String> nodes, String property)
       throws IOException, InterruptedException {
     List<String> args = new ArrayList<>();
@@ -313,6 +301,18 @@ public class ExistenceChecker {
   // See https://stackoverflow.com/a/4737967.  Mixer does not treat '+' in param value as space.
   private String spaceHandlingUrlEncoder(String part) {
     return URLEncoder.encode(part, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  private static void logEntry(LogCb logCb, String obj) {
+    String message, counter;
+    if (obj.isEmpty()) {
+      counter = "Existence_MissingReference";
+      message = "Failed reference existence check";
+    } else {
+      counter = "Existence_MissingTriple";
+      message = "Failed triple existence check";
+    }
+    logCb.logError(counter, message);
   }
 
   private static String makeKey(String s, String p, String o) {

--- a/util/src/main/java/org/datacommons/util/ExistenceChecker.java
+++ b/util/src/main/java/org/datacommons/util/ExistenceChecker.java
@@ -157,15 +157,16 @@ public class ExistenceChecker {
       throws IOException, InterruptedException {
     logCtx.incrementCounterBy("Existence_NumDcCalls", 1);
 
-    // Make one call with all entries in subMap.
     var dataJson = callDc(subs, pred);
 
     if (dataJson == null) {
       if (verbose) {
         logger.info("DC call failed for - " + Strings.join(subs, ',') + ", " + pred);
       }
-      // If the DCID is malformed Mixer can return failure. So Issue independent RPCs now.
-      logger.warn("DC Call failed due to bad DCID. Issuing individual calls now.");
+      logger.warn("DC Call failed (bad DCID or URI length). Issuing individual calls now.");
+      // Important: If the DCID is malformed, Mixer can return failure. Also, if the URI is too
+      // long, then too this happens. So Issue independent RPCs now. If this happens often enough,
+      // we can revisit.
       for (String sub : subs) {
         performDcCall(pred, List.of(sub), subMap);
       }
@@ -193,9 +194,6 @@ public class ExistenceChecker {
         var cbs = kv.getValue();
         var key = makeKey(sub, pred, obj);
         if (checkOneResult(obj, nodeJson)) {
-          if (verbose) {
-            logger.info("Found " + (obj.isEmpty() ? "node" : "triple") + " in DC " + key);
-          }
           existingNodesOrTriples.add(key);
         } else {
           if (verbose) {

--- a/util/src/main/java/org/datacommons/util/FileGroup.java
+++ b/util/src/main/java/org/datacommons/util/FileGroup.java
@@ -21,32 +21,38 @@ import org.apache.logging.log4j.Logger;
 import picocli.CommandLine;
 
 public class FileGroup {
-  private File tmcfFile;
   private List<File> csvFiles;
   private List<File> mcfFiles;
+  // NOTE: When csvFiles is provided, then tmcfFiles must be <= 1.
+  private List<File> tmcfFiles;
   int nTsv;
 
-  public FileGroup(File tmcfFile, List<File> csvFiles, List<File> mcfFiles, int nTsv) {
-    this.tmcfFile = tmcfFile;
+  public FileGroup(List<File> tmcfFiles, List<File> csvFiles, List<File> mcfFiles, int nTsv) {
+    this.tmcfFiles = tmcfFiles;
     this.csvFiles = csvFiles;
     this.mcfFiles = mcfFiles;
     this.nTsv = nTsv;
   }
 
   public File GetTmcf() {
-    return this.tmcfFile;
+    if (tmcfFiles != null && tmcfFiles.size() > 0) return tmcfFiles.get(0);
+    return null;
   }
 
-  public List<File> GetCsv() {
-    return this.csvFiles;
+  public List<File> GetTmcfs() {
+    return tmcfFiles;
   }
 
-  public List<File> GetMcf() {
-    return this.mcfFiles;
+  public List<File> GetCsvs() {
+    return csvFiles;
+  }
+
+  public List<File> GetMcfs() {
+    return mcfFiles;
   }
 
   public int GetNumTsv() {
-    return this.nTsv;
+    return nTsv;
   }
 
   public static FileGroup Build(File[] files, CommandLine.Model.CommandSpec spec, Logger logger) {
@@ -87,7 +93,7 @@ public class FileGroup {
     if (tmcfFiles.isEmpty()) {
       return new FileGroup(null, csvFiles, mcfFiles, nTsv);
     } else {
-      return new FileGroup(tmcfFiles.get(0), csvFiles, mcfFiles, nTsv);
+      return new FileGroup(tmcfFiles, csvFiles, mcfFiles, nTsv);
     }
   }
 }

--- a/util/src/main/java/org/datacommons/util/LogCb.java
+++ b/util/src/main/java/org/datacommons/util/LogCb.java
@@ -5,18 +5,35 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.datacommons.proto.Debug;
+import org.datacommons.proto.Mcf;
 
 // A class to hold information for logging errors or warnings
 public class LogCb {
   public static final String VALUE_KEY = "value";
+  public static final String PREF_KEY = "property-ref";
+  public static final String VREF_KEY = "value-ref";
   public static final String COLUMN_KEY = "column";
   public static final String PROP_KEY = "property";
+  public static final String SUB_KEY = "subject";
+  public static final String PRED_KEY = "predicate";
+  public static final String OBJ_KEY = "object";
   public static final String NODE_KEY = "node";
+  // This specifies the order in which the keys should be displayed.
   private static final List<String> messageDetailsKeys =
-      Arrays.asList(VALUE_KEY, COLUMN_KEY, PROP_KEY, NODE_KEY);
+      Arrays.asList(
+          VALUE_KEY,
+          PREF_KEY,
+          VREF_KEY,
+          COLUMN_KEY,
+          PROP_KEY,
+          SUB_KEY,
+          PRED_KEY,
+          OBJ_KEY,
+          NODE_KEY);
   private final LogWrapper logCtx;
   private final Debug.Log.Level logLevel;
-  private final long lineNum;
+  private Mcf.McfGraph.PropertyValues node; // Optional
+  private long lineNum;
   private Map<String, String> messageDetails = new HashMap<>();
   private String counter_prefix = "";
   private String counter_suffix = "";
@@ -27,18 +44,24 @@ public class LogCb {
     this.lineNum = lineNum;
   }
 
+  public LogCb(LogWrapper logCtx, Debug.Log.Level logLevel, Mcf.McfGraph.PropertyValues node) {
+    this.logCtx = logCtx;
+    this.logLevel = logLevel;
+    this.node = node;
+  }
+
   public org.datacommons.util.LogCb setDetail(String key, String val) {
-    this.messageDetails.put(key, val);
+    messageDetails.put(key, val);
     return this;
   }
 
   public org.datacommons.util.LogCb setCounterPrefix(String prefix) {
-    this.counter_prefix = prefix;
+    counter_prefix = prefix;
     return this;
   }
 
   public org.datacommons.util.LogCb setCounterSuffix(String suffix) {
-    this.counter_suffix = suffix;
+    counter_suffix = suffix;
     return this;
   }
 
@@ -49,15 +72,29 @@ public class LogCb {
     if (!counter_suffix.isEmpty()) {
       counter = counter + "_" + counter_suffix;
     }
-    String message = problemMessage + " :: ";
+    String finalMessage = getFinalMessage(problemMessage);
+    if (node != null) {
+      logCtx.addEntry(logLevel, counter, finalMessage, node.getLocationsList());
+    } else {
+      logCtx.addEntry(logLevel, counter, finalMessage, lineNum);
+    }
+  }
+
+  private String getFinalMessage(String problemMessage) {
+    if (messageDetails.isEmpty()) return problemMessage;
+
+    StringBuilder message = new StringBuilder();
+    message.append(problemMessage).append(" :: ");
     boolean isFirstDetail = true;
     for (String detailKey : messageDetailsKeys) {
       if (messageDetails.containsKey(detailKey)) {
-        message +=
-            (isFirstDetail ? "" : ", ") + detailKey + ": '" + messageDetails.get(detailKey) + "'";
+        if (!isFirstDetail) {
+          message.append(", ");
+        }
+        message.append(detailKey).append(": '").append(messageDetails.get(detailKey)).append("'");
         isFirstDetail = false;
       }
     }
-    this.logCtx.addEntry(this.logLevel, counter, message, this.lineNum);
+    return message.toString();
   }
 }

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -41,6 +41,8 @@ public class LogWrapper {
   public static final int MAX_ERROR_COUNTERS_LIMIT = 50;
   public static final int MAX_MESSAGES_PER_COUNTER = 30;
 
+  public static boolean TEST_MODE = false;
+
   private Debug.Log.Builder log;
   private Path logPath;
   private String locationFile;
@@ -146,6 +148,7 @@ public class LogWrapper {
 
   private void addEntry(
       Debug.Log.Level level, String counter, String message, String file, long lno) {
+    if (TEST_MODE) System.err.println(counter + " - " + message);
     if (level == Debug.Log.Level.LEVEL_ERROR || level == Debug.Log.Level.LEVEL_FATAL) {
       countersWithErrors.add(counter);
     }

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -15,14 +15,15 @@
 package org.datacommons.util;
 
 import com.google.common.base.Charsets;
+import org.datacommons.proto.Debug;
+import org.datacommons.proto.Mcf;
+
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.datacommons.proto.Debug;
-import org.datacommons.proto.Mcf;
 
 // Checks common types of nodes on naming and schema requirements.
 //
@@ -61,7 +62,7 @@ public class McfChecker {
   }
 
   // Used to check a single node from TMcfCsvParser.
-  public static boolean check(
+  public static boolean checkNode(
       Mcf.McfType mcfType, String nodeId, Mcf.McfGraph.PropertyValues node, LogWrapper logCtx)
       throws IOException, InterruptedException {
     Mcf.McfGraph.Builder nodeGraph = Mcf.McfGraph.newBuilder();
@@ -71,7 +72,7 @@ public class McfChecker {
   }
 
   // Used with Template MCF when there are columns from CSV header.
-  public static boolean check(
+  public static boolean checkTemplate(
       Mcf.McfGraph graph, Set<String> columns, ExistenceChecker existenceChecker, LogWrapper logCtx)
       throws IOException, InterruptedException {
     return new McfChecker(graph, columns, existenceChecker, logCtx).check();

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -15,15 +15,14 @@
 package org.datacommons.util;
 
 import com.google.common.base.Charsets;
-import org.datacommons.proto.Debug;
-import org.datacommons.proto.Mcf;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import org.datacommons.proto.Debug;
+import org.datacommons.proto.Mcf;
 
 // Checks common types of nodes on naming and schema requirements.
 //

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -216,6 +216,9 @@ public class McfChecker {
           "Found an unknown statType value :: value: '" + statType + "', node: '" + nodeId + "'",
           node);
     }
+
+    // Every SV must have DCID defined.
+    checkRequiredSingleValueProp(nodeId, node, Vocabulary.STAT_VAR_TYPE, Vocabulary.DCID);
   }
 
   private void checkSVObs(String nodeId, Mcf.McfGraph.PropertyValues node)

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -72,7 +72,7 @@ public class TmcfCsvParser {
     }
     // Check TMCF.
     boolean success =
-        McfChecker.check(
+        McfChecker.checkTemplate(
             tmcfCsvParser.tmcf, tmcfCsvParser.csvParser.getHeaderMap().keySet(), null, logCtx);
     if (!success) {
       // Set location file to make sure log entry refers to the tmcf file.
@@ -207,7 +207,7 @@ public class TmcfCsvParser {
 
         Mcf.McfGraph.PropertyValues newNode = nodeBuilder.build();
         boolean success =
-            McfChecker.check(Mcf.McfType.INSTANCE_MCF, currentNodeId, newNode, logCtx);
+            McfChecker.checkNode(Mcf.McfType.INSTANCE_MCF, currentNodeId, newNode, logCtx);
         if (success) {
           logCtx.incrementCounterBy("NumNodeSuccesses", 1);
           logCtx.incrementCounterBy("NumPVSuccesses", newNode.getPvsCount());

--- a/util/src/test/java/org/datacommons/util/ExistenceCheckerTest.java
+++ b/util/src/test/java/org/datacommons/util/ExistenceCheckerTest.java
@@ -1,5 +1,6 @@
 package org.datacommons.util;
 
+import static org.datacommons.util.LogCb.*;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -8,6 +9,9 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import org.datacommons.proto.Debug;
+import org.datacommons.proto.Mcf;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -29,25 +33,44 @@ public class ExistenceCheckerTest {
     var mockResp = Mockito.mock(HttpResponse.class);
     when(mockHttp.send(any(), any())).thenReturn(mockResp);
 
-    var checker = new ExistenceChecker(mockHttp, false, TestUtil.newLogCtx("inmem"));
+    Debug.Log.Builder lb = Debug.Log.newBuilder();
+    LogWrapper lw = new LogWrapper(lb, Path.of("InMemory"));
+    ExistenceChecker.DC_CALL_BATCH_LIMIT = 1;
 
-    // Caching for miss.
+    var checker = new ExistenceChecker(mockHttp, false, lw);
+
+    assertFalse(TestUtil.checkCounter(lb.build(), "Existence_MissingReference", 1));
+
+    // Non-existing node, response from RPC.
     when(mockResp.body()).thenReturn(NONEXISTING_LAT);
-    assertFalse(checker.checkNode("latitude"));
+    checker.submitNodeCheck("latitude", newLogCb(lw, PREF_KEY, "latitude1"));
     verify(mockHttp, times(1)).send(any(), any());
-    assertFalse(checker.checkNode("latitude"));
-    verify(mockHttp, times(1)).send(any(), any());
+    assertTrue(TestUtil.checkCounter(lb.build(), "Existence_MissingReference", 1));
 
-    // Caching for hit.
+    // Non-existing node must be cached. No further RPCs.
+    checker.submitNodeCheck("latitude", newLogCb(lw, PREF_KEY, "latitude2"));
+    verify(mockHttp, times(1)).send(any(), any());
+    // Two missing-ref counts.
+    assertTrue(TestUtil.checkCounter(lb.build(), "Existence_MissingReference", 2));
+
+    // Existing node, response from RPC.
     when(mockResp.body()).thenReturn(EXISTING_GENDER);
-    assertTrue(checker.checkNode("gender"));
+    checker.submitNodeCheck("gender", newLogCb(lw, PREF_KEY, "gender1"));
     verify(mockHttp, times(2)).send(any(), any());
-    assertTrue(checker.checkNode("gender"));
-    verify(mockHttp, times(2)).send(any(), any());
+    assertTrue(TestUtil.checkCounter(lb.build(), "Existence_MissingReference", 2));
 
-    // Local KG hit.
+    // Existing node must be cached. No further RPCs.
+    checker.submitNodeCheck("gender", newLogCb(lw, PREF_KEY, "gender2"));
+    verify(mockHttp, times(2)).send(any(), any());
+    // Same missing-ref count as before.
+    assertTrue(TestUtil.checkCounter(lb.build(), "Existence_MissingReference", 2));
+
+    // Local KG hit. No further RPCs.
     checker.addLocalGraph(TestUtil.graphFromMcf(LOCAL_KG_NODE));
-    assertTrue(checker.checkNode("latitude"));
+    checker.submitNodeCheck("latitude", newLogCb(lw, PREF_KEY, "latitude3"));
+    verify(mockHttp, times(2)).send(any(), any());
+    // Same missing-ref count as before.
+    assertTrue(TestUtil.checkCounter(lb.build(), "Existence_MissingReference", 2));
   }
 
   @Test
@@ -56,33 +79,99 @@ public class ExistenceCheckerTest {
     var mockResp = Mockito.mock(HttpResponse.class);
     when(mockHttp.send(any(), any())).thenReturn(mockResp);
 
-    var checker = new ExistenceChecker(mockHttp, false, TestUtil.newLogCtx("inmem"));
+    Debug.Log.Builder lb = Debug.Log.newBuilder();
+    LogWrapper lw = new LogWrapper(lb, Path.of("InMemory"));
+    ExistenceChecker.DC_CALL_BATCH_LIMIT = 1;
 
+    var checker = new ExistenceChecker(mockHttp, false, lw);
+
+    assertFalse(TestUtil.checkCounter(lb.build(), "Existence_MissingTriple", 0));
+
+    // Non-existing triple, response from RPC.
     when(mockResp.body()).thenReturn(NONEXISTING_LAT);
-    assertFalse(checker.checkTriple("latitude", "rangeIncludes", "Place"));
-    assertFalse(checker.checkTriple("latitude", "rangeIncludes", "Place"));
+    checker.submitTripleCheck(
+        "latitude", "rangeIncludes", "Place", newLogCb(lw, SUB_KEY, "latitude"));
     verify(mockHttp, times(1)).send(any(), any());
+    assertTrue(TestUtil.checkCounter(lb.build(), "Existence_MissingTriple", 1));
 
+    // Non-existing triple response must be cached. No further RPCs.
+    checker.submitTripleCheck(
+        "latitude", "rangeIncludes", "Place", newLogCb(lw, SUB_KEY, "latitude"));
+    verify(mockHttp, times(1)).send(any(), any());
+    assertTrue(TestUtil.checkCounter(lb.build(), "Existence_MissingTriple", 2));
+
+    // Existing triple, response from RPC.
     when(mockResp.body()).thenReturn(EXISTING_GENDER);
-    assertTrue(checker.checkTriple("gender", "domainIncludes", "Person"));
-    assertTrue(checker.checkTriple("gender", "domainIncludes", "Person"));
+    checker.submitTripleCheck(
+        "gender", "domainIncludes", "Person", newLogCb(lw, SUB_KEY, "gender"));
     verify(mockHttp, times(2)).send(any(), any());
+    assertTrue(TestUtil.checkCounter(lb.build(), "Existence_MissingTriple", 2));
 
-    // Local KG hit.
+    // Existing triple again, must be cached.
+    when(mockResp.body()).thenReturn(EXISTING_GENDER);
+    checker.submitTripleCheck(
+        "gender", "domainIncludes", "Person", newLogCb(lw, SUB_KEY, "gender"));
+    verify(mockHttp, times(2)).send(any(), any());
+    assertTrue(TestUtil.checkCounter(lb.build(), "Existence_MissingTriple", 2));
+
+    // Local KG hit. Must be cached.
     checker.addLocalGraph(TestUtil.graphFromMcf(LOCAL_KG_NODE));
-    assertTrue(checker.checkTriple("latitude", "rangeIncludes", "Place"));
+    checker.submitTripleCheck(
+        "latitude", "rangeIncludes", "Place", newLogCb(lw, SUB_KEY, "latitude"));
+    verify(mockHttp, times(2)).send(any(), any());
+    assertTrue(TestUtil.checkCounter(lb.build(), "Existence_MissingTriple", 2));
   }
 
   @Test
   public void endToEnd() throws IOException, InterruptedException {
-    var checker =
-        new ExistenceChecker(HttpClient.newHttpClient(), false, TestUtil.newLogCtx("inmem"));
-    assertTrue(checker.checkNode("gender"));
-    assertFalse(checker.checkNode("Nope"));
-    assertTrue(checker.checkTriple("gender", "domainIncludes", "Person"));
-    assertTrue(checker.checkTriple("gender", "rangeIncludes", "GenderType"));
-    assertTrue(checker.checkNode("Count_Person"));
-    assertTrue(checker.checkNode("minimumWage"));
-    assertFalse(checker.checkNode("UnemploymentRate")); // must be unemploymentRate
+    var dummyNode = Mcf.McfGraph.PropertyValues.newBuilder().build();
+    Debug.Log.Builder lb = Debug.Log.newBuilder();
+    LogWrapper lw = new LogWrapper(lb, Path.of("InMemory"));
+    ExistenceChecker.DC_CALL_BATCH_LIMIT = 5;
+
+    var checker = new ExistenceChecker(HttpClient.newHttpClient(), false, lw);
+
+    // Ref 1. Exists
+    checker.submitNodeCheck("gender", newLogCb(lw, VREF_KEY, "gender"));
+    // Ref 2. Missing
+    checker.submitNodeCheck("Nope", newLogCb(lw, VREF_KEY, "Nope"));
+    // Tripe. Exists
+    checker.submitTripleCheck(
+        "gender", "domainIncludes", "Person", newLogCb(lw, PRED_KEY, "domainIncludes"));
+    // Triple. Exists
+    checker.submitTripleCheck(
+        "gender", "rangeIncludes", "GenderType", newLogCb(lw, PRED_KEY, "rangeIncludes"));
+    // Triple. Missing
+    checker.submitTripleCheck(
+        "gender", "subPropertyOf", "notReally", newLogCb(lw, PRED_KEY, "subPropertyOf"));
+    // Ref 3. Exists
+    checker.submitNodeCheck("Count_Person", newLogCb(lw, VREF_KEY, "Count_Person"));
+    // Ref 4. Exists
+    checker.submitNodeCheck("minimumWage", newLogCb(lw, VREF_KEY, "minimumWage"));
+
+    // Up till this point no call should have been made.
+    assertFalse(TestUtil.checkCounter(lb.build(), "Existence_MissingTriple", 1));
+    assertFalse(TestUtil.checkCounter(lb.build(), "Existence_MissingReference", 1));
+
+    // Ref 5. Missing
+    checker.submitNodeCheck("UnemploymentRate", newLogCb(lw, VREF_KEY, "UnemploymentRate"));
+
+    // Since we have issued 5 ref-checks (all, typeOf), we should now see 2 missing refs.
+    assertFalse(TestUtil.checkCounter(lb.build(), "Existence_MissingTriple", 1));
+    assertTrue(TestUtil.checkCounter(lb.build(), "Existence_MissingReference", 2));
+
+    // After we drain all, we should see the one missing triple.
+    checker.drainRemoteCalls();
+    assertTrue(TestUtil.checkCounter(lb.build(), "Existence_MissingTriple", 1));
+
+    // Lets also confirm the exact missing ones.
+    assertTrue(TestUtil.checkLog(lb.build(), "Existence_MissingReference", "Nope"));
+    assertTrue(TestUtil.checkLog(lb.build(), "Existence_MissingReference", "UnemploymentRate"));
+    assertTrue(TestUtil.checkLog(lb.build(), "Existence_MissingTriple", "subPropertyOf"));
+  }
+
+  private static LogCb newLogCb(LogWrapper lw, String key, String value) {
+    var dummyNode = Mcf.McfGraph.PropertyValues.newBuilder().build();
+    return new LogCb(lw, Debug.Log.Level.LEVEL_WARNING, dummyNode).setDetail(key, value);
   }
 }

--- a/util/src/test/java/org/datacommons/util/McfCheckerTest.java
+++ b/util/src/test/java/org/datacommons/util/McfCheckerTest.java
@@ -14,16 +14,17 @@
 
 package org.datacommons.util;
 
-import static org.junit.Assert.assertTrue;
+import org.datacommons.proto.Debug;
+import org.datacommons.proto.Mcf;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
-import org.datacommons.proto.Debug;
-import org.datacommons.proto.Mcf;
-import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 public class McfCheckerTest {
 
@@ -181,6 +182,7 @@ public class McfCheckerTest {
         "Node: SV\n"
             + "typeOf: schema:StatisticalVariable\n"
             + "measuredProperty: dcs:count\n"
+            + "dcid: \"Count_Person\"\n"
             + "statType: dcs:measuredValue";
     assertTrue(
         failure(
@@ -194,6 +196,7 @@ public class McfCheckerTest {
             + "typeOf: schema:StatisticalVariable\n"
             + "populationType: dcs:person\n"
             + "measuredProperty: dcs:count\n"
+            + "dcid: \"Count_Person\"\n"
             + "statType: dcs:measuredValue";
     assertTrue(failure(mcf, "Sanity_NotInitUpper_populationType", "person"));
 
@@ -202,6 +205,7 @@ public class McfCheckerTest {
         "Node: SV\n"
             + "typeOf: schema:StatisticalVariable\n"
             + "populationType: schema:Person\n"
+            + "dcid: \"Count_Person\"\n"
             + "statType: dcs:measuredValue";
     assertTrue(
         failure(mcf, "Sanity_MissingOrEmpty_measuredProperty", "'measuredProperty', node: 'SV'"));
@@ -212,6 +216,7 @@ public class McfCheckerTest {
             + "typeOf: schema:StatisticalVariable\n"
             + "populationType: schema:Person\n"
             + "statType: dcs:measuredValue\n"
+            + "dcid: \"Income_Person\"\n"
             + "measuredProperty: dcs:Income";
     assertTrue(failure(mcf, "Sanity_NotInitLower_measuredProperty", "Income"));
 
@@ -221,8 +226,18 @@ public class McfCheckerTest {
             + "typeOf: schema:StatisticalVariable\n"
             + "populationType: schema:Person\n"
             + "statType: dcs:projection\n"
+            + "dcid: \"Income_Person\"\n"
             + "measuredProperty: dcs:income";
     assertTrue(failure(mcf, "Sanity_UnknownStatType", "projection"));
+
+    // Missing DCID
+    mcf =
+        "Node: SV\n"
+            + "typeOf: schema:StatisticalVariable\n"
+            + "populationType: schema:Person\n"
+            + "statType: dcs:measuredValue\n"
+            + "measuredProperty: dcs:income";
+    assertTrue(failure(mcf, "Sanity_MissingOrEmpty_dcid", "SV"));
   }
 
   @Test

--- a/util/src/test/java/org/datacommons/util/McfCheckerTest.java
+++ b/util/src/test/java/org/datacommons/util/McfCheckerTest.java
@@ -587,7 +587,7 @@ public class McfCheckerTest {
     } else {
       graph = McfParser.parseInstanceMcfString(mcfString, false, lw);
     }
-    if (McfChecker.check(graph, columns, ec, lw) && !doExistenceCheck) {
+    if (McfChecker.checkTemplate(graph, columns, ec, lw) && !doExistenceCheck) {
       System.err.println("Check unexpectedly passed for " + mcfString);
       return false;
     }
@@ -617,7 +617,7 @@ public class McfCheckerTest {
     if (doExistenceCheck) {
       ec = new ExistenceChecker(HttpClient.newHttpClient(), false, lw);
     }
-    if (!McfChecker.check(graph, columns, ec, lw)) {
+    if (!McfChecker.checkTemplate(graph, columns, ec, lw)) {
       System.err.println("Check unexpectedly failed for \n" + mcfString + "\n :: \n" + log);
       return false;
     }


### PR DESCRIPTION
Previously, we relied only on caching prior checks. But each DC call from India takes ~250ms, so ~5K calls (e.g., to validate [all SVs](https://github.com/datacommonsorg/schema/tree/main/stat_vars)), which takes 5m from my laptop (and 2m from cloud-top), takes 20m from India.

With this change, we first collect checks (along with a callback) to batch and invoke DC calls when we have collected enough. The same SV validation now takes ~8s and makes 53 calls (see screenshot).

Additional changes:
1. Add a check that all stat-vars include a DCID.  We could in theory have StatVars without DCID and we compute it, but in practice we don't.  This tripped @ajaits.
2. Fix minor regression introduced [here](https://github.com/datacommonsorg/import/pull/34/files#diff-368ed99815e72875840d6857e431260a508c7f7fa7f6a375d45d2b12365eb99dL104-L107).

![Screen Shot 2021-09-03 at 9 04 36 AM](https://user-images.githubusercontent.com/4375037/132035045-7a0524b3-9578-4fbf-ba91-d314dc5a6111.png)
