### PR TITLE
Enable Summary Report Generation as default

### DIFF
--- a/tool/src/main/java/org/datacommons/tool/Main.java
+++ b/tool/src/main/java/org/datacommons/tool/Main.java
@@ -91,7 +91,7 @@ class Main {
 
   @CommandLine.Option(
       names = {"-sr", "--summary-report"},
-      defaultValue = "false",
+      defaultValue = "true",
       scope = CommandLine.ScopeType.INHERIT,
       description = "Generates a summary report in html format.")
   public boolean generateSummaryReport;

--- a/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
+++ b/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
@@ -91,7 +91,6 @@ public class GenMcfTest {
       }
       argsList.add("--resolution=FULL");
       argsList.add("--output-dir=" + Paths.get(testFolder.getRoot().getPath(), testName));
-      argsList.add("--summary-report=True");
       String[] args = argsList.toArray(new String[argsList.size()]);
       cmd.execute(args);
 

--- a/tool/src/test/java/org/datacommons/tool/LintTest.java
+++ b/tool/src/test/java/org/datacommons/tool/LintTest.java
@@ -53,7 +53,6 @@ public class LintTest {
       }
       argsList.add(
           "--output-dir=" + Paths.get(testFolder.getRoot().getPath(), directory.getName()));
-      argsList.add("--summary-report=True");
       String[] args = argsList.toArray(new String[argsList.size()]);
       cmd.execute(args);
 

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/summary_report.html
@@ -11,6 +11,11 @@
         border-collapse: collapse;
         padding: 5px;
       }
+      td, th {
+        max-width: 25rem;
+        word-wrap: break-word;
+        vertical-align: top;
+      }
       tbody tr:hover {
         background-color: #ccc;
       }

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/input/covid.tmcf
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/input/covid.tmcf
@@ -1,6 +1,6 @@
 Node: E:COVID19_cases_india->E0
 typeOf: dcs:StatVarObservation
-variableMeasured: dcs:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive
+variableMeasured: dcs:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name
 observationAbout: E:COVID19_cases_india->E1
 observationDate: C:COVID19_cases_india->DateTime
 value: C:COVID19_cases_india->CumulativeCount_MedicalTest_ConditionCOVID_19_Positive

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/report.json
@@ -13,6 +13,7 @@
     "LEVEL_WARNING": {
       "counters": {
         "Existence_MissingReference_Property": "2",
+        "Existence_MissingReference_variableMeasured": "10",
         "Existence_MissingReference_typeOf": "1"
       }
     },
@@ -108,6 +109,86 @@
     },
     "userMessage": "Found a local ref to an unresolvable node :: ref: 'l:SVId', property: 'variableMeasured', node: 'UnresSVObsId'",
     "counterKey": "Resolution_ReferenceToFailedNode_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "covid.csv",
+      "lineNumber": "2"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name', property: 'variableMeasured', node: 'E:COVID19_cases_india->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "covid.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name', property: 'variableMeasured', node: 'E:COVID19_cases_india->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "covid.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name', property: 'variableMeasured', node: 'E:COVID19_cases_india->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "covid.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name', property: 'variableMeasured', node: 'E:COVID19_cases_india->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "covid.csv",
+      "lineNumber": "6"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name', property: 'variableMeasured', node: 'E:COVID19_cases_india->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "covid.csv",
+      "lineNumber": "7"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name', property: 'variableMeasured', node: 'E:COVID19_cases_india->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "covid.csv",
+      "lineNumber": "8"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name', property: 'variableMeasured', node: 'E:COVID19_cases_india->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "covid.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name', property: 'variableMeasured', node: 'E:COVID19_cases_india->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "covid.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name', property: 'variableMeasured', node: 'E:COVID19_cases_india->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "covid.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name', property: 'variableMeasured', node: 'E:COVID19_cases_india->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
   }],
   "commandArgs": {
     "existenceChecks": true,

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/summary_report.html
@@ -11,6 +11,11 @@
         border-collapse: collapse;
         padding: 5px;
       }
+      td, th {
+        max-width: 25rem;
+        word-wrap: break-word;
+        vertical-align: top;
+      }
       tbody tr:hover {
         background-color: #ccc;
       }
@@ -97,6 +102,10 @@
                     <td>2</td>
                   </tr>
                   <tr>
+                    <td>Existence_MissingReference_variableMeasured</td>
+                    <td>10</td>
+                  </tr>
+                  <tr>
                     <td>Existence_MissingReference_typeOf</td>
                     <td>1</td>
                   </tr>
@@ -138,7 +147,7 @@
     </div>
       <div>
         <h2>StatVarObservations by StatVar</h2>
-        <table width="80%">
+        <table width="95%">
           <thead>
             <tr>
               <th>Stat Var</th>
@@ -171,7 +180,7 @@
               </td>
             </tr>
             <tr>
-              <td>CumulativeCount_MedicalTest_ConditionCOVID_19_Positive</td>
+              <td>CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name</td>
               <td>4</td>
               <td>10</td>
               <td>5</td>
@@ -194,7 +203,7 @@
         <h2>Series Summaries for Sample Places</h2>
             <details open>
               <summary>geoId/0649670</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -219,7 +228,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -230,7 +239,7 @@
             </details>
             <details open>
               <summary>wikidataId/Q1186</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -245,7 +254,7 @@
                 </thead>
                 <tbody>
                   <tr>
-                    <td>CumulativeCount_MedicalTest_ConditionCOVID_19_Positive</td>
+                    <td>CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name</td>
                     <td>5</td>
                     <td>2020-01-30 | 2020-02-02 | 2020-02-03 | 2020-03-02 | 2020-03-03</td>
                     <td>1 | 2 | 3 | 3 | 3</td>
@@ -255,7 +264,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -266,7 +275,7 @@
             </details>
             <details open>
               <summary>wikidataId/Q1353</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -281,7 +290,7 @@
                 </thead>
                 <tbody>
                   <tr>
-                    <td>CumulativeCount_MedicalTest_ConditionCOVID_19_Positive</td>
+                    <td>CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name</td>
                     <td>2</td>
                     <td>2020-03-02 | 2020-03-03</td>
                     <td>1 | 1</td>
@@ -291,7 +300,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -302,7 +311,7 @@
             </details>
             <details open>
               <summary>wikidataId/Q1437</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -317,7 +326,7 @@
                 </thead>
                 <tbody>
                   <tr>
-                    <td>CumulativeCount_MedicalTest_ConditionCOVID_19_Positive</td>
+                    <td>CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name</td>
                     <td>1</td>
                     <td>2020-03-03</td>
                     <td>1</td>
@@ -327,7 +336,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -338,7 +347,7 @@
             </details>
             <details open>
               <summary>wikidataId/Q677037</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -353,7 +362,7 @@
                 </thead>
                 <tbody>
                   <tr>
-                    <td>CumulativeCount_MedicalTest_ConditionCOVID_19_Positive</td>
+                    <td>CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name</td>
                     <td>2</td>
                     <td>2020-03-02 | 2020-03-03</td>
                     <td>1 | 1</td>
@@ -363,7 +372,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/table_mcf_nodes_covid.mcf
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/table_mcf_nodes_covid.mcf
@@ -6,11 +6,11 @@ dcid: "wikidataId/Q1186"
 Node: COVID19_cases_india/E0/1
 observationDate: "2020-01-30"
 observationAbout: dcid:wikidataId/Q1186
-variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive
+variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name
 value: 1
 typeOf: dcid:StatVarObservation
-keyString: "observationAbout=wikidataId/Q1186variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_PositiveobservationDate=2020-01-30value=1"
-dcid: "dc/o/6hr6hr1e2wthc"
+keyString: "observationAbout=wikidataId/Q1186variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_NameobservationDate=2020-01-30value=1"
+dcid: "dc/o/qsplnlg5x13m2"
 
 Node: COVID19_cases_india/E1/2
 isoCode: "IN-KL"
@@ -20,11 +20,11 @@ dcid: "wikidataId/Q1186"
 Node: COVID19_cases_india/E0/2
 observationDate: "2020-02-02"
 observationAbout: dcid:wikidataId/Q1186
-variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive
+variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name
 value: 2
 typeOf: dcid:StatVarObservation
-keyString: "observationAbout=wikidataId/Q1186variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_PositiveobservationDate=2020-02-02value=2"
-dcid: "dc/o/0vxql5gf8dzv5"
+keyString: "observationAbout=wikidataId/Q1186variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_NameobservationDate=2020-02-02value=2"
+dcid: "dc/o/0lblgw7c6xmj6"
 
 Node: COVID19_cases_india/E1/3
 isoCode: "IN-KL"
@@ -34,11 +34,11 @@ dcid: "wikidataId/Q1186"
 Node: COVID19_cases_india/E0/3
 observationDate: "2020-02-03"
 observationAbout: dcid:wikidataId/Q1186
-variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive
+variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name
 value: 3
 typeOf: dcid:StatVarObservation
-keyString: "observationAbout=wikidataId/Q1186variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_PositiveobservationDate=2020-02-03value=3"
-dcid: "dc/o/t3t7j6wq03pz7"
+keyString: "observationAbout=wikidataId/Q1186variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_NameobservationDate=2020-02-03value=3"
+dcid: "dc/o/z2eynzc2ydgy8"
 
 Node: COVID19_cases_india/E1/4
 isoCode: "IN-DL"
@@ -48,11 +48,11 @@ dcid: "wikidataId/Q1353"
 Node: COVID19_cases_india/E0/4
 observationDate: "2020-03-02"
 observationAbout: dcid:wikidataId/Q1353
-variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive
+variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name
 value: 1
 typeOf: dcid:StatVarObservation
-keyString: "observationAbout=wikidataId/Q1353variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_PositiveobservationDate=2020-03-02value=1"
-dcid: "dc/o/sdsc20re0e86c"
+keyString: "observationAbout=wikidataId/Q1353variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_NameobservationDate=2020-03-02value=1"
+dcid: "dc/o/vr3nbh8hsjp72"
 
 Node: COVID19_cases_india/E1/5
 isoCode: "IN-KL"
@@ -62,11 +62,11 @@ dcid: "wikidataId/Q1186"
 Node: COVID19_cases_india/E0/5
 observationDate: "2020-03-02"
 observationAbout: dcid:wikidataId/Q1186
-variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive
+variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name
 value: 3
 typeOf: dcid:StatVarObservation
-keyString: "observationAbout=wikidataId/Q1186variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_PositiveobservationDate=2020-03-02value=3"
-dcid: "dc/o/bv6rz6fqm1vq1"
+keyString: "observationAbout=wikidataId/Q1186variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_NameobservationDate=2020-03-02value=3"
+dcid: "dc/o/b4ndpwvqq1neb"
 
 Node: COVID19_cases_india/E1/6
 isoCode: "IN-TG"
@@ -76,11 +76,11 @@ dcid: "wikidataId/Q677037"
 Node: COVID19_cases_india/E0/6
 observationDate: "2020-03-02"
 observationAbout: dcid:wikidataId/Q677037
-variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive
+variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name
 value: 1
 typeOf: dcid:StatVarObservation
-keyString: "observationAbout=wikidataId/Q677037variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_PositiveobservationDate=2020-03-02value=1"
-dcid: "dc/o/9j5bvrk9tr9n2"
+keyString: "observationAbout=wikidataId/Q677037variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_NameobservationDate=2020-03-02value=1"
+dcid: "dc/o/1h3dqw2kdt046"
 
 Node: COVID19_cases_india/E1/7
 isoCode: "IN-DL"
@@ -90,11 +90,11 @@ dcid: "wikidataId/Q1353"
 Node: COVID19_cases_india/E0/7
 observationDate: "2020-03-03"
 observationAbout: dcid:wikidataId/Q1353
-variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive
+variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name
 value: 1
 typeOf: dcid:StatVarObservation
-keyString: "observationAbout=wikidataId/Q1353variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_PositiveobservationDate=2020-03-03value=1"
-dcid: "dc/o/9pmx2jbevffd4"
+keyString: "observationAbout=wikidataId/Q1353variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_NameobservationDate=2020-03-03value=1"
+dcid: "dc/o/m9by987yzzln3"
 
 Node: COVID19_cases_india/E1/8
 isoCode: "IN-KL"
@@ -104,11 +104,11 @@ dcid: "wikidataId/Q1186"
 Node: COVID19_cases_india/E0/8
 observationDate: "2020-03-03"
 observationAbout: dcid:wikidataId/Q1186
-variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive
+variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name
 value: 3
 typeOf: dcid:StatVarObservation
-keyString: "observationAbout=wikidataId/Q1186variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_PositiveobservationDate=2020-03-03value=3"
-dcid: "dc/o/e13rp3tklef0h"
+keyString: "observationAbout=wikidataId/Q1186variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_NameobservationDate=2020-03-03value=3"
+dcid: "dc/o/lzvsccegpht3g"
 
 Node: COVID19_cases_india/E1/9
 isoCode: "IN-RJ"
@@ -118,11 +118,11 @@ dcid: "wikidataId/Q1437"
 Node: COVID19_cases_india/E0/9
 observationDate: "2020-03-03"
 observationAbout: dcid:wikidataId/Q1437
-variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive
+variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name
 value: 1
 typeOf: dcid:StatVarObservation
-keyString: "observationAbout=wikidataId/Q1437variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_PositiveobservationDate=2020-03-03value=1"
-dcid: "dc/o/hhb7ld8g1gvz3"
+keyString: "observationAbout=wikidataId/Q1437variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_NameobservationDate=2020-03-03value=1"
+dcid: "dc/o/vq4kwmlmz68m6"
 
 Node: COVID19_cases_india/E1/10
 isoCode: "IN-TG"
@@ -132,9 +132,9 @@ dcid: "wikidataId/Q677037"
 Node: COVID19_cases_india/E0/10
 observationDate: "2020-03-03"
 observationAbout: dcid:wikidataId/Q677037
-variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive
+variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name
 value: 1
 typeOf: dcid:StatVarObservation
-keyString: "observationAbout=wikidataId/Q677037variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_PositiveobservationDate=2020-03-03value=1"
-dcid: "dc/o/2v733e745m2r4"
+keyString: "observationAbout=wikidataId/Q677037variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_NameobservationDate=2020-03-03value=1"
+dcid: "dc/o/qnrjyqqpwgltf"
 

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/statchecks/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/statchecks/output/summary_report.html
@@ -11,6 +11,11 @@
         border-collapse: collapse;
         padding: 5px;
       }
+      td, th {
+        max-width: 25rem;
+        word-wrap: break-word;
+        vertical-align: top;
+      }
       tbody tr:hover {
         background-color: #ccc;
       }
@@ -118,7 +123,7 @@
     </div>
       <div>
         <h2>StatVarObservations by StatVar</h2>
-        <table width="80%">
+        <table width="95%">
           <thead>
             <tr>
               <th>Stat Var</th>
@@ -157,7 +162,7 @@
         <h2>Series Summaries for Sample Places</h2>
             <details open>
               <summary>geoId/06</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -182,7 +187,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -193,7 +198,7 @@
             </details>
             <details open>
               <summary>geoId/0601</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -218,7 +223,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -229,7 +234,7 @@
             </details>
             <details open>
               <summary>geoId/07</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -254,7 +259,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -265,7 +270,7 @@
             </details>
             <details open>
               <summary>geoId/08</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -290,7 +295,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -301,7 +306,7 @@
             </details>
             <details open>
               <summary>geoId/09</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -326,7 +331,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -337,7 +342,7 @@
             </details>
             <details open>
               <summary>geoId/10</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -362,7 +367,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -373,7 +378,7 @@
             </details>
             <details open>
               <summary>geoId/201</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -398,7 +403,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -409,7 +414,7 @@
             </details>
             <details open>
               <summary>geoId/211</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -434,7 +439,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -445,7 +450,7 @@
             </details>
             <details open>
               <summary>geoId/221</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -470,7 +475,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -481,7 +486,7 @@
             </details>
             <details open>
               <summary>geoId/231</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -506,7 +511,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -517,7 +522,7 @@
             </details>
             <details open>
               <summary>geoId/241</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -542,7 +547,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -553,7 +558,7 @@
             </details>
             <details open>
               <summary>geoId/25111</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -578,7 +583,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -589,7 +594,7 @@
             </details>
             <details open>
               <summary>geoId/26111</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -614,7 +619,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -625,7 +630,7 @@
             </details>
             <details open>
               <summary>geoId/27111</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -650,7 +655,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -661,7 +666,7 @@
             </details>
             <details open>
               <summary>geoId/28111</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -686,7 +691,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/output/summary_report.html
@@ -11,6 +11,11 @@
         border-collapse: collapse;
         padding: 5px;
       }
+      td, th {
+        max-width: 25rem;
+        word-wrap: break-word;
+        vertical-align: top;
+      }
       tbody tr:hover {
         background-color: #ccc;
       }
@@ -202,7 +207,7 @@
     </div>
       <div>
         <h2>StatVarObservations by StatVar</h2>
-        <table width="80%">
+        <table width="95%">
           <thead>
             <tr>
               <th>Stat Var</th>
@@ -258,7 +263,7 @@
         <h2>Series Summaries for Sample Places</h2>
             <details open>
               <summary>CA-AB</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -284,7 +289,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -304,7 +309,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -315,7 +320,7 @@
             </details>
             <details open>
               <summary>CA-BC</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -341,7 +346,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -361,7 +366,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -372,7 +377,7 @@
             </details>
             <details open>
               <summary>CA-MN</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -398,7 +403,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -418,7 +423,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -429,7 +434,7 @@
             </details>
             <details open>
               <summary>CH-SH</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -455,7 +460,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -475,7 +480,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -486,7 +491,7 @@
             </details>
             <details open>
               <summary>US-SF</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -512,7 +517,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -532,7 +537,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -543,7 +548,7 @@
             </details>
             <details open>
               <summary>veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongdcid</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -569,7 +574,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -589,7 +594,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>

--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/summary_report.html
@@ -11,6 +11,11 @@
         border-collapse: collapse;
         padding: 5px;
       }
+      td, th {
+        max-width: 25rem;
+        word-wrap: break-word;
+        vertical-align: top;
+      }
       tbody tr:hover {
         background-color: #ccc;
       }
@@ -314,7 +319,7 @@
     </div>
       <div>
         <h2>StatVarObservations by StatVar</h2>
-        <table width="80%">
+        <table width="95%">
           <thead>
             <tr>
               <th>Stat Var</th>
@@ -370,7 +375,7 @@
         <h2>Series Summaries for Sample Places</h2>
             <details open>
               <summary>CA-AB</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -396,7 +401,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -416,7 +421,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -427,7 +432,7 @@
             </details>
             <details open>
               <summary>CA-BC</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -453,7 +458,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -473,7 +478,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -484,7 +489,7 @@
             </details>
             <details open>
               <summary>CA-MN</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -510,7 +515,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -530,7 +535,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -541,7 +546,7 @@
             </details>
             <details open>
               <summary>CH-SH</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -567,7 +572,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -587,7 +592,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -598,7 +603,7 @@
             </details>
             <details open>
               <summary>US-SF</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -624,7 +629,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -644,7 +649,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -655,7 +660,7 @@
             </details>
             <details open>
               <summary>veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongdcid</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -681,7 +686,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -701,7 +706,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>

--- a/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/summary_report.html
@@ -11,6 +11,11 @@
         border-collapse: collapse;
         padding: 5px;
       }
+      td, th {
+        max-width: 25rem;
+        word-wrap: break-word;
+        vertical-align: top;
+      }
       tbody tr:hover {
         background-color: #ccc;
       }

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/summary_report.html
@@ -11,6 +11,11 @@
         border-collapse: collapse;
         padding: 5px;
       }
+      td, th {
+        max-width: 25rem;
+        word-wrap: break-word;
+        vertical-align: top;
+      }
       tbody tr:hover {
         background-color: #ccc;
       }

--- a/tool/src/test/resources/org/datacommons/tool/lint/statchecks/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/statchecks/output/summary_report.html
@@ -11,6 +11,11 @@
         border-collapse: collapse;
         padding: 5px;
       }
+      td, th {
+        max-width: 25rem;
+        word-wrap: break-word;
+        vertical-align: top;
+      }
       tbody tr:hover {
         background-color: #ccc;
       }
@@ -106,7 +111,7 @@
     </div>
       <div>
         <h2>StatVarObservations by StatVar</h2>
-        <table width="80%">
+        <table width="95%">
           <thead>
             <tr>
               <th>Stat Var</th>
@@ -145,7 +150,7 @@
         <h2>Series Summaries for Sample Places</h2>
             <details open>
               <summary>geoId/06</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -170,7 +175,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -181,7 +186,7 @@
             </details>
             <details open>
               <summary>geoId/0601</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -206,7 +211,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -217,7 +222,7 @@
             </details>
             <details open>
               <summary>geoId/07</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -242,7 +247,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -253,7 +258,7 @@
             </details>
             <details open>
               <summary>geoId/08</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -278,7 +283,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -289,7 +294,7 @@
             </details>
             <details open>
               <summary>geoId/10</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -314,7 +319,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>
@@ -325,7 +330,7 @@
             </details>
             <details open>
               <summary>geoId/11</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -350,7 +355,7 @@
                     </td>
                     <td>
                     </td>
-                    <td><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+                    <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
 <defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
 <clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
 </defs>

--- a/util/src/main/resources/SummaryReport.ftl
+++ b/util/src/main/resources/SummaryReport.ftl
@@ -11,6 +11,11 @@
         border-collapse: collapse;
         padding: 5px;
       }
+      td, th {
+        max-width: 25rem;
+        word-wrap: break-word;
+        vertical-align: top;
+      }
       tbody tr:hover {
         background-color: #ccc;
       }
@@ -77,7 +82,7 @@
     <#if svSummaryMap?has_content>
       <div>
         <h2>StatVarObservations by StatVar</h2>
-        <table width="80%">
+        <table width="95%">
           <thead>
             <tr>
               <th>Stat Var</th>
@@ -127,7 +132,7 @@
           <#list placeSeriesSummaryMap as place, placeSeriesSummary>
             <details open>
               <summary>${place}</summary>
-              <table width="80%">
+              <table width="95%">
                 <thead>
                   <tr>
                     <th>Stat Var</th>
@@ -162,7 +167,7 @@
                       <div>${sFactor}</div>
                       </#list>
                     </td>
-                    <td>${svSummary.getTimeSeriesChartSVG()}</td>
+                    <td style="max-width:none;text-align: -webkit-center;">${svSummary.getTimeSeriesChartSVG()}</td>
                   </tr>
                   </tbody>
                   </#list>


### PR DESCRIPTION
- Make summary report generation the default 
- Add max width to columns to handle extra long variable names: [summary report with long variable name](https://htmlpreview.github.io/?https://github.com/chejennifer/import/blob/43e72f05937745ff6ab52623e00489594459feeb/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/summary_report.html)