### PR TITLE
Improve existence-check batching and resolution usability

### DIFF
--- a/tool/src/main/java/org/datacommons/tool/GenMcf.java
+++ b/tool/src/main/java/org/datacommons/tool/GenMcf.java
@@ -58,16 +58,7 @@ class GenMcf implements Callable<Integer> {
     }
     Processor.Args args = new Processor.Args();
     args.doExistenceChecks = parent.doExistenceChecks;
-    if (parent.localResolution && parent.fullResolution) {
-      throw new IllegalArgumentException("Cannot set both -f " + "and -l");
-    }
-    if (parent.fullResolution) {
-      args.resolutionMode = Processor.ResolutionMode.FULL;
-    } else if (parent.localResolution) {
-      args.resolutionMode = Processor.ResolutionMode.LOCAL;
-    } else {
-      args.resolutionMode = Processor.ResolutionMode.NONE;
-    }
+    args.resolutionMode = parent.resolutionMode;
     args.verbose = parent.verbose;
     args.fileGroup = FileGroup.build(files, spec, delimiter, logger);
     args.logCtx = new LogWrapper(Debug.Log.newBuilder(), parent.outputDir.toPath());

--- a/tool/src/main/java/org/datacommons/tool/GenMcf.java
+++ b/tool/src/main/java/org/datacommons/tool/GenMcf.java
@@ -58,7 +58,16 @@ class GenMcf implements Callable<Integer> {
     }
     Processor.Args args = new Processor.Args();
     args.doExistenceChecks = parent.doExistenceChecks;
-    args.doResolution = parent.doResolution;
+    if (parent.localResolution && parent.fullResolution) {
+      throw new IllegalArgumentException("Cannot set both -f " + "and -l");
+    }
+    if (parent.fullResolution) {
+      args.resolutionMode = Processor.ResolutionMode.FULL;
+    } else if (parent.localResolution) {
+      args.resolutionMode = Processor.ResolutionMode.LOCAL;
+    } else {
+      args.resolutionMode = Processor.ResolutionMode.NONE;
+    }
     args.verbose = parent.verbose;
     args.fileGroup = FileGroup.build(files, spec, delimiter, logger);
     args.logCtx = new LogWrapper(Debug.Log.newBuilder(), parent.outputDir.toPath());

--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -14,16 +14,15 @@
 
 package org.datacommons.tool;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.Callable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.datacommons.proto.Debug;
 import org.datacommons.util.FileGroup;
 import org.datacommons.util.LogWrapper;
 import picocli.CommandLine;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.concurrent.Callable;
 
 @CommandLine.Command(name = "lint", description = "Run various checks on input MCF/TMCF/CSV files")
 class Lint implements Callable<Integer> {

--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -14,15 +14,16 @@
 
 package org.datacommons.tool;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.concurrent.Callable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.datacommons.proto.Debug;
 import org.datacommons.util.FileGroup;
 import org.datacommons.util.LogWrapper;
 import picocli.CommandLine;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.Callable;
 
 @CommandLine.Command(name = "lint", description = "Run various checks on input MCF/TMCF/CSV files")
 class Lint implements Callable<Integer> {
@@ -56,16 +57,7 @@ class Lint implements Callable<Integer> {
     }
     Processor.Args args = new Processor.Args();
     args.doExistenceChecks = parent.doExistenceChecks;
-    if (parent.localResolution && parent.fullResolution) {
-      throw new IllegalArgumentException("Cannot set both -f " + "and -l");
-    }
-    if (parent.fullResolution) {
-      args.resolutionMode = Processor.ResolutionMode.FULL;
-    } else if (parent.localResolution) {
-      args.resolutionMode = Processor.ResolutionMode.LOCAL;
-    } else {
-      args.resolutionMode = Processor.ResolutionMode.NONE;
-    }
+    args.resolutionMode = parent.resolutionMode;
     args.verbose = parent.verbose;
     args.fileGroup = FileGroup.build(files, spec, delimiter, logger);
     args.logCtx = new LogWrapper(Debug.Log.newBuilder(), parent.outputDir.toPath());

--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -56,7 +56,16 @@ class Lint implements Callable<Integer> {
     }
     Processor.Args args = new Processor.Args();
     args.doExistenceChecks = parent.doExistenceChecks;
-    args.doResolution = parent.doResolution;
+    if (parent.localResolution && parent.fullResolution) {
+      throw new IllegalArgumentException("Cannot set both -f " + "and -l");
+    }
+    if (parent.fullResolution) {
+      args.resolutionMode = Processor.ResolutionMode.FULL;
+    } else if (parent.localResolution) {
+      args.resolutionMode = Processor.ResolutionMode.LOCAL;
+    } else {
+      args.resolutionMode = Processor.ResolutionMode.NONE;
+    }
     args.verbose = parent.verbose;
     args.fileGroup = FileGroup.build(files, spec, delimiter, logger);
     args.logCtx = new LogWrapper(Debug.Log.newBuilder(), parent.outputDir.toPath());

--- a/tool/src/main/java/org/datacommons/tool/Main.java
+++ b/tool/src/main/java/org/datacommons/tool/Main.java
@@ -14,9 +14,8 @@
 
 package org.datacommons.tool;
 
-import picocli.CommandLine;
-
 import java.io.File;
+import picocli.CommandLine;
 
 @CommandLine.Command(
     name = "dc-import",

--- a/tool/src/main/java/org/datacommons/tool/Main.java
+++ b/tool/src/main/java/org/datacommons/tool/Main.java
@@ -52,11 +52,22 @@ class Main {
 
   // TODO: Default to true after some trials.
   @CommandLine.Option(
-      names = {"-r", "--resolution"},
+      names = {"-r", "--full-resolution"},
       defaultValue = "false",
       scope = CommandLine.ScopeType.INHERIT,
-      description = "Resolves local references and generates node DCIDs.")
-  public boolean doResolution;
+      description =
+          "Resolves external IDs, local references and generates node DCIDs. "
+              + "Mutually exclusive with -l.")
+  public boolean fullResolution;
+
+  @CommandLine.Option(
+      names = {"-l", "--local-resolution"},
+      defaultValue = "false",
+      scope = CommandLine.ScopeType.INHERIT,
+      description =
+          "Resolves local references and generates node DCIDs (without Recon API). "
+              + "Mutually exclusive with -r.")
+  public boolean localResolution;
 
   public static void main(String... args) {
     System.exit(new CommandLine(new Main()).execute(args));

--- a/tool/src/main/java/org/datacommons/tool/Main.java
+++ b/tool/src/main/java/org/datacommons/tool/Main.java
@@ -14,8 +14,9 @@
 
 package org.datacommons.tool;
 
-import java.io.File;
 import picocli.CommandLine;
+
+import java.io.File;
 
 @CommandLine.Command(
     name = "dc-import",
@@ -47,29 +48,24 @@ class Main {
       description =
           "Check DCID references to schema nodes against the KG and locally. If set, then "
               + "calls will be made to the Staging API server, and instance MCFs get fully "
-              + "loaded into memory.")
+              + "loaded into memory. Defaults to true.")
   public boolean doExistenceChecks;
 
-  // TODO: Default to true after some trials.
+  // TODO: Default to LOCAL after some trials.
   @CommandLine.Option(
-      names = {"-r", "--full-resolution"},
-      defaultValue = "false",
+      names = {"-r", "--resolution"},
+      defaultValue = "NONE",
       scope = CommandLine.ScopeType.INHERIT,
       description =
-          "Resolves external IDs, local references and generates node DCIDs. "
-              + "Mutually exclusive with -l.")
-  public boolean fullResolution;
-
-  @CommandLine.Option(
-      names = {"-l", "--local-resolution"},
-      defaultValue = "false",
-      scope = CommandLine.ScopeType.INHERIT,
-      description =
-          "Resolves local references and generates node DCIDs (without Recon API). "
-              + "Mutually exclusive with -r.")
-  public boolean localResolution;
+          "Specifies the mode of resolution to use: ${COMPLETION-CANDIDATES}.  For no resolution,"
+              + " set NONE.  To lookup external IDs (like ISO) in DC, resolve local references "
+              + "and generated DCIDs, set FULL.  To just resolve local references and generate "
+              + "DCIDs, set LOCAL.  Note that FULL mode may be slower since it makes "
+              + "(batched) DC Recon API calls and two passes over your CSV files. Default to NONE.")
+  public Processor.ResolutionMode resolutionMode = Processor.ResolutionMode.NONE;
 
   public static void main(String... args) {
-    System.exit(new CommandLine(new Main()).execute(args));
+    System.exit(
+        new CommandLine(new Main()).setCaseInsensitiveEnumValuesAllowed(true).execute(args));
   }
 }

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -79,7 +79,7 @@ public class Processor {
 
       // Load all the instance MCFs into memory, so we can do existence checks, resolution, etc.
       if (args.doExistenceChecks) {
-        logger.info("Loading Instance MCF files");
+        logger.info("Loading Instance MCF files into memory");
       } else {
         logger.info("Loading and Checking Instance MCF files");
       }
@@ -87,7 +87,7 @@ public class Processor {
 
       // Perform existence checks.
       if (args.doExistenceChecks) {
-        logger.info("Checking Instance MCF nodes (with Existence)");
+        logger.info("Checking Instance MCF nodes (with Existence checks)");
         // NOTE: If doExistenceChecks is true, we do a checkNodes() call *after* all instance MCF
         // files are processed (via processNodes). This is so that the newly added schema, StatVar,
         // etc. are known to the Existence Checker first, before existence checks are performed.
@@ -232,7 +232,7 @@ public class Processor {
       }
       logger.info(
           "Checked "
-              + (resolutionMode != ResolutionMode.NONE ? ", Resolved " : "")
+              + (resolutionMode != ResolutionMode.NONE ? "and Resolved " : "")
               + "CSV {} ({}"
               + " rows, {} nodes)",
           csvFile.getName(),
@@ -329,7 +329,7 @@ public class Processor {
     var writer = writers.getOrDefault(type, null);
     if (writer == null) {
       var fileString = outputFiles.get(type).toString();
-      logger.info("Opening file " + fileString + " of type " + type.name());
+      logger.info("Opening output file " + fileString + " of type " + type.name());
       writer = new BufferedWriter(new FileWriter(fileString));
       writers.put(type, writer);
     }

--- a/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
+++ b/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
@@ -60,7 +60,7 @@ public class GenMcfTest {
       for (File inputFile : inputFiles) {
         argsList.add(inputFile.getPath());
       }
-      argsList.add("--full-resolution");
+      argsList.add("--resolution=FULL");
       argsList.add(
           "--output-dir=" + Paths.get(testFolder.getRoot().getPath(), directory.getName()));
       String[] args = argsList.toArray(new String[argsList.size()]);

--- a/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
+++ b/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
@@ -60,7 +60,7 @@ public class GenMcfTest {
       for (File inputFile : inputFiles) {
         argsList.add(inputFile.getPath());
       }
-      argsList.add("--resolution");
+      argsList.add("--full-resolution");
       argsList.add(
           "--output-dir=" + Paths.get(testFolder.getRoot().getPath(), directory.getName()));
       String[] args = argsList.toArray(new String[argsList.size()]);

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/report.json
@@ -115,14 +115,6 @@
       "file": "FatalTmcf.tmcf",
       "lineNumber": "19"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_TmcfMissingEntityDef"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "FatalTmcf.tmcf",
-      "lineNumber": "19"
-    },
     "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E10', property: 'dcid' node: 'E:SVTest->E3'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
@@ -133,6 +125,14 @@
     },
     "userMessage": "Column referred to in TMCF is missing from CSV header :: column: 'dcid1', node: 'E:SVTest->E3'",
     "counterKey": "Sanity_TmcfMissingColumn"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "FatalTmcf.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",
     "location": {

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/report.json
@@ -13,7 +13,6 @@
     "LEVEL_ERROR": {
       "counters": {
         "Sanity_MissingOrEmpty_statType": "1",
-        "Sanity_UnknownStatType": "1",
         "Sanity_MissingOrEmpty_dcid": "1",
         "Resolution_OrphanLocalReference_parent": "1",
         "Resolution_DcidAssignmentFailure_Song": "1",
@@ -37,14 +36,6 @@
     },
     "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'SVId', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_statType"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "misc.mcf",
-      "lineNumber": "15"
-    },
-    "userMessage": "Found an unknown statType value :: value: '', node: 'SVId'",
-    "counterKey": "Sanity_UnknownStatType"
   }, {
     "level": "LEVEL_ERROR",
     "location": {

--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
@@ -23,7 +23,6 @@
         "Sanity_MissingOrEmpty_populationType": "2",
         "Sanity_MissingOrEmpty_measuredProperty": "1",
         "Sanity_MissingOrEmpty_statType": "1",
-        "Sanity_UnknownStatType": "1",
         "Sanity_NotInitLowerPropName": "1",
         "Sanity_InvalidChars_domainIncludes": "1",
         "Sanity_UnexpectedPropInProperty": "1",
@@ -261,14 +260,6 @@
     },
     "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_statType"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Found an unknown statType value :: value: '', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "Sanity_UnknownStatType"
   }, {
     "level": "LEVEL_ERROR",
     "location": {

--- a/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
@@ -23,7 +23,6 @@
         "Sanity_MissingOrEmpty_populationType": "2",
         "Sanity_MissingOrEmpty_measuredProperty": "1",
         "Sanity_MissingOrEmpty_statType": "1",
-        "Sanity_UnknownStatType": "1",
         "Sanity_NotInitLowerPropName": "1",
         "Sanity_InvalidChars_domainIncludes": "1",
         "Sanity_UnexpectedPropInProperty": "1",
@@ -246,14 +245,6 @@
     },
     "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_statType"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Found an unknown statType value :: value: '', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "Sanity_UnknownStatType"
   }, {
     "level": "LEVEL_ERROR",
     "location": {

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
@@ -23,7 +23,6 @@
         "Sanity_MissingOrEmpty_populationType": "2",
         "Sanity_MissingOrEmpty_measuredProperty": "1",
         "Sanity_MissingOrEmpty_statType": "1",
-        "Sanity_UnknownStatType": "1",
         "Sanity_NotInitLowerPropName": "2",
         "Sanity_InvalidChars_domainIncludes": "1",
         "Sanity_UnexpectedPropInProperty": "1",
@@ -253,14 +252,6 @@
     },
     "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
     "counterKey": "Sanity_MissingOrEmpty_statType"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Found an unknown statType value :: value: '', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "Sanity_UnknownStatType"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -515,7 +506,7 @@
       "file": "NoCsv.tmcf",
       "lineNumber": "3"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E3', property: 'observationAbout' node: 'E:SVTest->E0'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E30', property: 'observationAbout' node: 'E:SVTest->E0'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",
@@ -523,7 +514,7 @@
       "file": "NoCsv.tmcf",
       "lineNumber": "3"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E30', property: 'observationAbout' node: 'E:SVTest->E0'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E3', property: 'observationAbout' node: 'E:SVTest->E0'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",
@@ -579,7 +570,7 @@
       "file": "NoCsv.tmcf",
       "lineNumber": "19"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E10', property: 'dcid' node: 'E:SVTest->E3'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",
@@ -587,7 +578,7 @@
       "file": "NoCsv.tmcf",
       "lineNumber": "19"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E10', property: 'dcid' node: 'E:SVTest->E3'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",

--- a/util/src/main/java/org/datacommons/util/DcidGenerator.java
+++ b/util/src/main/java/org/datacommons/util/DcidGenerator.java
@@ -4,7 +4,6 @@ import static org.datacommons.util.Vocabulary.*;
 
 import com.google.common.base.Charsets;
 import com.google.common.hash.Hashing;
-import java.nio.file.Path;
 import java.util.*;
 import org.datacommons.proto.Debug;
 import org.datacommons.proto.Mcf;
@@ -116,8 +115,7 @@ public class DcidGenerator {
   static final int LAST_REQUIRED_LEGACY_OBS_PROP_INDEX =
       ORDERED_LEGACY_OBS_KEY_PROPS.indexOf(Vocabulary.MEASURED_PROP);
 
-  private static final LogWrapper dummyLogCtx =
-      new LogWrapper(Debug.Log.newBuilder(), Path.of("/tmp/report.html"));
+  private static final LogWrapper dummyLogCtx = new LogWrapper(Debug.Log.newBuilder());
 
   public static class Result {
     // The dcid will be empty if there were any errors in the node. These should have been

--- a/util/src/main/java/org/datacommons/util/ExternalIdResolver.java
+++ b/util/src/main/java/org/datacommons/util/ExternalIdResolver.java
@@ -209,7 +209,9 @@ public class ExternalIdResolver {
         continue;
       }
       var parts = entity.getSourceId().split(":", 2);
-      if (parts.length != 2 || entity.getResolvedIdsCount() != 1) {
+      // TODO: Add back the (entity.getResolvedIdsCount() == 1) assertion after
+      // https://github.com/datacommonsorg/reconciliation/issues/15 is fixed.
+      if (parts.length != 2) {
         throw new InvalidProtocolBufferException(
             "Malformed ResolveEntitiesResponse.ResolvedEntity " + entity);
       }

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -17,6 +17,7 @@ package org.datacommons.util;
 import static org.datacommons.proto.Debug.Log.Level.LEVEL_FATAL;
 import static org.datacommons.proto.Debug.Log.Level.LEVEL_INFO;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -45,20 +46,33 @@ public class LogWrapper {
   public static boolean TEST_MODE = false;
 
   private final Debug.Log.Builder log;
-  private final Path logPath;
+  private Path logPath;
   private String locationFile;
   private Instant lastStatusAt;
   private long countAtLastStatus;
-  private final Set<String> countersWithErrors;
+  private final Set<String> countersWithErrors = new HashSet<>();
+  public final boolean persistLog;
 
   public LogWrapper(Debug.Log.Builder log, Path outputDir) {
     this.log = log;
-    this.countersWithErrors = new HashSet<>();
-    logPath = Paths.get(outputDir.toString(), REPORT_JSON);
-    logger.info(
-        "Report written every {}s to {}",
-        SECONDS_BETWEEN_STATUS,
-        logPath.toAbsolutePath().normalize().toString());
+    this.persistLog = true;
+    init(log, outputDir);
+  }
+
+  public LogWrapper(Debug.Log.Builder log) {
+    this.log = log;
+    this.persistLog = false;
+    init(log, null);
+  }
+
+  private void init(Debug.Log.Builder log, Path outputDir) {
+    if (persistLog) {
+      logPath = Paths.get(outputDir.toString(), REPORT_JSON);
+      logger.info(
+          "Report written every {}s to {}",
+          SECONDS_BETWEEN_STATUS,
+          logPath.toAbsolutePath().normalize().toString());
+    }
     locationFile = "FileNotSet.idk";
     lastStatusAt = Instant.now();
     countAtLastStatus = 0;
@@ -106,7 +120,7 @@ public class LogWrapper {
         logger.info(
             "{} {} of {} [{}]", count - countAtLastStatus, thing, locationFile, summaryString());
       }
-      persistLog(true);
+      if (persistLog) persistLog(true);
       lastStatusAt = now;
       countAtLastStatus = count;
     }
@@ -121,6 +135,10 @@ public class LogWrapper {
           logPath.toAbsolutePath().normalize().toString(),
           summaryString());
     }
+  }
+
+  public String dumpLog() throws InvalidProtocolBufferException {
+    return StringUtil.msgToJson(log.build());
   }
 
   public boolean loggedTooManyFailures() {

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -69,9 +69,7 @@ public class LogWrapper {
     if (persistLog) {
       logPath = Paths.get(outputDir.toString(), REPORT_JSON);
       logger.info(
-          "Report written every {}s to {}",
-          SECONDS_BETWEEN_STATUS,
-          logPath.toAbsolutePath().normalize().toString());
+          "Report written periodically to {}", logPath.toAbsolutePath().normalize().toString());
     }
     locationFile = "FileNotSet.idk";
     lastStatusAt = Instant.now();

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -186,12 +186,16 @@ public class McfChecker {
     String popType =
         checkRequiredSingleValueProp(
             nodeId, node, Vocabulary.STAT_VAR_TYPE, Vocabulary.POPULATION_TYPE);
-    checkInitCasing(nodeId, node, Vocabulary.POPULATION_TYPE, popType, "", true);
+    if (!popType.isEmpty()) {
+      checkInitCasing(nodeId, node, Vocabulary.POPULATION_TYPE, popType, "", true);
+    }
 
     String mProp =
         checkRequiredSingleValueProp(
             nodeId, node, Vocabulary.STAT_VAR_TYPE, Vocabulary.MEASURED_PROP);
-    checkInitCasing(nodeId, node, Vocabulary.MEASURED_PROP, mProp, "", false);
+    if (!mProp.isEmpty()) {
+      checkInitCasing(nodeId, node, Vocabulary.MEASURED_PROP, mProp, "", false);
+    }
     // TODO: Do this check for all constraint properties too.
     if (existenceChecker != null) {
       LogCb logCb =
@@ -206,7 +210,8 @@ public class McfChecker {
 
     String statType =
         checkRequiredSingleValueProp(nodeId, node, Vocabulary.STAT_VAR_TYPE, Vocabulary.STAT_TYPE);
-    if (!Vocabulary.isStatValueProperty(statType)
+    if (!statType.isEmpty()
+        && !Vocabulary.isStatValueProperty(statType)
         && !statType.equals(Vocabulary.MEASUREMENT_RESULT)) {
       addLog(
           "Sanity_UnknownStatType",
@@ -253,7 +258,9 @@ public class McfChecker {
     String popType =
         checkRequiredSingleValueProp(
             nodeId, node, "StatisticalPopulation", Vocabulary.POPULATION_TYPE);
-    checkInitCasing(nodeId, node, Vocabulary.POPULATION_TYPE, popType, "", true);
+    if (!popType.isEmpty()) {
+      checkInitCasing(nodeId, node, Vocabulary.POPULATION_TYPE, popType, "", true);
+    }
 
     checkRequiredSingleValueProp(nodeId, node, "StatisticalPopulation", Vocabulary.LOCATION);
   }
@@ -262,7 +269,9 @@ public class McfChecker {
     String mProp =
         checkRequiredSingleValueProp(
             nodeId, node, Vocabulary.LEGACY_OBSERVATION_TYPE_SUFFIX, Vocabulary.MEASURED_PROP);
-    checkInitCasing(nodeId, node, Vocabulary.MEASURED_PROP, mProp, "", false);
+    if (!mProp.isEmpty()) {
+      checkInitCasing(nodeId, node, Vocabulary.MEASURED_PROP, mProp, "", false);
+    }
 
     checkRequiredSingleValueProp(
         nodeId, node, Vocabulary.LEGACY_OBSERVATION_TYPE_SUFFIX, Vocabulary.OBSERVED_NODE);

--- a/util/src/main/java/org/datacommons/util/TestUtil.java
+++ b/util/src/main/java/org/datacommons/util/TestUtil.java
@@ -18,7 +18,6 @@ import com.google.protobuf.TextFormat;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
@@ -29,7 +28,7 @@ import org.datacommons.proto.Mcf;
 public class TestUtil {
   public static LogWrapper newLogCtx(String mcfFile) {
     Debug.Log.Builder log = Debug.Log.newBuilder();
-    LogWrapper logCtx = new LogWrapper(log, Path.of("/tmp/report.html"));
+    LogWrapper logCtx = new LogWrapper(log);
     logCtx.setLocationFile(mcfFile);
     return logCtx;
   }


### PR DESCRIPTION
1. Use POST requests and increase existence-check batching by 10x (largely for India latencies)
2. Add more log messages for resolution flow
3. Add a LOCAL resolution mode where we don't need two passes, or recon calls
4. Fix some double-counting bugs in McfChecker lib