### PR TITLE
Generate observations using mapping and csvData

### DIFF
--- a/wizard/src/types.ts
+++ b/wizard/src/types.ts
@@ -132,11 +132,9 @@ export interface DetectedDetails {
   confidence: ConfidenceLevel;
 }
 
-// A map from the mapped thing (aka StatVarObs fields) to the data value.
-//
-// This can be expected to contain *all* the required properties.
+// A map from the mapped thing (aka StatVarObs props) to the property value.
 export type Observation = Map<MappedThing, string>;
 
-// Observations keyed by the CSV row number.  A row has multiple observations
-// when the Mapping is of type COLUMN_HEADER with multiple MappingVal.headers.
+// Observations keyed by CSV row number. A row has multiple observations when
+// the Mapping is of type COLUMN_HEADER with multiple MappingVal.headers.
 export type RowObservations = Map<RowNumber, Array<Observation>>;

--- a/wizard/src/types.ts
+++ b/wizard/src/types.ts
@@ -28,7 +28,7 @@ export enum MappedThing {
   VALUE = "value",
 }
 
-interface Column {
+export interface Column {
   // id of the column
   id: string;
   // original column header
@@ -56,6 +56,9 @@ export interface MappingVal {
 
 export type Mapping = Map<MappedThing, MappingVal>;
 
+// CSV Row number.
+export type RowNumber = number;
+
 // CvsData should contain the minimum sufficient data from the
 // data csv file which will be used for all processing, e.g. column detection,
 // and display/rendering.
@@ -80,7 +83,7 @@ export interface CsvData {
   // is no expectation that this structure contains all rows.
   // It is also assumed that order of values in the array will correspond to
   // the orderedColumnNames.
-  rowsForDisplay: Map<bigint, Array<string>>;
+  rowsForDisplay: Map<RowNumber, Array<string>>;
 
   // The raw csv data can be either in the form of a file or a URL. One of the
   // following fields must be set:
@@ -128,3 +131,12 @@ export interface DetectedDetails {
   // The level of confidence associated with the detection.
   confidence: ConfidenceLevel;
 }
+
+// A map from the mapped thing (aka StatVarObs fields) to the data value.
+//
+// This can be expected to contain *all* the required properties.
+export type Observation = Map<MappedThing, string>;
+
+// Observations keyed by the CSV row number.  A row has multiple observations
+// when the Mapping is of type COLUMN_HEADER with multiple MappingVal.headers.
+export type RowObservations = Map<RowNumber, Array<Observation>>;

--- a/wizard/src/utils/obs_generation.test.tsx
+++ b/wizard/src/utils/obs_generation.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from "lodash";
+
+import {
+  CsvData,
+  MappedThing,
+  Mapping,
+  MappingType,
+  RowNumber,
+  RowObservations,
+} from "../types";
+import { generateRowObservations, observationToString } from "./obs_generation";
+
+function rowObsToStrList(
+  rowObs: RowObservations
+): Map<RowNumber, Array<string>> {
+  const res = new Map<RowNumber, Array<string>>();
+  for (const idx of Array.from(rowObs.keys())) {
+    const strList = new Array<string>();
+    for (const obs of rowObs.get(idx)) {
+      strList.push(observationToString(obs));
+    }
+    res.set(idx, strList);
+  }
+  return res;
+}
+
+test("GenerateRowObservations_SingleValueColumn", () => {
+  const inMappings: Mapping = new Map([
+    [
+      MappedThing.PLACE,
+      {
+        type: MappingType.COLUMN,
+        column: { id: "iso", header: "iso", columnIdx: 0 },
+        placeProperty: { dcid: "isoCode", displayName: "isoCode" },
+      },
+    ],
+    [
+      MappedThing.STAT_VAR,
+      {
+        type: MappingType.COLUMN,
+        column: { id: "indicators", header: "indicators", columnIdx: 1 },
+      },
+    ],
+    [
+      MappedThing.DATE,
+      {
+        type: MappingType.COLUMN,
+        column: { id: "date", header: "date", columnIdx: 2 },
+      },
+    ],
+    [
+      MappedThing.VALUE,
+      {
+        type: MappingType.COLUMN,
+        column: { id: "val", header: "val", columnIdx: 3 },
+      },
+    ],
+    [
+      MappedThing.UNIT,
+      {
+        type: MappingType.CONSTANT,
+        constant: "USDollar",
+      },
+    ],
+  ]);
+  const inCsvData: CsvData = {
+    orderedColumns: [
+      { id: "iso", header: "iso", columnIdx: 0 },
+      { id: "indicators", header: "indicators", columnIdx: 1 },
+      { id: "date", header: "date", columnIdx: 2 },
+      { id: "val", header: "val", columnIdx: 3 },
+    ],
+    columnValuesSampled: null,
+    rowsForDisplay: new Map([
+      [1, ["USA", "Count_Person", "2022", "329000000"]],
+      [2, ["IND", "Count_Goat", "2021", ""]],
+      [1000, ["CHN", "Count_Dog", "2022", "100000001"]],
+    ]),
+  };
+  const expected: Map<RowNumber, Array<string>> = new Map([
+    [1, ["Value of Count_Person for USA in 2022 is 329000000 USDollar"]],
+    [1000, ["Value of Count_Dog for CHN in 2022 is 100000001 USDollar"]],
+  ]);
+  const actual = rowObsToStrList(
+    generateRowObservations(inMappings, inCsvData)
+  );
+  expect(Array.from(actual.keys())).toEqual(Array.from(expected.keys()));
+  expect(Array.from(actual.values())).toEqual(Array.from(expected.values()));
+});
+
+test("GenerateRowObservations_DateValuesInHeader", () => {
+  const inMappings: Mapping = new Map([
+    [
+      MappedThing.PLACE,
+      {
+        type: MappingType.COLUMN,
+        column: { id: "id", header: "id", columnIdx: 0 },
+        placeProperty: { dcid: "dcid", displayName: "dcid" },
+      },
+    ],
+    [
+      MappedThing.STAT_VAR,
+      {
+        type: MappingType.COLUMN,
+        column: { id: "indicators", header: "indicators", columnIdx: 1 },
+      },
+    ],
+    [
+      MappedThing.DATE,
+      {
+        type: MappingType.COLUMN_HEADER,
+        headers: [
+          { id: "2018", header: "2018", columnIdx: 2 },
+          { id: "2019", header: "2019", columnIdx: 3 },
+        ],
+      },
+    ],
+    [
+      MappedThing.UNIT,
+      {
+        type: MappingType.CONSTANT,
+        constant: "USDollar",
+      },
+    ],
+  ]);
+  const inCsvData: CsvData = {
+    orderedColumns: [
+      { id: "id", header: "id", columnIdx: 0 },
+      { id: "indicators", header: "indicators", columnIdx: 1 },
+      { id: "2018", header: "2019", columnIdx: 2 },
+      { id: "2018", header: "2019", columnIdx: 3 },
+    ],
+    columnValuesSampled: null,
+    rowsForDisplay: new Map([
+      [1, ["USA", "Count_Person", "300000000", "329000000"]],
+      [2, ["IND", "Count_Goat", "2000000", ""]],
+      [1000, ["CHN", "Count_Dog", "100000001", "110000000"]],
+    ]),
+  };
+  const expected: Map<RowNumber, Array<string>> = new Map([
+    [
+      1,
+      [
+        "Value of Count_Person for USA in 2019 is 300000000 USDollar",
+        "Value of Count_Person for USA in 2019 is 329000000 USDollar",
+      ],
+    ],
+    [2, ["Value of Count_Goat for IND in 2019 is 2000000 USDollar"]],
+    [
+      1000,
+      [
+        "Value of Count_Dog for CHN in 2019 is 100000001 USDollar",
+        "Value of Count_Dog for CHN in 2019 is 110000000 USDollar",
+      ],
+    ],
+  ]);
+  const actual = rowObsToStrList(
+    generateRowObservations(inMappings, inCsvData)
+  );
+  expect(Array.from(actual.keys())).toEqual(Array.from(expected.keys()));
+  expect(Array.from(actual.values())).toEqual(Array.from(expected.values()));
+});

--- a/wizard/src/utils/obs_generation.test.tsx
+++ b/wizard/src/utils/obs_generation.test.tsx
@@ -92,6 +92,7 @@ test("GenerateRowObservations_SingleValueColumn", () => {
       [1000, ["CHN", "Count_Dog", "2022", "100000001"]],
     ]),
   };
+  // NOTE: Row 2 only has no entry because value is empty.
   const expected: Map<RowNumber, Array<string>> = new Map([
     [1, ["Value of Count_Person for USA in 2022 is 329000000 USDollar"]],
     [1000, ["Value of Count_Dog for CHN in 2022 is 100000001 USDollar"]],
@@ -152,6 +153,7 @@ test("GenerateRowObservations_DateValuesInHeader", () => {
       [1000, ["CHN", "Count_Dog", "100000001", "110000000"]],
     ]),
   };
+  // NOTE: Row 2 only has one entry because the value is empty.
   const expected: Map<RowNumber, Array<string>> = new Map([
     [
       1,

--- a/wizard/src/utils/obs_generation.ts
+++ b/wizard/src/utils/obs_generation.ts
@@ -25,6 +25,7 @@ import {
   RowObservations,
 } from "../types";
 
+// Helper maps used while generating observaitons.
 interface ObsGenMaps {
   // Column Index -> mapping thing found in header for VALUE.
   valCol2Hdr: Map<number, MappedThing>;
@@ -34,6 +35,11 @@ interface ObsGenMaps {
   thing2Const: Map<MappedThing, string>;
 }
 
+/**
+ * Given a mapping and CSV Data computes the observations for every row
+ * corresponding to |rowsForDisplay|.
+ * ASSUMES: checkMappings() returns success on |mappings|
+ */
 export function generateRowObservations(
   mappings: Mapping,
   csvData: CsvData
@@ -76,6 +82,10 @@ export function generateRowObservations(
   return rowObs;
 }
 
+/**
+ * Given an Observation that was returned from generateRowObservations(), returns
+ * a human-readable string.
+ */
 export function observationToString(obs: Observation): string {
   const sv = obs.get(MappedThing.STAT_VAR);
   const place = obs.get(MappedThing.PLACE);

--- a/wizard/src/utils/obs_generation.ts
+++ b/wizard/src/utils/obs_generation.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Column,
+  CsvData,
+  MappedThing,
+  Mapping,
+  MappingType,
+  MappingVal,
+  Observation,
+  RowObservations,
+} from "../types";
+
+interface ObsGenMaps {
+  // Column Index -> mapping thing found in header for VALUE.
+  valCol2Hdr: Map<number, MappedThing>;
+  // Mapped thing -> column index (for non-VALUE)
+  thing2Col: Map<MappedThing, number>;
+  // Mapped thing -> constant value (for non-VALUE)
+  thing2Const: Map<MappedThing, string>;
+}
+
+export function generateRowObservations(
+  mappings: Mapping,
+  csvData: CsvData
+): RowObservations {
+  // Compute ObsGenMaps first.
+  const obsGenMaps: ObsGenMaps = {
+    valCol2Hdr: new Map<number, MappedThing>(),
+    thing2Col: new Map<MappedThing, number>(),
+    thing2Const: new Map<MappedThing, string>(),
+  };
+  for (const mthing of Array.from(mappings.keys())) {
+    const mval: MappingVal = mappings.get(mthing);
+    if (mval.type === MappingType.COLUMN_HEADER) {
+      for (const hdr of mval.headers) {
+        obsGenMaps.valCol2Hdr.set(hdr.columnIdx, mthing);
+      }
+    } else if (mval.type == MappingType.COLUMN) {
+      if (mthing == MappedThing.VALUE) {
+        obsGenMaps.valCol2Hdr.set(mval.column.columnIdx, mthing);
+      } else {
+        obsGenMaps.thing2Col.set(mthing, mval.column.columnIdx);
+      }
+    } else if (mval.type == MappingType.CONSTANT) {
+      obsGenMaps.thing2Const.set(mthing, mval.constant);
+    }
+  }
+
+  const rowObs: RowObservations = new Map();
+  for (const idx of Array.from(csvData.rowsForDisplay.keys())) {
+    const row = csvData.rowsForDisplay.get(idx);
+    const obs = generateObservationsInRow(
+      row,
+      csvData.orderedColumns,
+      obsGenMaps
+    );
+    if (obs.length > 0) {
+      rowObs.set(idx, obs);
+    }
+  }
+  return rowObs;
+}
+
+export function observationToString(obs: Observation): string {
+  const sv = obs.get(MappedThing.STAT_VAR);
+  const place = obs.get(MappedThing.PLACE);
+  const date = obs.get(MappedThing.DATE);
+  const val = obs.get(MappedThing.VALUE);
+  let outStr = `Value of ${sv} for ${place} in ${date} is ${val}`;
+  if (obs.has(MappedThing.UNIT)) {
+    outStr += ` ${obs.get(MappedThing.UNIT)}`;
+  }
+  return outStr;
+}
+
+function generateObservationsInRow(
+  row: Array<string>,
+  header: Array<Column>,
+  obsGenMaps: ObsGenMaps
+): Array<Observation> {
+  const obsList = new Array<Observation>();
+  for (const valColIdx of Array.from(obsGenMaps.valCol2Hdr.keys())) {
+    const hdrThing = obsGenMaps.valCol2Hdr.get(valColIdx);
+    const obs: Observation = new Map();
+    // TODO: Consider if we want to do some cleaning and checking for non-numeric value.
+    if (row[valColIdx] != null && row[valColIdx] !== "") {
+      obs.set(MappedThing.VALUE, row[valColIdx]);
+    }
+    // If this is a COLUMN_HEADER case, get the corresponding header value.
+    if (hdrThing !== MappedThing.VALUE) {
+      obs.set(hdrThing, header[valColIdx].header);
+    }
+    for (const mthing of Array.from(obsGenMaps.thing2Col.keys())) {
+      const colIdx = obsGenMaps.thing2Col.get(mthing);
+      if (row[colIdx] != null && row[colIdx] !== "") {
+        obs.set(mthing, row[colIdx]);
+      }
+    }
+    for (const mthing of Array.from(obsGenMaps.thing2Const.keys())) {
+      obs.set(mthing, obsGenMaps.thing2Const.get(mthing));
+    }
+    if (hasRequiredProps(obs)) {
+      obsList.push(obs);
+    }
+  }
+  return obsList;
+}
+
+function hasRequiredProps(obs: Observation): boolean {
+  for (const mthing of [
+    MappedThing.PLACE,
+    MappedThing.STAT_VAR,
+    MappedThing.DATE,
+    MappedThing.VALUE,
+  ]) {
+    if (!obs.has(mthing)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/wizard/src/utils/obs_generation.ts
+++ b/wizard/src/utils/obs_generation.ts
@@ -27,7 +27,7 @@ import {
   RowObservations,
 } from "../types";
 
-// Helper maps used while generating observaitons.
+// Helper maps used while generating observations.
 interface ObsGenMaps {
   // Column Index -> mapped thing found in header for VALUE.
   valCol2Hdr: Map<number, MappedThing>;
@@ -88,6 +88,10 @@ function generateObservationsInRow(
  * Given a mapping and CSV Data computes the observations for every row
  * corresponding to |rowsForDisplay|.
  * ASSUMES: checkMappings() returns success on |mappings|
+ *
+ * @param {mappings} finalized column mappings
+ * @param {csvData} summary of input CSV
+ * @returns {RowObservations} valid observations per display row
  */
 export function generateRowObservations(
   mappings: Mapping,
@@ -134,6 +138,9 @@ export function generateRowObservations(
 /**
  * Given an Observation that was returned from generateRowObservations(), returns
  * a human-readable string.
+ *
+ * @param {obs} a valid Observation
+ * @returns {string} a human-readable string describing the Observation
  */
 export function observationToString(obs: Observation): string {
   const sv = obs.get(MappedThing.STAT_VAR);


### PR DESCRIPTION
The main API returns observations as a map, associated with rows, so that the frontend can decide to link it to display rows.

There's also a helper to produce a text string from the map that's to be tweaked as necessary.