### PR TITLE
Removing the requirement for StatVars to have a populationType.

### DIFF
--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
@@ -23,7 +23,8 @@
         "Existence_MissingReference_Property": "4",
         "Existence_MissingReference_containedInPlace": "1",
         "Existence_MissingReference_variableMeasured": "12",
-        "Existence_MissingReference_subClassOf": "1"
+        "Existence_MissingReference_subClassOf": "1",
+        "Sanity_MissingOrEmpty_populationType": "2"
       }
     },
     "LEVEL_ERROR": {
@@ -65,7 +66,6 @@
         "Resolution_OrphanLocalReference_containedInPlace": "1",
         "Sanity_MultipleDcidValues": "2",
         "MCF_MalformedNodeName": "1",
-        "Sanity_MissingOrEmpty_populationType": "2",
         "Resolution_DcidAssignmentFailure_City": "1",
         "Sanity_MissingOrEmpty_observationAbout": "2",
         "Sanity_NonDoubleObsValue": "1"
@@ -241,7 +241,7 @@
     "userMessage": "Found dcid with more than one value :: count: 2, node: '\"CANCountry\"'",
     "counterKey": "Sanity_MultipleDcidValues"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.mcf",
       "lineNumber": "77"
@@ -273,7 +273,7 @@
     "userMessage": "Found property name that does not start with a lower-case :: property: 'PopulationType', node: 'dcid:Count_Death_15YearsPlus'",
     "counterKey": "Sanity_NotInitLowerPropName"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.mcf",
       "lineNumber": "109"

--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/summary_report.html
@@ -122,6 +122,10 @@
                     <td>12</td>
                   </tr>
                   <tr>
+                    <td>Sanity_MissingOrEmpty_populationType</td>
+                    <td>2</td>
+                  </tr>
+                  <tr>
                     <td>Sanity_ObsMissingValueProp</td>
                     <td>1</td>
                   </tr>
@@ -297,10 +301,6 @@
                   <tr>
                     <td>MCF_MalformedNodeName</td>
                     <td>1</td>
-                  </tr>
-                  <tr>
-                    <td>Sanity_MissingOrEmpty_populationType</td>
-                    <td>2</td>
                   </tr>
                   <tr>
                     <td>Resolution_DcidAssignmentFailure_City</td>

--- a/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
@@ -14,7 +14,8 @@
         "Existence_MissingReference_containedIn": "1",
         "Existence_MissingReference_Property": "4",
         "Existence_MissingReference_containedInPlace": "1",
-        "Existence_MissingReference_subClassOf": "1"
+        "Existence_MissingReference_subClassOf": "1",
+        "Sanity_MissingOrEmpty_populationType": "2"
       }
     },
     "LEVEL_ERROR": {
@@ -53,7 +54,6 @@
         "Resolution_OrphanLocalReference_containedInPlace": "1",
         "Sanity_MultipleDcidValues": "1",
         "MCF_MalformedNodeName": "1",
-        "Sanity_MissingOrEmpty_populationType": "2",
         "Resolution_DcidAssignmentFailure_City": "1",
         "Sanity_NonDoubleObsValue": "1"
       }
@@ -228,7 +228,7 @@
     "userMessage": "Found dcid with more than one value :: count: 2, node: '\"CANCountry\"'",
     "counterKey": "Sanity_MultipleDcidValues"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "McfOnly.mcf",
       "lineNumber": "77"
@@ -260,7 +260,7 @@
     "userMessage": "Found property name that does not start with a lower-case :: property: 'PopulationType', node: 'dcid:Count_Death_15YearsPlus'",
     "counterKey": "Sanity_NotInitLowerPropName"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "McfOnly.mcf",
       "lineNumber": "109"

--- a/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/summary_report.html
@@ -86,6 +86,10 @@
                     <td>6</td>
                   </tr>
                   <tr>
+                    <td>Sanity_MissingOrEmpty_populationType</td>
+                    <td>2</td>
+                  </tr>
+                  <tr>
                     <td>Sanity_ObsMissingValueProp</td>
                     <td>1</td>
                   </tr>
@@ -249,10 +253,6 @@
                   <tr>
                     <td>MCF_MalformedNodeName</td>
                     <td>1</td>
-                  </tr>
-                  <tr>
-                    <td>Sanity_MissingOrEmpty_populationType</td>
-                    <td>2</td>
                   </tr>
                   <tr>
                     <td>Resolution_DcidAssignmentFailure_City</td>

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
@@ -15,7 +15,8 @@
         "Existence_MissingReference_Property": "4",
         "Sanity_MultipleVals_value": "1",
         "Existence_MissingReference_containedInPlace": "1",
-        "Existence_MissingReference_subClassOf": "1"
+        "Existence_MissingReference_subClassOf": "1",
+        "Sanity_MissingOrEmpty_populationType": "2"
       }
     },
     "LEVEL_ERROR": {
@@ -57,7 +58,6 @@
         "Resolution_OrphanLocalReference_containedInPlace": "1",
         "Sanity_MultipleDcidValues": "2",
         "MCF_MalformedNodeName": "2",
-        "Sanity_MissingOrEmpty_populationType": "2",
         "Resolution_DcidAssignmentFailure_City": "1",
         "Sanity_DcidTableEntity": "1",
         "Sanity_NonDoubleObsValue": "1"
@@ -233,7 +233,7 @@
     "userMessage": "Found dcid with more than one value :: count: 2, node: '\"CANCountry\"'",
     "counterKey": "Sanity_MultipleDcidValues"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "NoCsv.mcf",
       "lineNumber": "77"
@@ -265,7 +265,7 @@
     "userMessage": "Found property name that does not start with a lower-case :: property: 'PopulationType', node: 'dcid:Count_Death_15YearsPlus'",
     "counterKey": "Sanity_NotInitLowerPropName"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "NoCsv.mcf",
       "lineNumber": "109"

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/summary_report.html
@@ -86,6 +86,10 @@
                     <td>5</td>
                   </tr>
                   <tr>
+                    <td>Sanity_MissingOrEmpty_populationType</td>
+                    <td>2</td>
+                  </tr>
+                  <tr>
                     <td>Sanity_ObsMissingValueProp</td>
                     <td>1</td>
                   </tr>
@@ -264,10 +268,6 @@
                   </tr>
                   <tr>
                     <td>MCF_MalformedNodeName</td>
-                    <td>2</td>
-                  </tr>
-                  <tr>
-                    <td>Sanity_MissingOrEmpty_populationType</td>
                     <td>2</td>
                   </tr>
                   <tr>

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -187,8 +187,13 @@ public class McfChecker {
   private void checkStatVar(String nodeId, Mcf.McfGraph.PropertyValues node)
       throws IOException, InterruptedException {
     String popType =
+        // Only Warn if popType is not set. No need for an Error.
         checkRequiredSingleValueProp(
-            nodeId, node, Vocabulary.STAT_VAR_TYPE, Vocabulary.POPULATION_TYPE);
+            Debug.Log.Level.LEVEL_WARNING,
+            nodeId,
+            node,
+            Vocabulary.STAT_VAR_TYPE,
+            Vocabulary.POPULATION_TYPE);
     if (!popType.isEmpty()) {
       checkInitCasing(nodeId, node, Vocabulary.POPULATION_TYPE, popType, "", true);
     }

--- a/util/src/test/java/org/datacommons/util/McfCheckerTest.java
+++ b/util/src/test/java/org/datacommons/util/McfCheckerTest.java
@@ -177,6 +177,8 @@ public class McfCheckerTest {
   @Test
   public void checkStatVar() throws IOException, InterruptedException {
     // Missing popType
+    // This should only result in a Warning (and not an error).
+    // The Warning vs Error is tested under org.datacommons.tool.LintTest.
     String mcf =
         "Node: SV\n"
             + "typeOf: schema:StatisticalVariable\n"


### PR DESCRIPTION
If a StatVar does not have a populationType, the tool will now generate a warning instead of an error. Note that if a StatVar has a 'PopulationType' field instead of 'populationType', the tool will still generate an error.