### PR TITLE
Fix test errors

### DIFF
--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
@@ -4,27 +4,27 @@
       "counters": {
         "NumRowSuccesses": "11",
         "NumPVSuccesses": "107",
-        "Existence_NumChecks": "249",
+        "Existence_NumChecks": "248",
         "NumNodeSuccesses": "15",
         "CSV_MalformedDCIDPVFailures": "4",
-        "Existence_NumDcCalls": "3"
+        "Existence_NumDcCalls": "2"
       }
     },
     "LEVEL_WARNING": {
       "counters": {
         "Existence_MissingReference_statType": "5",
         "CSV_EmptyDcidReferences": "2",
-        "Existence_MissingReference_domainIncludes": "2",
+        "Existence_MissingReference_domainIncludes": "1",
         "Existence_MissingReference_containedIn": "1",
         "CSV_MalformedDCIDFailures": "1",
         "Existence_MissingReference_measurementMethod": "12",
+        "Sanity_MissingOrEmpty_populationType": "2",
         "Sanity_ObsMissingValueProp": "1",
         "StrSplit_EmptyToken_typeOf": "1",
         "Existence_MissingReference_Property": "4",
         "Existence_MissingReference_containedInPlace": "1",
         "Existence_MissingReference_variableMeasured": "12",
-        "Existence_MissingReference_subClassOf": "1",
-        "Sanity_MissingOrEmpty_populationType": "2"
+        "Existence_MissingReference_subClassOf": "1"
       }
     },
     "LEVEL_ERROR": {
@@ -464,14 +464,6 @@
     },
     "userMessage": "Failed reference existence check :: value-ref: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
     "counterKey": "Existence_MissingReference_subClassOf"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Failed reference existence check :: subject: '', predicate: 'domainIncludes', object: '', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "Existence_MissingReference_domainIncludes"
   }, {
     "level": "LEVEL_ERROR",
     "location": {

--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/summary_report.html
@@ -78,7 +78,7 @@
                   </tr>
                   <tr>
                     <td>Existence_NumChecks</td>
-                    <td>249</td>
+                    <td>248</td>
                   </tr>
                   <tr>
                     <td>NumNodeSuccesses</td>
@@ -90,7 +90,7 @@
                   </tr>
                   <tr>
                     <td>Existence_NumDcCalls</td>
-                    <td>3</td>
+                    <td>2</td>
                   </tr>
               </tbody>
               <tbody>
@@ -107,7 +107,7 @@
                   </tr>
                   <tr>
                     <td>Existence_MissingReference_domainIncludes</td>
-                    <td>2</td>
+                    <td>1</td>
                   </tr>
                   <tr>
                     <td>Existence_MissingReference_containedIn</td>

--- a/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
@@ -2,20 +2,20 @@
   "levelSummary": {
     "LEVEL_INFO": {
       "counters": {
-        "Existence_NumChecks": "178",
-        "Existence_NumDcCalls": "2"
+        "Existence_NumChecks": "177",
+        "Existence_NumDcCalls": "1"
       }
     },
     "LEVEL_WARNING": {
       "counters": {
         "Existence_MissingReference_statType": "6",
+        "Sanity_MissingOrEmpty_populationType": "2",
         "Sanity_ObsMissingValueProp": "1",
-        "Existence_MissingReference_domainIncludes": "2",
+        "Existence_MissingReference_domainIncludes": "1",
         "Existence_MissingReference_containedIn": "1",
         "Existence_MissingReference_Property": "4",
         "Existence_MissingReference_containedInPlace": "1",
-        "Existence_MissingReference_subClassOf": "1",
-        "Sanity_MissingOrEmpty_populationType": "2"
+        "Existence_MissingReference_subClassOf": "1"
       }
     },
     "LEVEL_ERROR": {
@@ -475,14 +475,6 @@
     },
     "userMessage": "Failed reference existence check :: value-ref: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
     "counterKey": "Existence_MissingReference_subClassOf"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Failed reference existence check :: subject: '', predicate: 'domainIncludes', object: '', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "Existence_MissingReference_domainIncludes"
   }, {
     "level": "LEVEL_ERROR",
     "location": {

--- a/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/summary_report.html
@@ -70,11 +70,11 @@
                 </tr>
                   <tr>
                     <td>Existence_NumChecks</td>
-                    <td>178</td>
+                    <td>177</td>
                   </tr>
                   <tr>
                     <td>Existence_NumDcCalls</td>
-                    <td>2</td>
+                    <td>1</td>
                   </tr>
               </tbody>
               <tbody>
@@ -95,7 +95,7 @@
                   </tr>
                   <tr>
                     <td>Existence_MissingReference_domainIncludes</td>
-                    <td>2</td>
+                    <td>1</td>
                   </tr>
                   <tr>
                     <td>Existence_MissingReference_containedIn</td>

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
@@ -2,21 +2,21 @@
   "levelSummary": {
     "LEVEL_INFO": {
       "counters": {
-        "Existence_NumChecks": "149",
-        "Existence_NumDcCalls": "2"
+        "Existence_NumChecks": "148",
+        "Existence_NumDcCalls": "1"
       }
     },
     "LEVEL_WARNING": {
       "counters": {
         "Existence_MissingReference_statType": "5",
+        "Sanity_MissingOrEmpty_populationType": "2",
         "Sanity_ObsMissingValueProp": "1",
-        "Existence_MissingReference_domainIncludes": "2",
+        "Existence_MissingReference_domainIncludes": "1",
         "Existence_MissingReference_containedIn": "1",
         "Existence_MissingReference_Property": "4",
         "Sanity_MultipleVals_value": "1",
         "Existence_MissingReference_containedInPlace": "1",
-        "Existence_MissingReference_subClassOf": "1",
-        "Sanity_MissingOrEmpty_populationType": "2"
+        "Existence_MissingReference_subClassOf": "1"
       }
     },
     "LEVEL_ERROR": {
@@ -456,14 +456,6 @@
     },
     "userMessage": "Failed reference existence check :: value-ref: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
     "counterKey": "Existence_MissingReference_subClassOf"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Failed reference existence check :: subject: '', predicate: 'domainIncludes', object: '', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "Existence_MissingReference_domainIncludes"
   }, {
     "level": "LEVEL_ERROR",
     "location": {

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/summary_report.html
@@ -70,11 +70,11 @@
                 </tr>
                   <tr>
                     <td>Existence_NumChecks</td>
-                    <td>149</td>
+                    <td>148</td>
                   </tr>
                   <tr>
                     <td>Existence_NumDcCalls</td>
-                    <td>2</td>
+                    <td>1</td>
                   </tr>
               </tbody>
               <tbody>
@@ -95,7 +95,7 @@
                   </tr>
                   <tr>
                     <td>Existence_MissingReference_domainIncludes</td>
-                    <td>2</td>
+                    <td>1</td>
                   </tr>
                   <tr>
                     <td>Existence_MissingReference_containedIn</td>

--- a/util/src/main/java/org/datacommons/util/ExistenceChecker.java
+++ b/util/src/main/java/org/datacommons/util/ExistenceChecker.java
@@ -73,7 +73,7 @@ public class ExistenceChecker {
     if (checkLocal(node, Vocabulary.TYPE_OF, "", logCb)) {
       return;
     }
-    // assert !node.isEmpty();
+    assert !node.isEmpty();
     batchRemoteCall(node, Vocabulary.TYPE_OF, "", logCb);
   }
 
@@ -89,7 +89,7 @@ public class ExistenceChecker {
     if (checkLocal(sub, pred, obj, logCb)) {
       return;
     }
-    // assert !sub.isEmpty();
+    assert !sub.isEmpty();
     batchRemoteCall(sub, pred, obj, logCb);
   }
 
@@ -209,11 +209,12 @@ public class ExistenceChecker {
       // If this was an independent RPC call, don't want to re-issue the call.
       if (subs.size() == 1) {
         var sub = subs.get(0);
-        if (!subMap.containsKey(sub)) {
-          return;
-        }
+        assert subMap.containsKey(sub);
         var objMap = subMap.get(sub);
         for (var cbs : objMap.values()) {
+          for (var cb : cbs) {
+            cb.logError("Existence_FailedDcCall", "Failed DC Call");
+          }
           totalPendingCallCount -= cbs.size();
         }
         subMap.remove(subs.get(0));

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -218,7 +218,9 @@ public class McfChecker {
               .setDetail(LogCb.OBJ_KEY, popType)
               .setDetail(LogCb.NODE_KEY, nodeId)
               .setCounterSuffix(Vocabulary.DOMAIN_INCLUDES);
-      existenceChecker.submitTripleCheck(mProp, Vocabulary.DOMAIN_INCLUDES, popType, logCb);
+      if (!mProp.isEmpty()) {
+        existenceChecker.submitTripleCheck(mProp, Vocabulary.DOMAIN_INCLUDES, popType, logCb);
+      }
     }
 
     String statType =
@@ -438,7 +440,9 @@ public class McfChecker {
                 .setDetail(LogCb.PREF_KEY, prop)
                 .setDetail(LogCb.NODE_KEY, nodeId)
                 .setCounterSuffix(Vocabulary.PROPERTY_TYPE);
-        existenceChecker.submitNodeCheck(prop, logCb);
+        if (!prop.isEmpty()) {
+          existenceChecker.submitNodeCheck(prop, logCb);
+        }
       }
 
       for (Mcf.McfGraph.TypedValue tv : pv.getValue().getTypedValuesList()) {
@@ -486,7 +490,9 @@ public class McfChecker {
             if (prop.equals(Vocabulary.MEASUREMENT_METHOD)) {
               value = value.replace("dcAggregate/", "");
             }
-            existenceChecker.submitNodeCheck(value, logCb);
+            if (!value.isEmpty()) {
+              existenceChecker.submitNodeCheck(value, logCb);
+            }
           }
         }
       }

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -210,7 +210,7 @@ public class McfChecker {
       }
     }
     // TODO: Do this check for all constraint properties too.
-    if (existenceChecker != null) {
+    if (existenceChecker != null && !mProp.isEmpty()) {
       LogCb logCb =
           new LogCb(logCtx, Debug.Log.Level.LEVEL_WARNING, node)
               .setDetail(LogCb.SUB_KEY, mProp)
@@ -218,9 +218,7 @@ public class McfChecker {
               .setDetail(LogCb.OBJ_KEY, popType)
               .setDetail(LogCb.NODE_KEY, nodeId)
               .setCounterSuffix(Vocabulary.DOMAIN_INCLUDES);
-      if (!mProp.isEmpty()) {
-        existenceChecker.submitTripleCheck(mProp, Vocabulary.DOMAIN_INCLUDES, popType, logCb);
-      }
+      existenceChecker.submitTripleCheck(mProp, Vocabulary.DOMAIN_INCLUDES, popType, logCb);
     }
 
     String statType =
@@ -434,15 +432,13 @@ public class McfChecker {
         }
       }
 
-      if (existenceChecker != null) {
+      if (existenceChecker != null && !prop.isEmpty()) {
         LogCb logCb =
             new LogCb(logCtx, Debug.Log.Level.LEVEL_WARNING, node)
                 .setDetail(LogCb.PREF_KEY, prop)
                 .setDetail(LogCb.NODE_KEY, nodeId)
                 .setCounterSuffix(Vocabulary.PROPERTY_TYPE);
-        if (!prop.isEmpty()) {
-          existenceChecker.submitNodeCheck(prop, logCb);
-        }
+        existenceChecker.submitNodeCheck(prop, logCb);
       }
 
       for (Mcf.McfGraph.TypedValue tv : pv.getValue().getTypedValuesList()) {
@@ -479,7 +475,9 @@ public class McfChecker {
         if (tv.getType() == Mcf.ValueType.RESOLVED_REF) {
           if (!checkDcid(tv.getValue(), prop, nodeId, node)) {
             // Failed. checkDcid would have updated logCtx, pass through...
-          } else if (shouldCheckExistence(prop, types) && existenceChecker != null) {
+          } else if (shouldCheckExistence(prop, types)
+              && existenceChecker != null
+              && !tv.getValue().isEmpty()) {
             LogCb logCb =
                 new LogCb(logCtx, Debug.Log.Level.LEVEL_WARNING, node)
                     .setDetail(LogCb.VREF_KEY, tv.getValue())
@@ -490,9 +488,7 @@ public class McfChecker {
             if (prop.equals(Vocabulary.MEASUREMENT_METHOD)) {
               value = value.replace("dcAggregate/", "");
             }
-            if (!value.isEmpty()) {
-              existenceChecker.submitNodeCheck(value, logCb);
-            }
+            existenceChecker.submitNodeCheck(value, logCb);
           }
         }
       }


### PR DESCRIPTION
- fix error when running LintTest which was caused by passing an empty dcid to the /node/property-values call. Do this by adding checks that dcid is not empty
- fix bug of infinite loop of independent RPC call issued -> RPC call fails -> same independent RPC call issued