### PR TITLE
Pass HTTP 1.1 version for DC calls

### DIFF
--- a/util/src/main/java/org/datacommons/util/ExistenceChecker.java
+++ b/util/src/main/java/org/datacommons/util/ExistenceChecker.java
@@ -24,10 +24,8 @@ import org.datacommons.proto.Mcf;
 // This class is thread-safe.
 public class ExistenceChecker {
   private static final Logger logger = LogManager.getLogger(ExistenceChecker.class);
-  // Use the autopush end-point so we get more recent schema additions that
-  // haven't rolled out.
   private static final String API_ROOT =
-      "https://autopush.api.datacommons.org/node/property-values";
+      "https://api.datacommons.org/node/property-values";
   // For now we only need checks for certain Property/Class props.
   private static final Set<String> SCHEMA_PROPERTIES =
       Set.of(Vocabulary.DOMAIN_INCLUDES, Vocabulary.RANGE_INCLUDES, Vocabulary.SUB_CLASS_OF);

--- a/util/src/main/java/org/datacommons/util/ExistenceChecker.java
+++ b/util/src/main/java/org/datacommons/util/ExistenceChecker.java
@@ -24,7 +24,10 @@ import org.datacommons.proto.Mcf;
 // This class is thread-safe.
 public class ExistenceChecker {
   private static final Logger logger = LogManager.getLogger(ExistenceChecker.class);
-  private static final String API_ROOT = "https://api.datacommons.org/node/property-values";
+  // Use the autopush end-point so we get more recent schema additions that
+  // haven't rolled out.
+  private static final String API_ROOT =
+      "https://autopush.api.datacommons.org/node/property-values";
   // For now we only need checks for certain Property/Class props.
   private static final Set<String> SCHEMA_PROPERTIES =
       Set.of(Vocabulary.DOMAIN_INCLUDES, Vocabulary.RANGE_INCLUDES, Vocabulary.SUB_CLASS_OF);
@@ -294,6 +297,7 @@ public class ExistenceChecker {
     arg.addProperty("direction", "out");
     var request =
         HttpRequest.newBuilder(URI.create(API_ROOT))
+            .version(HttpClient.Version.HTTP_1_1)
             .header("accept", "application/json")
             .POST(HttpRequest.BodyPublishers.ofString(arg.toString()))
             .build();

--- a/util/src/main/java/org/datacommons/util/ExistenceChecker.java
+++ b/util/src/main/java/org/datacommons/util/ExistenceChecker.java
@@ -24,8 +24,7 @@ import org.datacommons.proto.Mcf;
 // This class is thread-safe.
 public class ExistenceChecker {
   private static final Logger logger = LogManager.getLogger(ExistenceChecker.class);
-  private static final String API_ROOT =
-      "https://api.datacommons.org/node/property-values";
+  private static final String API_ROOT = "https://api.datacommons.org/node/property-values";
   // For now we only need checks for certain Property/Class props.
   private static final Set<String> SCHEMA_PROPERTIES =
       Set.of(Vocabulary.DOMAIN_INCLUDES, Vocabulary.RANGE_INCLUDES, Vocabulary.SUB_CLASS_OF);

--- a/util/src/main/java/org/datacommons/util/ExternalIdResolver.java
+++ b/util/src/main/java/org/datacommons/util/ExternalIdResolver.java
@@ -32,7 +32,7 @@ import org.datacommons.proto.Recon;
 public class ExternalIdResolver {
   private static final Logger logger = LogManager.getLogger(ExternalIdResolver.class);
 
-  private static final String API_ROOT = "https://autopush.recon.datacommons.org/entity/resolve";
+  private static final String API_ROOT = "https://staging.recon.datacommons.org/entity/resolve";
   // Let tests modify it.
   static int MAX_RESOLUTION_BATCH_IDS = 500;
 

--- a/util/src/main/java/org/datacommons/util/ExternalIdResolver.java
+++ b/util/src/main/java/org/datacommons/util/ExternalIdResolver.java
@@ -265,6 +265,7 @@ public class ExternalIdResolver {
     logCtx.incrementInfoCounterBy("Resolution_NumDcCalls", 1);
     var request =
         HttpRequest.newBuilder(URI.create(API_ROOT))
+            .version(HttpClient.Version.HTTP_1_1)
             .header("accept", "application/json")
             .POST(HttpRequest.BodyPublishers.ofString(StringUtil.msgToJson(reconReq)))
             .build();


### PR DESCRIPTION
This fixes the presubmit failures [here](https://pantheon.corp.google.com/cloud-build/builds/3f58eb85-10f5-4d06-8334-a4d6954ccd4d;step=0?project=879489846695).

Possible reason:  There seems to have been a regression in Java 11 HttpClient, wherein, if the server supports only HTTP 1.1 (as our servers do), the default Java HttpClient connection (which uses HTTP2) throws this error.  See details in these bugs: [1](https://bugs.openjdk.java.net/browse/JDK-8218546), [2](https://bugs.openjdk.java.net/browse/JDK-8218623)

I suspect the Docker image that CloudBuild uses somehow uses a minor version of Java that includes the regression bug, but not the subsequent fix.  Handle this by setting the HTTP version that the servers support.

Bonus:  upgrade recon API endpoint to staging