### PR TITLE
Support schemaless SVs with init-cap mprop

### DIFF
--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -202,7 +202,12 @@ public class McfChecker {
         checkRequiredSingleValueProp(
             nodeId, node, Vocabulary.STAT_VAR_TYPE, Vocabulary.MEASURED_PROP);
     if (!mProp.isEmpty()) {
-      checkInitCasing(nodeId, node, Vocabulary.MEASURED_PROP, mProp, "", false);
+      var dcid = McfUtil.getPropVal(node, Vocabulary.DCID);
+      if (!mProp.equals(dcid)) {
+        // Perform init-casing check for measuredProperty when it is not a schema-less SV
+        // (schema-less SVs have a self-referential measuredProperty that can have any casing).
+        checkInitCasing(nodeId, node, Vocabulary.MEASURED_PROP, mProp, "", false);
+      }
     }
     // TODO: Do this check for all constraint properties too.
     if (existenceChecker != null) {

--- a/util/src/test/java/org/datacommons/util/McfCheckerTest.java
+++ b/util/src/test/java/org/datacommons/util/McfCheckerTest.java
@@ -221,6 +221,16 @@ public class McfCheckerTest {
             + "measuredProperty: dcs:Income";
     assertTrue(failure(mcf, "Sanity_NotInitLower_measuredProperty", "Income"));
 
+    // Schema-less mprop with init-capital.
+    mcf =
+        "Node: SV\n"
+            + "typeOf: schema:StatisticalVariable\n"
+            + "populationType: schema:Person\n"
+            + "statType: dcs:measuredValue\n"
+            + "dcid: \"Income_Person\"\n"
+            + "measuredProperty: dcs:Income_Person";
+    assertTrue(success(mcf));
+
     // Unknown statType
     mcf =
         "Node: SV\n"


### PR DESCRIPTION
This is so that we can have schema-less SVs that have mprops that refer to the SV itself (which may start with an upper case letter).