### PR TITLE
Update html file comparison in e2e tests

### DIFF
--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -80,6 +80,13 @@
             <artifactId>guava</artifactId>
             <version>25.1-jre</version>
         </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.14.3</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
+++ b/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
@@ -115,7 +115,7 @@ public class GenMcfTest {
             TestUtil.assertReportFilesAreSimilar(
                 expect, TestUtil.readStringFromPath(expected), TestUtil.readStringFromPath(actual));
           } else if (f.equals("summary_report.html")) {
-            assertEquals(
+            TestUtil.assertHtmlFilesAreSimilar(
                 TestUtil.readStringFromPath(expected), TestUtil.readStringFromPath(actual));
           } else {
             assertEquals(

--- a/tool/src/test/java/org/datacommons/tool/LintTest.java
+++ b/tool/src/test/java/org/datacommons/tool/LintTest.java
@@ -1,7 +1,6 @@
 package org.datacommons.tool;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static org.junit.Assert.assertEquals;
 
 import com.google.common.truth.Expect;
 import java.io.File;
@@ -71,8 +70,8 @@ public class LintTest {
           if (f.equals("report.json")) {
             TestUtil.assertReportFilesAreSimilar(
                 expect, TestUtil.readStringFromPath(expected), TestUtil.readStringFromPath(actual));
-          } else {
-            assertEquals(
+          } else if (f.equals("summary_report.html")) {
+            TestUtil.assertHtmlFilesAreSimilar(
                 TestUtil.readStringFromPath(expected), TestUtil.readStringFromPath(actual));
           }
         }

--- a/tool/src/test/java/org/datacommons/tool/TestUtil.java
+++ b/tool/src/test/java/org/datacommons/tool/TestUtil.java
@@ -35,6 +35,8 @@ import org.junit.rules.TemporaryFolder;
 
 // Common set of utils used in e2e tests.
 public class TestUtil {
+  private static String EMPTY_TEXT_HTML_ELEMENT_STRING = "<ELEMENT WITHOUT TEXT>";
+
   public static void assertReportFilesAreSimilar(Expect expect, String expected, String actual)
       throws IOException {
     Debug.Log expectedLog = reportToProto(expected).build();
@@ -81,20 +83,30 @@ public class TestUtil {
     Document actualHtml = htmlParser.parseInput(actual, "actual");
     LinkedList<Element> expectedElements = new LinkedList<>(expectedHtml.children());
     LinkedList<Element> actualElements = new LinkedList<>(actualHtml.children());
+    // Create a string with all the text from all the elements in the expectedHtml file. If an
+    // element has no text, append a default string.
     StringBuilder expectedHtmlText = new StringBuilder();
-    StringBuilder actualHtmlText = new StringBuilder();
-    while (!expectedElements.isEmpty() && !actualElements.isEmpty()) {
+    while (!expectedElements.isEmpty()) {
       Element expectedElement = expectedElements.poll();
-      Element actualElement = actualElements.poll();
       expectedElements.addAll(expectedElement.children());
-      actualElements.addAll(actualElement.children());
-      expectedHtmlText.append(expectedElement.ownText());
-      actualHtmlText.append(actualElement.ownText());
+      if (expectedElement.ownText().isEmpty()) {
+        expectedHtmlText.append(EMPTY_TEXT_HTML_ELEMENT_STRING);
+      } else {
+        expectedHtmlText.append(expectedElement.ownText());
+      }
     }
-    assertTrue(
-        "Actual HTML file contains additional elements that were not expected",
-        expectedElements.isEmpty());
-    assertTrue("Actual HTML file is missing some expected elements", actualElements.isEmpty());
+    // Create a string with all the text from all the elements in the actualHtml file. If an element
+    // has no text, append a default string.
+    StringBuilder actualHtmlText = new StringBuilder();
+    while (!actualElements.isEmpty()) {
+      Element actualElement = actualElements.poll();
+      actualElements.addAll(actualElement.children());
+      if (actualElement.ownText().isEmpty()) {
+        actualHtmlText.append(EMPTY_TEXT_HTML_ELEMENT_STRING);
+      } else {
+        actualHtmlText.append(actualElement.ownText());
+      }
+    }
     assertEquals(
         "The text content of the actual HTML file differed from expected",
         expectedHtmlText.toString(),

--- a/tool/src/test/java/org/datacommons/tool/TestUtil.java
+++ b/tool/src/test/java/org/datacommons/tool/TestUtil.java
@@ -81,21 +81,23 @@ public class TestUtil {
     Document actualHtml = htmlParser.parseInput(actual, "actual");
     LinkedList<Element> expectedElements = new LinkedList<>(expectedHtml.children());
     LinkedList<Element> actualElements = new LinkedList<>(actualHtml.children());
+    StringBuilder expectedHtmlText = new StringBuilder();
+    StringBuilder actualHtmlText = new StringBuilder();
     while (!expectedElements.isEmpty() && !actualElements.isEmpty()) {
       Element expectedElement = expectedElements.poll();
       Element actualElement = actualElements.poll();
       expectedElements.addAll(expectedElement.children());
       actualElements.addAll(actualElement.children());
-      String expectedElementText = expectedElement.ownText();
-      String actualElementText = actualElement.ownText();
-      assertEquals(
-          "Actual HTML file has an element that differs in text content from what is expected",
-          expectedElementText,
-          actualElementText);
+      expectedHtmlText.append(expectedElement.ownText());
+      actualHtmlText.append(actualElement.ownText());
     }
     assertTrue(
         "Actual HTML file contains additional elements that were not expected",
         expectedElements.isEmpty());
     assertTrue("Actual HTML file is missing some expected elements", actualElements.isEmpty());
+    assertEquals(
+        "The text content of the actual HTML file differed from expected",
+        expectedHtmlText.toString(),
+        actualHtmlText.toString());
   }
 }


### PR DESCRIPTION
- When generating charts for the summary report, depending on the machine, the dimensions may vary slightly. In the e2e tests, instead of comparing the actual vs expected summary_report.html files just as strings, compare the elements on the page and their text content. This tests the important parts of the html file