### PR TITLE
add "expand/collapse all" buttons to summary_report

### DIFF
--- a/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/summary_report.html
@@ -316,6 +316,22 @@
       $(id).removeClass("no-footer");
     }
 
+    // Set the "open" attribute of all 'details' tags to `new_value`.
+    // `new_value` should be boolean; true for open, false for close.
+    function set_all_details(new_value){
+      const tags = document.querySelectorAll('details');
+      tags.forEach(tag=>{
+          tag.open = new_value
+        });
+    }
+
+    function close_all_details(tags){
+      set_all_details(false)
+    }
+    function open_all_details(tags){
+      set_all_details(true)
+    }
+
     $(document).ready(function () {
       const sampleplace_table_ids = [
       ]

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/summary_report.html
@@ -53,6 +53,8 @@
     </div>
     <h1>Summary Report</h1>
     <h3>Table of Contents</h3>
+    <button onclick="open_all_details()">Expand All</button>
+    <button onclick="close_all_details()">Collapse All</button>
     <ul>
       <li><a href="#import-run-details">Import Run Details</a></li>
       <li><a href="#counters">Counters</a></li>

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/summary_report.html
@@ -53,6 +53,8 @@
     </div>
     <h1>Summary Report</h1>
     <h3>Table of Contents</h3>
+    <button onclick="open_all_details()">Expand All</button>
+    <button onclick="close_all_details()">Collapse All</button>
     <ul>
       <li><a href="#import-run-details">Import Run Details</a></li>
       <li><a href="#counters">Counters</a></li>
@@ -277,8 +279,7 @@
         <h2>
           <a name="places" href="#places">Series Summaries for Sample Places</a>
         </h2>
-        <button onclick="open_all_details()">Expand All</button>
-        <button onclick="close_all_details()">Collapse All</button>
+
           <details class="place-series-details">
             <summary class="place-series-summary"><a name="places--pseudoPlaceSimple" href="#places--pseudoPlaceSimple">pseudoPlaceSimple (pseudoPlaceSimple)</a></summary>
             <a href="https://datacommons.org/browser/pseudoPlaceSimple" target="_blank">Open this place (pseudoPlaceSimple) in Data Commons browser.</a>

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/summary_report.html
@@ -277,6 +277,8 @@
         <h2>
           <a name="places" href="#places">Series Summaries for Sample Places</a>
         </h2>
+        <button onclick="open_all_details()">Expand All</button>
+        <button onclick="close_all_details()">Collapse All</button>
           <details class="place-series-details">
             <summary class="place-series-summary"><a name="places--pseudoPlaceSimple" href="#places--pseudoPlaceSimple">pseudoPlaceSimple (pseudoPlaceSimple)</a></summary>
             <a href="https://datacommons.org/browser/pseudoPlaceSimple" target="_blank">Open this place (pseudoPlaceSimple) in Data Commons browser.</a>
@@ -365,6 +367,22 @@
       // reference for another post mentioning this issue:
       // https://datatables.net/forums/discussion/53837/class-no-footer-applied-to-table-despite-a-footer-is-present
       $(id).removeClass("no-footer");
+    }
+
+    // Set the "open" attribute of all 'details' tags to `new_value`.
+    // `new_value` should be boolean; true for open, false for close.
+    function set_all_details(new_value){
+      const tags = document.querySelectorAll('details');
+      tags.forEach(tag=>{
+          tag.open = new_value
+        });
+    }
+
+    function close_all_details(tags){
+      set_all_details(false)
+    }
+    function open_all_details(tags){
+      set_all_details(true)
     }
 
     $(document).ready(function () {

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/summary_report.html
@@ -53,6 +53,8 @@
     </div>
     <h1>Summary Report</h1>
     <h3>Table of Contents</h3>
+    <button onclick="open_all_details()">Expand All</button>
+    <button onclick="close_all_details()">Collapse All</button>
     <ul>
       <li><a href="#import-run-details">Import Run Details</a></li>
       <li><a href="#counters">Counters</a></li>
@@ -413,8 +415,7 @@
         <h2>
           <a name="places" href="#places">Series Summaries for Sample Places</a>
         </h2>
-        <button onclick="open_all_details()">Expand All</button>
-        <button onclick="close_all_details()">Collapse All</button>
+
           <details class="place-series-details">
             <summary class="place-series-summary"><a name="places--geoId/0649670" href="#places--geoId/0649670">Mountain View (geoId/0649670)</a></summary>
             <a href="https://datacommons.org/browser/geoId/0649670" target="_blank">Open this place (geoId/0649670) in Data Commons browser.</a>

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/summary_report.html
@@ -413,6 +413,8 @@
         <h2>
           <a name="places" href="#places">Series Summaries for Sample Places</a>
         </h2>
+        <button onclick="open_all_details()">Expand All</button>
+        <button onclick="close_all_details()">Collapse All</button>
           <details class="place-series-details">
             <summary class="place-series-summary"><a name="places--geoId/0649670" href="#places--geoId/0649670">Mountain View (geoId/0649670)</a></summary>
             <a href="https://datacommons.org/browser/geoId/0649670" target="_blank">Open this place (geoId/0649670) in Data Commons browser.</a>
@@ -677,6 +679,22 @@
       // reference for another post mentioning this issue:
       // https://datatables.net/forums/discussion/53837/class-no-footer-applied-to-table-despite-a-footer-is-present
       $(id).removeClass("no-footer");
+    }
+
+    // Set the "open" attribute of all 'details' tags to `new_value`.
+    // `new_value` should be boolean; true for open, false for close.
+    function set_all_details(new_value){
+      const tags = document.querySelectorAll('details');
+      tags.forEach(tag=>{
+          tag.open = new_value
+        });
+    }
+
+    function close_all_details(tags){
+      set_all_details(false)
+    }
+    function open_all_details(tags){
+      set_all_details(true)
     }
 
     $(document).ready(function () {

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/statchecks/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/statchecks/output/summary_report.html
@@ -53,6 +53,8 @@
     </div>
     <h1>Summary Report</h1>
     <h3>Table of Contents</h3>
+    <button onclick="open_all_details()">Expand All</button>
+    <button onclick="close_all_details()">Collapse All</button>
     <ul>
       <li><a href="#import-run-details">Import Run Details</a></li>
       <li><a href="#counters">Counters</a></li>
@@ -470,8 +472,7 @@
         <h2>
           <a name="places" href="#places">Series Summaries for Sample Places</a>
         </h2>
-        <button onclick="open_all_details()">Expand All</button>
-        <button onclick="close_all_details()">Collapse All</button>
+
           <details class="place-series-details">
             <summary class="place-series-summary"><a name="places--geoId/01" href="#places--geoId/01">Alabama (geoId/01)</a></summary>
             <a href="https://datacommons.org/browser/geoId/01" target="_blank">Open this place (geoId/01) in Data Commons browser.</a>

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/statchecks/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/statchecks/output/summary_report.html
@@ -470,6 +470,8 @@
         <h2>
           <a name="places" href="#places">Series Summaries for Sample Places</a>
         </h2>
+        <button onclick="open_all_details()">Expand All</button>
+        <button onclick="close_all_details()">Collapse All</button>
           <details class="place-series-details">
             <summary class="place-series-summary"><a name="places--geoId/01" href="#places--geoId/01">Alabama (geoId/01)</a></summary>
             <a href="https://datacommons.org/browser/geoId/01" target="_blank">Open this place (geoId/01) in Data Commons browser.</a>
@@ -1220,6 +1222,22 @@
       // reference for another post mentioning this issue:
       // https://datatables.net/forums/discussion/53837/class-no-footer-applied-to-table-despite-a-footer-is-present
       $(id).removeClass("no-footer");
+    }
+
+    // Set the "open" attribute of all 'details' tags to `new_value`.
+    // `new_value` should be boolean; true for open, false for close.
+    function set_all_details(new_value){
+      const tags = document.querySelectorAll('details');
+      tags.forEach(tag=>{
+          tag.open = new_value
+        });
+    }
+
+    function close_all_details(tags){
+      set_all_details(false)
+    }
+    function open_all_details(tags){
+      set_all_details(true)
     }
 
     $(document).ready(function () {

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/output/summary_report.html
@@ -53,6 +53,8 @@
     </div>
     <h1>Summary Report</h1>
     <h3>Table of Contents</h3>
+    <button onclick="open_all_details()">Expand All</button>
+    <button onclick="close_all_details()">Collapse All</button>
     <ul>
       <li><a href="#import-run-details">Import Run Details</a></li>
       <li><a href="#counters">Counters</a></li>
@@ -572,8 +574,7 @@
         <h2>
           <a name="places" href="#places">Series Summaries for Sample Places</a>
         </h2>
-        <button onclick="open_all_details()">Expand All</button>
-        <button onclick="close_all_details()">Collapse All</button>
+
           <details class="place-series-details">
             <summary class="place-series-summary"><a name="places--CA-AB" href="#places--CA-AB">CA-AB (CA-AB)</a></summary>
             <a href="https://datacommons.org/browser/CA-AB" target="_blank">Open this place (CA-AB) in Data Commons browser.</a>

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/output/summary_report.html
@@ -572,6 +572,8 @@
         <h2>
           <a name="places" href="#places">Series Summaries for Sample Places</a>
         </h2>
+        <button onclick="open_all_details()">Expand All</button>
+        <button onclick="close_all_details()">Collapse All</button>
           <details class="place-series-details">
             <summary class="place-series-summary"><a name="places--CA-AB" href="#places--CA-AB">CA-AB (CA-AB)</a></summary>
             <a href="https://datacommons.org/browser/CA-AB" target="_blank">Open this place (CA-AB) in Data Commons browser.</a>
@@ -1106,6 +1108,22 @@
       // reference for another post mentioning this issue:
       // https://datatables.net/forums/discussion/53837/class-no-footer-applied-to-table-despite-a-footer-is-present
       $(id).removeClass("no-footer");
+    }
+
+    // Set the "open" attribute of all 'details' tags to `new_value`.
+    // `new_value` should be boolean; true for open, false for close.
+    function set_all_details(new_value){
+      const tags = document.querySelectorAll('details');
+      tags.forEach(tag=>{
+          tag.open = new_value
+        });
+    }
+
+    function close_all_details(tags){
+      set_all_details(false)
+    }
+    function open_all_details(tags){
+      set_all_details(true)
     }
 
     $(document).ready(function () {

--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/summary_report.html
@@ -744,6 +744,8 @@
         <h2>
           <a name="places" href="#places">Series Summaries for Sample Places</a>
         </h2>
+        <button onclick="open_all_details()">Expand All</button>
+        <button onclick="close_all_details()">Collapse All</button>
           <details class="place-series-details">
             <summary class="place-series-summary"><a name="places--CA-AB" href="#places--CA-AB">CA-AB (CA-AB)</a></summary>
             <a href="https://datacommons.org/browser/CA-AB" target="_blank">Open this place (CA-AB) in Data Commons browser.</a>
@@ -1190,6 +1192,22 @@
       // reference for another post mentioning this issue:
       // https://datatables.net/forums/discussion/53837/class-no-footer-applied-to-table-despite-a-footer-is-present
       $(id).removeClass("no-footer");
+    }
+
+    // Set the "open" attribute of all 'details' tags to `new_value`.
+    // `new_value` should be boolean; true for open, false for close.
+    function set_all_details(new_value){
+      const tags = document.querySelectorAll('details');
+      tags.forEach(tag=>{
+          tag.open = new_value
+        });
+    }
+
+    function close_all_details(tags){
+      set_all_details(false)
+    }
+    function open_all_details(tags){
+      set_all_details(true)
     }
 
     $(document).ready(function () {

--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/summary_report.html
@@ -53,6 +53,8 @@
     </div>
     <h1>Summary Report</h1>
     <h3>Table of Contents</h3>
+    <button onclick="open_all_details()">Expand All</button>
+    <button onclick="close_all_details()">Collapse All</button>
     <ul>
       <li><a href="#import-run-details">Import Run Details</a></li>
       <li><a href="#counters">Counters</a></li>
@@ -744,8 +746,7 @@
         <h2>
           <a name="places" href="#places">Series Summaries for Sample Places</a>
         </h2>
-        <button onclick="open_all_details()">Expand All</button>
-        <button onclick="close_all_details()">Collapse All</button>
+
           <details class="place-series-details">
             <summary class="place-series-summary"><a name="places--CA-AB" href="#places--CA-AB">CA-AB (CA-AB)</a></summary>
             <a href="https://datacommons.org/browser/CA-AB" target="_blank">Open this place (CA-AB) in Data Commons browser.</a>

--- a/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/summary_report.html
@@ -526,6 +526,22 @@
       $(id).removeClass("no-footer");
     }
 
+    // Set the "open" attribute of all 'details' tags to `new_value`.
+    // `new_value` should be boolean; true for open, false for close.
+    function set_all_details(new_value){
+      const tags = document.querySelectorAll('details');
+      tags.forEach(tag=>{
+          tag.open = new_value
+        });
+    }
+
+    function close_all_details(tags){
+      set_all_details(false)
+    }
+    function open_all_details(tags){
+      set_all_details(true)
+    }
+
     $(document).ready(function () {
       const sampleplace_table_ids = [
       ]

--- a/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/summary_report.html
@@ -53,6 +53,8 @@
     </div>
     <h1>Summary Report</h1>
     <h3>Table of Contents</h3>
+    <button onclick="open_all_details()">Expand All</button>
+    <button onclick="close_all_details()">Collapse All</button>
     <ul>
       <li><a href="#import-run-details">Import Run Details</a></li>
       <li><a href="#counters">Counters</a></li>

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/summary_report.html
@@ -561,6 +561,22 @@
       $(id).removeClass("no-footer");
     }
 
+    // Set the "open" attribute of all 'details' tags to `new_value`.
+    // `new_value` should be boolean; true for open, false for close.
+    function set_all_details(new_value){
+      const tags = document.querySelectorAll('details');
+      tags.forEach(tag=>{
+          tag.open = new_value
+        });
+    }
+
+    function close_all_details(tags){
+      set_all_details(false)
+    }
+    function open_all_details(tags){
+      set_all_details(true)
+    }
+
     $(document).ready(function () {
       const sampleplace_table_ids = [
       ]

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/summary_report.html
@@ -53,6 +53,8 @@
     </div>
     <h1>Summary Report</h1>
     <h3>Table of Contents</h3>
+    <button onclick="open_all_details()">Expand All</button>
+    <button onclick="close_all_details()">Collapse All</button>
     <ul>
       <li><a href="#import-run-details">Import Run Details</a></li>
       <li><a href="#counters">Counters</a></li>

--- a/tool/src/test/resources/org/datacommons/tool/lint/statchecks/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/statchecks/output/summary_report.html
@@ -339,6 +339,8 @@
         <h2>
           <a name="places" href="#places">Series Summaries for Sample Places</a>
         </h2>
+        <button onclick="open_all_details()">Expand All</button>
+        <button onclick="close_all_details()">Collapse All</button>
           <details class="place-series-details">
             <summary class="place-series-summary"><a name="places--geoId/06" href="#places--geoId/06">California (geoId/06)</a></summary>
             <a href="https://datacommons.org/browser/geoId/06" target="_blank">Open this place (geoId/06) in Data Commons browser.</a>
@@ -647,6 +649,22 @@
       // reference for another post mentioning this issue:
       // https://datatables.net/forums/discussion/53837/class-no-footer-applied-to-table-despite-a-footer-is-present
       $(id).removeClass("no-footer");
+    }
+
+    // Set the "open" attribute of all 'details' tags to `new_value`.
+    // `new_value` should be boolean; true for open, false for close.
+    function set_all_details(new_value){
+      const tags = document.querySelectorAll('details');
+      tags.forEach(tag=>{
+          tag.open = new_value
+        });
+    }
+
+    function close_all_details(tags){
+      set_all_details(false)
+    }
+    function open_all_details(tags){
+      set_all_details(true)
     }
 
     $(document).ready(function () {

--- a/tool/src/test/resources/org/datacommons/tool/lint/statchecks/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/statchecks/output/summary_report.html
@@ -53,6 +53,8 @@
     </div>
     <h1>Summary Report</h1>
     <h3>Table of Contents</h3>
+    <button onclick="open_all_details()">Expand All</button>
+    <button onclick="close_all_details()">Collapse All</button>
     <ul>
       <li><a href="#import-run-details">Import Run Details</a></li>
       <li><a href="#counters">Counters</a></li>
@@ -339,8 +341,7 @@
         <h2>
           <a name="places" href="#places">Series Summaries for Sample Places</a>
         </h2>
-        <button onclick="open_all_details()">Expand All</button>
-        <button onclick="close_all_details()">Collapse All</button>
+
           <details class="place-series-details">
             <summary class="place-series-summary"><a name="places--geoId/06" href="#places--geoId/06">California (geoId/06)</a></summary>
             <a href="https://datacommons.org/browser/geoId/06" target="_blank">Open this place (geoId/06) in Data Commons browser.</a>

--- a/util/src/main/resources/SummaryReport.ftl
+++ b/util/src/main/resources/SummaryReport.ftl
@@ -236,6 +236,8 @@
         <h2>
           <a name="places" href="#places">Series Summaries for Sample Places</a>
         </h2>
+        <button onclick="open_all_details()">Expand All</button>
+        <button onclick="close_all_details()">Collapse All</button>
         <#list placeSeriesSummaryMap as place, placeSeriesSummary>
           <details class="place-series-details">
             <summary class="place-series-summary"><a name="places--${place}" href="#places--${place}">${(placeSeriesSummary.getPlaceName())!place} (${place})</a></summary>
@@ -327,6 +329,22 @@
       // reference for another post mentioning this issue:
       // https://datatables.net/forums/discussion/53837/class-no-footer-applied-to-table-despite-a-footer-is-present
       $(id).removeClass("no-footer");
+    }
+
+    // Set the "open" attribute of all 'details' tags to `new_value`.
+    // `new_value` should be boolean; true for open, false for close.
+    function set_all_details(new_value){
+      const tags = document.querySelectorAll('details');
+      tags.forEach(tag=>{
+          tag.open = new_value
+        });
+    }
+
+    function close_all_details(tags){
+      set_all_details(false)
+    }
+    function open_all_details(tags){
+      set_all_details(true)
     }
 
     $(document).ready(function () {

--- a/util/src/main/resources/SummaryReport.ftl
+++ b/util/src/main/resources/SummaryReport.ftl
@@ -53,6 +53,8 @@
     </div>
     <h1>Summary Report</h1>
     <h3>Table of Contents</h3>
+    <button onclick="open_all_details()">Expand All</button>
+    <button onclick="close_all_details()">Collapse All</button>
     <ul>
       <li><a href="#import-run-details">Import Run Details</a></li>
       <li><a href="#counters">Counters</a></li>
@@ -236,8 +238,7 @@
         <h2>
           <a name="places" href="#places">Series Summaries for Sample Places</a>
         </h2>
-        <button onclick="open_all_details()">Expand All</button>
-        <button onclick="close_all_details()">Collapse All</button>
+
         <#list placeSeriesSummaryMap as place, placeSeriesSummary>
           <details class="place-series-details">
             <summary class="place-series-summary"><a name="places--${place}" href="#places--${place}">${(placeSeriesSummary.getPlaceName())!place} (${place})</a></summary>


### PR DESCRIPTION
Closes #160 

---

add buttons under the "Series Summaries for Sample Places" header that
expand or collapse all `<details>` tags for sample places.

uses a javascript function that queries the page for `<details>` tags, and
sets the ".open" boolean attribute on all of them.