### PR TITLE
 Fix test `report.json` flaky order

### DIFF
--- a/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
+++ b/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FilenameUtils;
+import org.datacommons.util.LogWrapper;
 import org.datacommons.util.SummaryReportGenerator;
 import org.datacommons.util.TmcfCsvParser;
 import org.junit.Rule;
@@ -61,6 +62,7 @@ public class GenMcfTest {
     // Set this so that the generated node IDs are deterministic
     TmcfCsvParser.TEST_mode = true;
     SummaryReportGenerator.TEST_mode = true;
+    LogWrapper.TEST_MODE = true;
 
     String goldenFilesPrefix = System.getProperty("goldenFilesPrefix");
     Main app = new Main();

--- a/tool/src/test/java/org/datacommons/tool/LintTest.java
+++ b/tool/src/test/java/org/datacommons/tool/LintTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import org.datacommons.util.LogWrapper;
 import org.datacommons.util.SummaryReportGenerator;
 import org.datacommons.util.TmcfCsvParser;
 import org.junit.Rule;
@@ -35,6 +36,7 @@ public class LintTest {
     // Set this so that the generated node IDs are deterministic
     TmcfCsvParser.TEST_mode = true;
     SummaryReportGenerator.TEST_mode = true;
+    LogWrapper.TEST_MODE = true;
 
     String goldenFilesPrefix = System.getProperty("goldenFilesPrefix");
     Main app = new Main();

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/report.json
@@ -31,13 +31,13 @@
     }
   },
   "entries": [{
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_FATAL",
     "location": {
       "file": "FatalTmcf.tmcf",
-      "lineNumber": "1"
+      "lineNumber": "0"
     },
-    "userMessage": "Property found without a preceding line with 'Node' :: line: 'typeOf dcs:StatVarObservation'",
-    "counterKey": "MCF_UnexpectedProperty"
+    "userMessage": "Found fatal sanity error in TMCF; check Sanity_ counter messages :: TMCF-file: FatalTmcf.tmcf",
+    "counterKey": "CSV_TmcfCheckFailure"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -50,34 +50,10 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "FatalTmcf.tmcf",
-      "lineNumber": "11"
+      "lineNumber": "34"
     },
-    "userMessage": "Found malformed entity name that is not an entity prefix (E:) :: name: '\"E:SVTest->E1\"'",
-    "counterKey": "TMCF_MalformedEntity"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "FatalTmcf.tmcf",
-      "lineNumber": "22"
-    },
-    "userMessage": "Malformed column value; must have a '->' delimiter :: value: 'C:SVTest>Place_Name', property: 'name', node: 'E:SVTest->E3'",
-    "counterKey": "TMCF_MalformedSchemaTerm"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "FatalTmcf.tmcf",
-      "lineNumber": "25"
-    },
-    "userMessage": "Found malformed entity name that is not an entity prefix (E:) :: name: 'C:SVTest->NodeDcid'",
-    "counterKey": "TMCF_MalformedEntity"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "FatalTmcf.tmcf",
-      "lineNumber": "27"
-    },
-    "userMessage": "TMCF properties cannot refer to CSV columns yet :: value: 'SVTest->Property: C:SVTest->Property_Value', property: 'C', node: 'E:SVTest->E3'",
-    "counterKey": "TMCF_UnsupportedColumnNameInProperty"
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[', property: 'age', node: 'E:SVTest->E4'",
+    "counterKey": "MCF_MalformedComplexValue"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -90,58 +66,10 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "FatalTmcf.tmcf",
-      "lineNumber": "34"
+      "lineNumber": "1"
     },
-    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[', property: 'age', node: 'E:SVTest->E4'",
-    "counterKey": "MCF_MalformedComplexValue"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "FatalTmcf.tmcf",
-      "lineNumber": "19"
-    },
-    "userMessage": "Found dcid with more than one value :: count: 3, node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_MultipleDcidValues"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "FatalTmcf.tmcf",
-      "lineNumber": "19"
-    },
-    "userMessage": "Found property name that does not start with a lower-case :: property: 'Dcid', node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_NotInitLowerPropName"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "FatalTmcf.tmcf",
-      "lineNumber": "19"
-    },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E10', property: 'dcid' node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_TmcfMissingEntityDef"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "FatalTmcf.tmcf",
-      "lineNumber": "19"
-    },
-    "userMessage": "Column referred to in TMCF is missing from CSV header :: column: 'dcid1', node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_TmcfMissingColumn"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "FatalTmcf.tmcf",
-      "lineNumber": "19"
-    },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_TmcfMissingEntityDef"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "FatalTmcf.tmcf",
-      "lineNumber": "32"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'E:SVTest->E4', type: 'Thing'",
-    "counterKey": "Sanity_MissingOrEmpty_typeOf"
+    "userMessage": "Property found without a preceding line with 'Node' :: line: 'typeOf dcs:StatVarObservation'",
+    "counterKey": "MCF_UnexpectedProperty"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -156,8 +84,16 @@
       "file": "FatalTmcf.tmcf",
       "lineNumber": "32"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E1', property: 'dcid' node: 'E:SVTest->E4'",
-    "counterKey": "Sanity_TmcfMissingEntityDef"
+    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'E:SVTest->E4', type: 'Thing'",
+    "counterKey": "Sanity_MissingOrEmpty_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "FatalTmcf.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "Found dcid with more than one value :: count: 3, node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_MultipleDcidValues"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -178,18 +114,82 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "FatalTmcf.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "Found property name that does not start with a lower-case :: property: 'Dcid', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_NotInitLowerPropName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "FatalTmcf.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "Column referred to in TMCF is missing from CSV header :: column: 'dcid1', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_TmcfMissingColumn"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "FatalTmcf.tmcf",
+      "lineNumber": "32"
+    },
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E1', property: 'dcid' node: 'E:SVTest->E4'",
+    "counterKey": "Sanity_TmcfMissingEntityDef"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "FatalTmcf.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E10', property: 'dcid' node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_TmcfMissingEntityDef"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "FatalTmcf.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E13', property: 'dcid' node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_TmcfMissingEntityDef"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "FatalTmcf.tmcf",
       "lineNumber": "3"
     },
     "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E30', property: 'observationAbout' node: 'E:SVTest->E0'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
-    "level": "LEVEL_FATAL",
+    "level": "LEVEL_ERROR",
     "location": {
       "file": "FatalTmcf.tmcf",
-      "lineNumber": "0"
+      "lineNumber": "25"
     },
-    "userMessage": "Found fatal sanity error in TMCF; check Sanity_ counter messages :: TMCF-file: FatalTmcf.tmcf",
-    "counterKey": "CSV_TmcfCheckFailure"
+    "userMessage": "Found malformed entity name that is not an entity prefix (E:) :: name: 'C:SVTest->NodeDcid'",
+    "counterKey": "TMCF_MalformedEntity"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "FatalTmcf.tmcf",
+      "lineNumber": "11"
+    },
+    "userMessage": "Found malformed entity name that is not an entity prefix (E:) :: name: '\"E:SVTest->E1\"'",
+    "counterKey": "TMCF_MalformedEntity"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "FatalTmcf.tmcf",
+      "lineNumber": "22"
+    },
+    "userMessage": "Malformed column value; must have a '->' delimiter :: value: 'C:SVTest>Place_Name', property: 'name', node: 'E:SVTest->E3'",
+    "counterKey": "TMCF_MalformedSchemaTerm"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "FatalTmcf.tmcf",
+      "lineNumber": "27"
+    },
+    "userMessage": "TMCF properties cannot refer to CSV columns yet :: value: 'SVTest->Property: C:SVTest->Property_Value', property: 'C', node: 'E:SVTest->E3'",
+    "counterKey": "TMCF_UnsupportedColumnNameInProperty"
   }],
   "commandArgs": {
     "existenceChecks": true,

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/report.json
@@ -24,16 +24,16 @@
       "file": "covid.csv",
       "lineNumber": "2"
     },
-    "userMessage": "Found diverging DCIDs for external IDs :: extId1: 'pseudoIsoCodeDiverging, dcid1: 'pseudoPlaceDivergent_AAA', property1: 'isoCode, extId2: 'pseudoWikidataIdDiverging', dcid2:pseudoPlaceDivergent_BBB, property2: 'wikidataId', node: 'COVID19_cases_india/E1/1'",
-    "counterKey": "Resolution_DivergingDcidsForExternalIds_isoCode_wikidataId"
+    "userMessage": "Failed to assign DCID :: type: 'Place', node: 'COVID19_cases_india/E1/1'",
+    "counterKey": "Resolution_DcidAssignmentFailure_Place"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "covid.csv",
       "lineNumber": "2"
     },
-    "userMessage": "Failed to assign DCID :: type: 'Place', node: 'COVID19_cases_india/E1/1'",
-    "counterKey": "Resolution_DcidAssignmentFailure_Place"
+    "userMessage": "Found diverging DCIDs for external IDs :: extId1: 'pseudoIsoCodeDiverging, dcid1: 'pseudoPlaceDivergent_AAA', property1: 'isoCode, extId2: 'pseudoWikidataIdDiverging', dcid2:pseudoPlaceDivergent_BBB, property2: 'wikidataId', node: 'COVID19_cases_india/E1/1'",
+    "counterKey": "Resolution_DivergingDcidsForExternalIds_isoCode_wikidataId"
   }, {
     "level": "LEVEL_ERROR",
     "location": {

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/report.json
@@ -30,30 +30,6 @@
     }
   },
   "entries": [{
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "misc.mcf",
-      "lineNumber": "15"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'SVId', type: 'StatisticalVariable'",
-    "counterKey": "Sanity_MissingOrEmpty_statType"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "misc.mcf",
-      "lineNumber": "15"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'dcid', node: 'SVId', type: 'StatisticalVariable'",
-    "counterKey": "Sanity_MissingOrEmpty_dcid"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "misc.mcf",
-      "lineNumber": "51"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'Song', property: 'typeOf', node: 'SongLocalId'",
-    "counterKey": "Existence_MissingReference_typeOf"
-  }, {
     "level": "LEVEL_WARNING",
     "location": {
       "file": "misc.mcf",
@@ -70,45 +46,13 @@
     "userMessage": "Failed reference existence check :: property-ref: 'bestSong', node: 'AlbumLocalId'",
     "counterKey": "Existence_MissingReference_Property"
   }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "misc.mcf",
-      "lineNumber": "57"
-    },
-    "userMessage": "Found orphan local ref :: ref: 'l:AlphabetId', property: 'parent', node: 'GoogleId'",
-    "counterKey": "Resolution_OrphanLocalReference_parent"
-  }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "misc.mcf",
       "lineNumber": "51"
     },
-    "userMessage": "Failed to assign DCID :: type: 'Song', node: 'SongLocalId'",
-    "counterKey": "Resolution_DcidAssignmentFailure_Song"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "misc.mcf",
-      "lineNumber": "15"
-    },
-    "userMessage": "Failed to assign DCID :: type: 'StatisticalVariable', node: 'SVId'",
-    "counterKey": "Resolution_DcidAssignmentFailure_StatisticalVariable"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "misc.mcf",
-      "lineNumber": "45"
-    },
-    "userMessage": "Failed to assign DCID :: type: 'MusicAlbum', node: 'AlbumLocalId'",
-    "counterKey": "Resolution_DcidAssignmentFailure_MusicAlbum"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "misc.mcf",
-      "lineNumber": "21"
-    },
-    "userMessage": "Found a local ref to an unresolvable node :: ref: 'l:SVId', property: 'variableMeasured', node: 'UnresSVObsId'",
-    "counterKey": "Resolution_ReferenceToFailedNode_variableMeasured"
+    "userMessage": "Failed reference existence check :: value-ref: 'Song', property: 'typeOf', node: 'SongLocalId'",
+    "counterKey": "Existence_MissingReference_typeOf"
   }, {
     "level": "LEVEL_WARNING",
     "location": {
@@ -189,6 +133,62 @@
     },
     "userMessage": "Failed reference existence check :: value-ref: 'CumulativeCount_MedicalTest_ConditionCOVID_19_Positive_Super_Super_Super_Super_Super_Long_Variable_Name', property: 'variableMeasured', node: 'E:COVID19_cases_india->E0'",
     "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "misc.mcf",
+      "lineNumber": "45"
+    },
+    "userMessage": "Failed to assign DCID :: type: 'MusicAlbum', node: 'AlbumLocalId'",
+    "counterKey": "Resolution_DcidAssignmentFailure_MusicAlbum"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "misc.mcf",
+      "lineNumber": "51"
+    },
+    "userMessage": "Failed to assign DCID :: type: 'Song', node: 'SongLocalId'",
+    "counterKey": "Resolution_DcidAssignmentFailure_Song"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "misc.mcf",
+      "lineNumber": "15"
+    },
+    "userMessage": "Failed to assign DCID :: type: 'StatisticalVariable', node: 'SVId'",
+    "counterKey": "Resolution_DcidAssignmentFailure_StatisticalVariable"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "misc.mcf",
+      "lineNumber": "57"
+    },
+    "userMessage": "Found orphan local ref :: ref: 'l:AlphabetId', property: 'parent', node: 'GoogleId'",
+    "counterKey": "Resolution_OrphanLocalReference_parent"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "misc.mcf",
+      "lineNumber": "21"
+    },
+    "userMessage": "Found a local ref to an unresolvable node :: ref: 'l:SVId', property: 'variableMeasured', node: 'UnresSVObsId'",
+    "counterKey": "Resolution_ReferenceToFailedNode_variableMeasured"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "misc.mcf",
+      "lineNumber": "15"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'dcid', node: 'SVId', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_dcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "misc.mcf",
+      "lineNumber": "15"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'SVId', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_statType"
   }],
   "commandArgs": {
     "existenceChecks": true,

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/output/report.json
@@ -45,150 +45,6 @@
     }
   },
   "entries": [{
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "2"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: 'US- CA', invalid-chars: ' ', property: 'dcid', node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_InvalidChars_dcid"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "2"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: 'US- CA', invalid-chars: ' ', property: 'observationAbout', node: 'E:SVTest->E0'",
-    "counterKey": "Sanity_InvalidChars_observationAbout"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "2"
-    },
-    "userMessage": "Found a non-ISO8601 compliant date value :: value: '19', property: 'observationDate', node: 'E:SVTest->E0'",
-    "counterKey": "Sanity_InvalidObsDate"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "2"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: 'US- CA', invalid-chars: ' ', property: 'observationAbout', node: 'E:SVTest->E1'",
-    "counterKey": "Sanity_InvalidChars_observationAbout"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "2"
-    },
-    "userMessage": "Found a non-ISO8601 compliant date value :: value: '19', property: 'observationDate', node: 'E:SVTest->E1'",
-    "counterKey": "Sanity_InvalidObsDate"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "3"
-    },
-    "userMessage": "Found dcid with more than one value :: count: 2, node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_MultipleDcidValues"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "4"
-    },
-    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'Administrative–Area1', type: 'RESOLVED_REF', property: 'typeOf', node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_NonAsciiValueInNonText"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "4"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: 'Administrative–Area1', invalid-chars: '–', property: 'typeOf', node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_InvalidChars_typeOf"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "5"
-    },
-    "userMessage": "Empty value found :: value: '', column: 'Place_Type', property: 'typeOf', node: 'E:SVTest->E3'",
-    "counterKey": "StrSplit_EmptyToken_typeOf"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "5"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'E:SVTest->E3', type: 'Thing'",
-    "counterKey": "Sanity_MissingOrEmpty_typeOf"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "6"
-    },
-    "userMessage": "Found CSV row with different number of columns",
-    "counterKey": "CSV_InconsistentRows"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "7"
-    },
-    "userMessage": "Found multiple values for single-value property :: property: 'observationDate', column: 'Year', node: 'E:SVTest->E0'",
-    "counterKey": "Sanity_MultipleVals_observationDate"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "7"
-    },
-    "userMessage": "Found multiple values for single-value property :: property: 'observationDate', column: 'Year', node: 'E:SVTest->E1'",
-    "counterKey": "Sanity_MultipleVals_observationDate"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "7"
-    },
-    "userMessage": "Empty value found :: value: '[]', property: 'location', node: 'dcid:CA-VN'",
-    "counterKey": "StrSplit_EmptyToken_location"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "7"
-    },
-    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[]', components: 0, property: 'location', node: 'dcid:CA-VN'",
-    "counterKey": "MCF_MalformedComplexValueParts"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "8"
-    },
-    "userMessage": "Found CSV row with different number of columns",
-    "counterKey": "CSV_InconsistentRows"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "9"
-    },
-    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[', property: 'location', node: 'E:SVTest->E3'",
-    "counterKey": "MCF_MalformedComplexValue"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "10"
-    },
-    "userMessage": "Malformed CSV value for dcid property; must be a text or reference :: value: '123', node: 'E:SVTest->E3'",
-    "counterKey": "CSV_MalformedDCIDFailures"
-  }, {
     "level": "LEVEL_WARNING",
     "location": {
       "file": "SuccessTmcf.csv",
@@ -196,14 +52,6 @@
     },
     "userMessage": "In dcid:{entity} reference, found {entity} to be empty :: property: 'observationAbout', node: 'E:SVTest->E0'",
     "counterKey": "CSV_EmptyDcidReferences"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "10"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'observationAbout', node: 'E:SVTest->E0', type: 'StatVarObservation'",
-    "counterKey": "Sanity_MissingOrEmpty_observationAbout"
   }, {
     "level": "LEVEL_WARNING",
     "location": {
@@ -216,74 +64,218 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "SuccessTmcf.csv",
-      "lineNumber": "10"
+      "lineNumber": "6"
     },
-    "userMessage": "Found a missing or empty property value :: property: 'observationAbout', node: 'E:SVTest->E1', type: 'StatVarObservation'",
-    "counterKey": "Sanity_MissingOrEmpty_observationAbout"
+    "userMessage": "Found CSV row with different number of columns",
+    "counterKey": "CSV_InconsistentRows"
   }, {
     "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "8"
+    },
+    "userMessage": "Found CSV row with different number of columns",
+    "counterKey": "CSV_InconsistentRows"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "Malformed CSV value for dcid property; must be a text or reference :: value: '123', node: 'E:SVTest->E3'",
+    "counterKey": "CSV_MalformedDCIDFailures"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "14"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'latLong/-4300000_11600000', property: 'location', node: 'E:SVTest->E3'",
+    "counterKey": "Existence_MissingReference_location"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "SuccessTmcf.csv",
       "lineNumber": "11"
     },
-    "userMessage": "Found a very long dcid value; must be less than 256 :: node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_VeryLongDcid"
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "SuccessTmcf.csv",
       "lineNumber": "12"
     },
-    "userMessage": "Quantity value must be a number :: value: '[Lat Long]', property: 'location', node: 'dcid:CA-MN'",
-    "counterKey": "MCF_QuantityMalformedValue"
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "13"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "14"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "SuccessTmcf.csv",
       "lineNumber": "15"
     },
-    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'Administrative–Area1', type: 'RESOLVED_REF', property: 'typeOf', node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_NonAsciiValueInNonText"
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "16"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "16"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "12"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "13"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "14"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "SuccessTmcf.csv",
       "lineNumber": "15"
     },
-    "userMessage": "Found invalid chars in dcid value :: value: 'Administrative–Area1', invalid-chars: '–', property: 'typeOf', node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_InvalidChars_typeOf"
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "SuccessTmcf.csv",
       "lineNumber": "16"
     },
-    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'Administrative–Area1', type: 'RESOLVED_REF', property: 'typeOf', node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_NonAsciiValueInNonText"
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "SuccessTmcf.csv",
       "lineNumber": "16"
     },
-    "userMessage": "Found invalid chars in dcid value :: value: 'Administrative–Area1', invalid-chars: '–', property: 'typeOf', node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_InvalidChars_typeOf"
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
   }, {
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
       "file": "SuccessTmcf.csv",
-      "lineNumber": "16"
+      "lineNumber": "14"
     },
-    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'Administrative–Area1', type: 'RESOLVED_REF', property: 'typeOf', node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_NonAsciiValueInNonText"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "16"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: 'Administrative–Area1', invalid-chars: '–', property: 'typeOf', node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_InvalidChars_typeOf"
+    "userMessage": "Failed reference existence check :: value-ref: 'Territory', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "Existence_MissingReference_typeOf"
   }, {
     "level": "LEVEL_WARNING",
     "location": {
@@ -469,197 +461,205 @@
     "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
     "counterKey": "Existence_MissingReference_variableMeasured"
   }, {
-    "level": "LEVEL_WARNING",
+    "level": "LEVEL_ERROR",
     "location": {
       "file": "SuccessTmcf.csv",
-      "lineNumber": "3"
+      "lineNumber": "9"
     },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[', property: 'location', node: 'E:SVTest->E3'",
+    "counterKey": "MCF_MalformedComplexValue"
   }, {
-    "level": "LEVEL_WARNING",
+    "level": "LEVEL_ERROR",
     "location": {
       "file": "SuccessTmcf.csv",
-      "lineNumber": "3"
+      "lineNumber": "7"
     },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
+    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[]', components: 0, property: 'location', node: 'dcid:CA-VN'",
+    "counterKey": "MCF_MalformedComplexValueParts"
   }, {
-    "level": "LEVEL_WARNING",
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "12"
+    },
+    "userMessage": "Quantity value must be a number :: value: '[Lat Long]', property: 'location', node: 'dcid:CA-MN'",
+    "counterKey": "MCF_QuantityMalformedValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "2"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'US- CA', invalid-chars: ' ', property: 'dcid', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_InvalidChars_dcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "2"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'US- CA', invalid-chars: ' ', property: 'observationAbout', node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_InvalidChars_observationAbout"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "2"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'US- CA', invalid-chars: ' ', property: 'observationAbout', node: 'E:SVTest->E1'",
+    "counterKey": "Sanity_InvalidChars_observationAbout"
+  }, {
+    "level": "LEVEL_ERROR",
     "location": {
       "file": "SuccessTmcf.csv",
       "lineNumber": "4"
     },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
+    "userMessage": "Found invalid chars in dcid value :: value: 'Administrative–Area1', invalid-chars: '–', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_InvalidChars_typeOf"
   }, {
-    "level": "LEVEL_WARNING",
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "15"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'Administrative–Area1', invalid-chars: '–', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_InvalidChars_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "16"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'Administrative–Area1', invalid-chars: '–', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_InvalidChars_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "16"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'Administrative–Area1', invalid-chars: '–', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_InvalidChars_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "2"
+    },
+    "userMessage": "Found a non-ISO8601 compliant date value :: value: '19', property: 'observationDate', node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_InvalidObsDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "2"
+    },
+    "userMessage": "Found a non-ISO8601 compliant date value :: value: '19', property: 'observationDate', node: 'E:SVTest->E1'",
+    "counterKey": "Sanity_InvalidObsDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'observationAbout', node: 'E:SVTest->E0', type: 'StatVarObservation'",
+    "counterKey": "Sanity_MissingOrEmpty_observationAbout"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'observationAbout', node: 'E:SVTest->E1', type: 'StatVarObservation'",
+    "counterKey": "Sanity_MissingOrEmpty_observationAbout"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'E:SVTest->E3', type: 'Thing'",
+    "counterKey": "Sanity_MissingOrEmpty_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Found dcid with more than one value :: count: 2, node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_MultipleDcidValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "7"
+    },
+    "userMessage": "Found multiple values for single-value property :: property: 'observationDate', column: 'Year', node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_MultipleVals_observationDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "7"
+    },
+    "userMessage": "Found multiple values for single-value property :: property: 'observationDate', column: 'Year', node: 'E:SVTest->E1'",
+    "counterKey": "Sanity_MultipleVals_observationDate"
+  }, {
+    "level": "LEVEL_ERROR",
     "location": {
       "file": "SuccessTmcf.csv",
       "lineNumber": "4"
     },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
+    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'Administrative–Area1', type: 'RESOLVED_REF', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_NonAsciiValueInNonText"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "15"
+    },
+    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'Administrative–Area1', type: 'RESOLVED_REF', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_NonAsciiValueInNonText"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "16"
+    },
+    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'Administrative–Area1', type: 'RESOLVED_REF', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_NonAsciiValueInNonText"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "16"
+    },
+    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'Administrative–Area1', type: 'RESOLVED_REF', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_NonAsciiValueInNonText"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Found a very long dcid value; must be less than 256 :: node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_VeryLongDcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "SuccessTmcf.csv",
+      "lineNumber": "7"
+    },
+    "userMessage": "Empty value found :: value: '[]', property: 'location', node: 'dcid:CA-VN'",
+    "counterKey": "StrSplit_EmptyToken_location"
   }, {
     "level": "LEVEL_WARNING",
     "location": {
       "file": "SuccessTmcf.csv",
       "lineNumber": "5"
     },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "5"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "9"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "9"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "12"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "12"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "13"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "13"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "14"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "14"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "15"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "15"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "16"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "16"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "16"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "16"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "14"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'Territory', property: 'typeOf', node: 'E:SVTest->E3'",
-    "counterKey": "Existence_MissingReference_typeOf"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "SuccessTmcf.csv",
-      "lineNumber": "14"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'latLong/-4300000_11600000', property: 'location', node: 'E:SVTest->E3'",
-    "counterKey": "Existence_MissingReference_location"
+    "userMessage": "Empty value found :: value: '', column: 'Place_Type', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "StrSplit_EmptyToken_typeOf"
   }],
   "statsCheckSummary": [{
     "placeDcid": "CA-AB",

--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
@@ -73,365 +73,45 @@
     }
   },
   "entries": [{
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_WARNING",
     "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "1"
+      "file": "AllFileTypes.csv",
+      "lineNumber": "10"
     },
-    "userMessage": "Property found without a preceding line with 'Node' :: line: 'typeOf: State'",
-    "counterKey": "MCF_UnexpectedProperty"
+    "userMessage": "In dcid:{entity} reference, found {entity} to be empty :: property: 'observationAbout', node: 'E:SVTest->E0'",
+    "counterKey": "CSV_EmptyDcidReferences"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "10"
+    },
+    "userMessage": "In dcid:{entity} reference, found {entity} to be empty :: property: 'observationAbout', node: 'E:SVTest->E1'",
+    "counterKey": "CSV_EmptyDcidReferences"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
-      "file": "AllFileTypes.mcf",
+      "file": "AllFileTypes.csv",
+      "lineNumber": "6"
+    },
+    "userMessage": "Found CSV row with different number of columns",
+    "counterKey": "CSV_InconsistentRows"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.csv",
       "lineNumber": "8"
     },
-    "userMessage": "Malformed line without a colon delimiter :: line: ': State'",
-    "counterKey": "MCF_MalformedColonLessLine"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "7"
-    },
-    "userMessage": "Missing typeOf value for node :: node: 'dcid:geoId/CA'",
-    "counterKey": "Mutator_MissingTypeOf"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "54"
-    },
-    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'USA,Country'",
-    "counterKey": "MCF_MalformedNodeName"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "67"
-    },
-    "userMessage": "Invalid latitude value; must be decimal degrees with an optional N/S suffix :: value: '-100', property: 'location', node: '\"CANCountry\"'",
-    "counterKey": "MCF_InvalidLatitude"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "73"
-    },
-    "userMessage": "Invalid longitude value; must be decimal degrees with an optional E/W suffix :: value: '181', property: 'location', node: 'dcid:geoId/sf'",
-    "counterKey": "MCF_InvalidLongitude"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "79"
-    },
-    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[10 12', property: 'age', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "MCF_MalformedComplexValue"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "81"
-    },
-    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[10]', components: 1, property: 'age', node: 'dcid:Count_Death_10YearsPlus'",
-    "counterKey": "MCF_MalformedComplexValueParts"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "88"
-    },
-    "userMessage": "Quantity value must be a number :: value: '[5Years 10Years]', property: 'age', node: 'dcid:Count_Death_5To10'",
-    "counterKey": "MCF_QuantityMalformedValue"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "95"
-    },
-    "userMessage": "Malformed start component in QuantityRange value; must be a number or '-' :: value: 'less', property: 'age', node: 'dcid:Count_Death_YearsLessThan5'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "102"
-    },
-    "userMessage": "Malformed end component in QuantityRange value; must be a number or '-' :: value: 'years', property: 'age', node: 'dcid:Count_Death_5YearsPlus'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "7"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'dcid:geoId/CA', type: 'Thing'",
-    "counterKey": "Sanity_MissingOrEmpty_typeOf"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "15"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: 'Statistical\nPopulation', invalid-chars: '\', property: 'typeOf', node: 'CityStats/E3/2'",
-    "counterKey": "Sanity_InvalidChars_typeOf"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "23"
-    },
-    "userMessage": "Found a non-ISO8601 compliant date value :: value: '7', property: 'observationDate', node: 'CityStats/E4/2'",
-    "counterKey": "Sanity_InvalidObsDate"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "32"
-    },
-    "userMessage": "Found a non-double Observation value :: value: 'onethousand', property: 'measuredValue', node: 'CityStats/E4/3'",
-    "counterKey": "Sanity_NonDoubleObsValue"
+    "userMessage": "Found CSV row with different number of columns",
+    "counterKey": "CSV_InconsistentRows"
   }, {
     "level": "LEVEL_WARNING",
     "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "41"
+      "file": "AllFileTypes.csv",
+      "lineNumber": "10"
     },
-    "userMessage": "Observation node missing value property :: node: 'CityStats/E4/4'",
-    "counterKey": "Sanity_ObsMissingValueProp"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "49"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: 'dc/ 2sffw13', invalid-chars: ' ', property: 'dcid', node: 'CityStats/E5/2'",
-    "counterKey": "Sanity_InvalidChars_dcid"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "49"
-    },
-    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'geoId–SFCounty', type: 'RESOLVED_REF', property: 'location', node: 'CityStats/E5/2'",
-    "counterKey": "Sanity_NonAsciiValueInNonText"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "49"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: 'geoId–SFCounty', invalid-chars: '–', property: 'location', node: 'CityStats/E5/2'",
-    "counterKey": "Sanity_InvalidChars_location"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "67"
-    },
-    "userMessage": "Found dcid with more than one value :: count: 2, node: '\"CANCountry\"'",
-    "counterKey": "Sanity_MultipleDcidValues"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
-    "counterKey": "Sanity_MissingOrEmpty_populationType"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'measuredProperty', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
-    "counterKey": "Sanity_MissingOrEmpty_measuredProperty"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
-    "counterKey": "Sanity_MissingOrEmpty_statType"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Found property name that does not start with a lower-case :: property: 'PopulationType', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "Sanity_NotInitLowerPropName"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_15YearsPlus', type: 'StatisticalVariable'",
-    "counterKey": "Sanity_MissingOrEmpty_populationType"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: '', invalid-chars: '', property: 'domainIncludes', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_InvalidChars_domainIncludes"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Unexpected property in Property node :: property: 'subClassOf', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_UnexpectedPropInProperty"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Schema node has property values with non-ascii characters :: value: 'Beverage–type', property: 'name', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_NonAsciiValueInSchema"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Found a property reference that does not start with a lower-case :: reference: 'BeverageType', property: 'label', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_NotInitLower_labelInProperty"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Found empty property value :: property: 'domainIncludes', node 'dcid:beverageType'",
-    "counterKey": "Sanity_EmptySchemaValue"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Schema node with dcid/name mismatch :: name: 'Beverage–type', dcid: 'beverageType', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_DcidNameMismatchInSchema"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Unexpected property in Class node :: property: 'domainIncludes', node: 'dcid:Pop'",
-    "counterKey": "Sanity_UnexpectedPropInClass"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Found a class reference that does not start with an upper-case :: reference: 'pop', property: 'name', node: 'dcid:Pop'",
-    "counterKey": "Sanity_NotInitUpper_nameInClass"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Schema node with dcid/name mismatch :: name: 'pop', dcid: 'Pop', node: 'dcid:Pop'",
-    "counterKey": "Sanity_DcidNameMismatchInSchema"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'subClassOf', node: 'dcid:Pop', type: 'Class'",
-    "counterKey": "Sanity_MissingOrEmpty_subClassOf"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
-    "counterKey": "Existence_MissingReference_containedIn"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "81"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "88"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "95"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "102"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
-    "counterKey": "Existence_MissingReference_domainIncludes"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "59"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingReference_containedInPlace"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "59"
-    },
-    "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingReference_Property"
+    "userMessage": "Malformed CSV value for dcid property; must be a text or reference :: value: '123', node: 'E:SVTest->E3'",
+    "counterKey": "CSV_MalformedDCIDFailures"
   }, {
     "level": "LEVEL_WARNING",
     "location": {
@@ -439,6 +119,14 @@
       "lineNumber": "123"
     },
     "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingReference_Property"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:dc/mx44'",
     "counterKey": "Existence_MissingReference_Property"
   }, {
     "level": "LEVEL_WARNING",
@@ -460,18 +148,386 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.mcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
+    "counterKey": "Existence_MissingReference_containedIn"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingReference_containedInPlace"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingReference_domainIncludes"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "81"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "88"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "102"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "95"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
       "lineNumber": "116"
     },
     "userMessage": "Failed reference existence check :: value-ref: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
     "counterKey": "Existence_MissingReference_subClassOf"
   }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.mcf",
-      "lineNumber": "59"
+      "lineNumber": "67"
     },
-    "userMessage": "Found orphan local ref :: ref: 'l:USACountry', property: 'containedInPlace', node: 'dcid:dc/mx44'",
-    "counterKey": "Resolution_OrphanLocalReference_containedInPlace"
+    "userMessage": "Invalid latitude value; must be decimal degrees with an optional N/S suffix :: value: '-100', property: 'location', node: '\"CANCountry\"'",
+    "counterKey": "MCF_InvalidLatitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "73"
+    },
+    "userMessage": "Invalid longitude value; must be decimal degrees with an optional E/W suffix :: value: '181', property: 'location', node: 'dcid:geoId/sf'",
+    "counterKey": "MCF_InvalidLongitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "8"
+    },
+    "userMessage": "Malformed line without a colon delimiter :: line: ': State'",
+    "counterKey": "MCF_MalformedColonLessLine"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "9"
+    },
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[', property: 'location', node: 'E:SVTest->E3'",
+    "counterKey": "MCF_MalformedComplexValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "79"
+    },
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[10 12', property: 'age', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "MCF_MalformedComplexValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "81"
+    },
+    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[10]', components: 1, property: 'age', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "MCF_MalformedComplexValueParts"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "7"
+    },
+    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[]', components: 0, property: 'location', node: 'dcid:CA-VN'",
+    "counterKey": "MCF_MalformedComplexValueParts"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "54"
+    },
+    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'USA,Country'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "88"
+    },
+    "userMessage": "Quantity value must be a number :: value: '[5Years 10Years]', property: 'age', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "MCF_QuantityMalformedValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "11"
+    },
+    "userMessage": "Quantity value must be a number :: value: '[Lat Long]', property: 'location', node: 'dcid:CA-MN'",
+    "counterKey": "MCF_QuantityMalformedValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "102"
+    },
+    "userMessage": "Malformed end component in QuantityRange value; must be a number or '-' :: value: 'years', property: 'age', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "95"
+    },
+    "userMessage": "Malformed start component in QuantityRange value; must be a number or '-' :: value: 'less', property: 'age', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "1"
+    },
+    "userMessage": "Property found without a preceding line with 'Node' :: line: 'typeOf: State'",
+    "counterKey": "MCF_UnexpectedProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "7"
+    },
+    "userMessage": "Missing typeOf value for node :: node: 'dcid:geoId/CA'",
+    "counterKey": "Mutator_MissingTypeOf"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -484,17 +540,9 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.mcf",
-      "lineNumber": "41"
+      "lineNumber": "15"
     },
-    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/4'",
-    "counterKey": "Resolution_IrreplaceableLocalRef"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "AllFileTypes.mcf",
-      "lineNumber": "32"
-    },
-    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/3'",
+    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E2/2', node: 'CityStats/E3/2'",
     "counterKey": "Resolution_IrreplaceableLocalRef"
   }, {
     "level": "LEVEL_ERROR",
@@ -508,9 +556,9 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.mcf",
-      "lineNumber": "15"
+      "lineNumber": "32"
     },
-    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E2/2', node: 'CityStats/E3/2'",
+    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/3'",
     "counterKey": "Resolution_IrreplaceableLocalRef"
   }, {
     "level": "LEVEL_ERROR",
@@ -518,15 +566,23 @@
       "file": "AllFileTypes.mcf",
       "lineNumber": "41"
     },
-    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/4'",
-    "counterKey": "Resolution_UnassignableNodeDcid"
+    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/4'",
+    "counterKey": "Resolution_IrreplaceableLocalRef"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.mcf",
-      "lineNumber": "32"
+      "lineNumber": "59"
     },
-    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/3'",
+    "userMessage": "Found orphan local ref :: ref: 'l:USACountry', property: 'containedInPlace', node: 'dcid:dc/mx44'",
+    "counterKey": "Resolution_OrphanLocalReference_containedInPlace"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "15"
+    },
+    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E2/2', node: 'CityStats/E3/2'",
     "counterKey": "Resolution_UnassignableNodeDcid"
   }, {
     "level": "LEVEL_ERROR",
@@ -540,10 +596,42 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.mcf",
-      "lineNumber": "15"
+      "lineNumber": "32"
     },
-    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E2/2', node: 'CityStats/E3/2'",
+    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/3'",
     "counterKey": "Resolution_UnassignableNodeDcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "41"
+    },
+    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/4'",
+    "counterKey": "Resolution_UnassignableNodeDcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Schema node with dcid/name mismatch :: name: 'Beverage–type', dcid: 'beverageType', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_DcidNameMismatchInSchema"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Schema node with dcid/name mismatch :: name: 'pop', dcid: 'Pop', node: 'dcid:Pop'",
+    "counterKey": "Sanity_DcidNameMismatchInSchema"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Found empty property value :: property: 'domainIncludes', node 'dcid:beverageType'",
+    "counterKey": "Sanity_EmptySchemaValue"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -552,6 +640,30 @@
     },
     "userMessage": "Found invalid chars in dcid value :: value: 'US- CA', invalid-chars: ' ', property: 'dcid', node: 'E:SVTest->E3'",
     "counterKey": "Sanity_InvalidChars_dcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "49"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'dc/ 2sffw13', invalid-chars: ' ', property: 'dcid', node: 'CityStats/E5/2'",
+    "counterKey": "Sanity_InvalidChars_dcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: '', invalid-chars: '', property: 'domainIncludes', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_InvalidChars_domainIncludes"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "49"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'geoId–SFCounty', invalid-chars: '–', property: 'location', node: 'CityStats/E5/2'",
+    "counterKey": "Sanity_InvalidChars_location"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -566,16 +678,32 @@
       "file": "AllFileTypes.csv",
       "lineNumber": "2"
     },
-    "userMessage": "Found a non-ISO8601 compliant date value :: value: '19', property: 'observationDate', node: 'E:SVTest->E0'",
-    "counterKey": "Sanity_InvalidObsDate"
+    "userMessage": "Found invalid chars in dcid value :: value: 'US- CA', invalid-chars: ' ', property: 'observationAbout', node: 'E:SVTest->E1'",
+    "counterKey": "Sanity_InvalidChars_observationAbout"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'Administrative–Area1', invalid-chars: '–', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_InvalidChars_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "15"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'Statistical\nPopulation', invalid-chars: '\', property: 'typeOf', node: 'CityStats/E3/2'",
+    "counterKey": "Sanity_InvalidChars_typeOf"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.csv",
       "lineNumber": "2"
     },
-    "userMessage": "Found invalid chars in dcid value :: value: 'US- CA', invalid-chars: ' ', property: 'observationAbout', node: 'E:SVTest->E1'",
-    "counterKey": "Sanity_InvalidChars_observationAbout"
+    "userMessage": "Found a non-ISO8601 compliant date value :: value: '19', property: 'observationDate', node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_InvalidObsDate"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -587,35 +715,67 @@
   }, {
     "level": "LEVEL_ERROR",
     "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "3"
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "23"
     },
-    "userMessage": "Found dcid with more than one value :: count: 2, node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_MultipleDcidValues"
+    "userMessage": "Found a non-ISO8601 compliant date value :: value: '7', property: 'observationDate', node: 'CityStats/E4/2'",
+    "counterKey": "Sanity_InvalidObsDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'measuredProperty', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_measuredProperty"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.csv",
-      "lineNumber": "4"
+      "lineNumber": "10"
     },
-    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'Administrative–Area1', type: 'RESOLVED_REF', property: 'typeOf', node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_NonAsciiValueInNonText"
+    "userMessage": "Found a missing or empty property value :: property: 'observationAbout', node: 'E:SVTest->E0', type: 'StatVarObservation'",
+    "counterKey": "Sanity_MissingOrEmpty_observationAbout"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.csv",
-      "lineNumber": "4"
+      "lineNumber": "10"
     },
-    "userMessage": "Found invalid chars in dcid value :: value: 'Administrative–Area1', invalid-chars: '–', property: 'typeOf', node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_InvalidChars_typeOf"
+    "userMessage": "Found a missing or empty property value :: property: 'observationAbout', node: 'E:SVTest->E1', type: 'StatVarObservation'",
+    "counterKey": "Sanity_MissingOrEmpty_observationAbout"
   }, {
     "level": "LEVEL_WARNING",
     "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "5"
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "77"
     },
-    "userMessage": "Empty value found :: value: '', column: 'Place_Type', property: 'typeOf', node: 'E:SVTest->E3'",
-    "counterKey": "StrSplit_EmptyToken_typeOf"
+    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_populationType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_15YearsPlus', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_populationType"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_statType"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'subClassOf', node: 'dcid:Pop', type: 'Class'",
+    "counterKey": "Sanity_MissingOrEmpty_subClassOf"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -627,11 +787,27 @@
   }, {
     "level": "LEVEL_ERROR",
     "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "6"
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "7"
     },
-    "userMessage": "Found CSV row with different number of columns",
-    "counterKey": "CSV_InconsistentRows"
+    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'dcid:geoId/CA', type: 'Thing'",
+    "counterKey": "Sanity_MissingOrEmpty_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Found dcid with more than one value :: count: 2, node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_MultipleDcidValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "67"
+    },
+    "userMessage": "Found dcid with more than one value :: count: 2, node: '\"CANCountry\"'",
+    "counterKey": "Sanity_MultipleDcidValues"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -652,74 +828,82 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.csv",
-      "lineNumber": "7"
+      "lineNumber": "4"
     },
-    "userMessage": "Empty value found :: value: '[]', property: 'location', node: 'dcid:CA-VN'",
-    "counterKey": "StrSplit_EmptyToken_location"
+    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'Administrative–Area1', type: 'RESOLVED_REF', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_NonAsciiValueInNonText"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "7"
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "49"
     },
-    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[]', components: 0, property: 'location', node: 'dcid:CA-VN'",
-    "counterKey": "MCF_MalformedComplexValueParts"
+    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'geoId–SFCounty', type: 'RESOLVED_REF', property: 'location', node: 'CityStats/E5/2'",
+    "counterKey": "Sanity_NonAsciiValueInNonText"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "8"
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "116"
     },
-    "userMessage": "Found CSV row with different number of columns",
-    "counterKey": "CSV_InconsistentRows"
+    "userMessage": "Schema node has property values with non-ascii characters :: value: 'Beverage–type', property: 'name', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_NonAsciiValueInSchema"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "9"
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "32"
     },
-    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[', property: 'location', node: 'E:SVTest->E3'",
-    "counterKey": "MCF_MalformedComplexValue"
+    "userMessage": "Found a non-double Observation value :: value: 'onethousand', property: 'measuredValue', node: 'CityStats/E4/3'",
+    "counterKey": "Sanity_NonDoubleObsValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Found property name that does not start with a lower-case :: property: 'PopulationType', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "Sanity_NotInitLowerPropName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Found a property reference that does not start with a lower-case :: reference: 'BeverageType', property: 'label', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_NotInitLower_labelInProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Found a class reference that does not start with an upper-case :: reference: 'pop', property: 'name', node: 'dcid:Pop'",
+    "counterKey": "Sanity_NotInitUpper_nameInClass"
   }, {
     "level": "LEVEL_WARNING",
     "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "10"
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "41"
     },
-    "userMessage": "Malformed CSV value for dcid property; must be a text or reference :: value: '123', node: 'E:SVTest->E3'",
-    "counterKey": "CSV_MalformedDCIDFailures"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "10"
-    },
-    "userMessage": "In dcid:{entity} reference, found {entity} to be empty :: property: 'observationAbout', node: 'E:SVTest->E0'",
-    "counterKey": "CSV_EmptyDcidReferences"
+    "userMessage": "Observation node missing value property :: node: 'CityStats/E4/4'",
+    "counterKey": "Sanity_ObsMissingValueProp"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "10"
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "123"
     },
-    "userMessage": "Found a missing or empty property value :: property: 'observationAbout', node: 'E:SVTest->E0', type: 'StatVarObservation'",
-    "counterKey": "Sanity_MissingOrEmpty_observationAbout"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "10"
-    },
-    "userMessage": "In dcid:{entity} reference, found {entity} to be empty :: property: 'observationAbout', node: 'E:SVTest->E1'",
-    "counterKey": "CSV_EmptyDcidReferences"
+    "userMessage": "Unexpected property in Class node :: property: 'domainIncludes', node: 'dcid:Pop'",
+    "counterKey": "Sanity_UnexpectedPropInClass"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "10"
+      "file": "AllFileTypes.mcf",
+      "lineNumber": "116"
     },
-    "userMessage": "Found a missing or empty property value :: property: 'observationAbout', node: 'E:SVTest->E1', type: 'StatVarObservation'",
-    "counterKey": "Sanity_MissingOrEmpty_observationAbout"
+    "userMessage": "Unexpected property in Property node :: property: 'subClassOf', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_UnexpectedPropInProperty"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -732,202 +916,18 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.csv",
-      "lineNumber": "11"
+      "lineNumber": "7"
     },
-    "userMessage": "Quantity value must be a number :: value: '[Lat Long]', property: 'location', node: 'dcid:CA-MN'",
-    "counterKey": "MCF_QuantityMalformedValue"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "4"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_variableMeasured"
+    "userMessage": "Empty value found :: value: '[]', property: 'location', node: 'dcid:CA-VN'",
+    "counterKey": "StrSplit_EmptyToken_location"
   }, {
     "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.csv",
       "lineNumber": "5"
     },
-    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "9"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "4"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "5"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "9"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_variableMeasured"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "4"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "4"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "5"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "5"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "9"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "9"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "AllFileTypes.csv",
-      "lineNumber": "11"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
-    "counterKey": "Existence_MissingReference_measurementMethod"
+    "userMessage": "Empty value found :: value: '', column: 'Place_Type', property: 'typeOf', node: 'E:SVTest->E3'",
+    "counterKey": "StrSplit_EmptyToken_typeOf"
   }],
   "commandArgs": {
     "existenceChecks": true,

--- a/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
@@ -61,381 +61,13 @@
     }
   },
   "entries": [{
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "1"
-    },
-    "userMessage": "Property found without a preceding line with 'Node' :: line: 'typeOf: State'",
-    "counterKey": "MCF_UnexpectedProperty"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "8"
-    },
-    "userMessage": "Malformed line without a colon delimiter :: line: ': State'",
-    "counterKey": "MCF_MalformedColonLessLine"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "7"
-    },
-    "userMessage": "Missing typeOf value for node :: node: 'dcid:geoId/CA'",
-    "counterKey": "Mutator_MissingTypeOf"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "54"
-    },
-    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'USA,Country'",
-    "counterKey": "MCF_MalformedNodeName"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "67"
-    },
-    "userMessage": "Invalid latitude value; must be decimal degrees with an optional N/S suffix :: value: '-100', property: 'location', node: '\"CANCountry\"'",
-    "counterKey": "MCF_InvalidLatitude"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "73"
-    },
-    "userMessage": "Invalid longitude value; must be decimal degrees with an optional E/W suffix :: value: '181', property: 'location', node: 'dcid:geoId/sf'",
-    "counterKey": "MCF_InvalidLongitude"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "79"
-    },
-    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[10 12', property: 'age', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "MCF_MalformedComplexValue"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "81"
-    },
-    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[10]', components: 1, property: 'age', node: 'dcid:Count_Death_10YearsPlus'",
-    "counterKey": "MCF_MalformedComplexValueParts"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "88"
-    },
-    "userMessage": "Quantity value must be a number :: value: '[5Years 10Years]', property: 'age', node: 'dcid:Count_Death_5To10'",
-    "counterKey": "MCF_QuantityMalformedValue"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "95"
-    },
-    "userMessage": "Malformed start component in QuantityRange value; must be a number or '-' :: value: 'less', property: 'age', node: 'dcid:Count_Death_YearsLessThan5'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "102"
-    },
-    "userMessage": "Malformed end component in QuantityRange value; must be a number or '-' :: value: 'years', property: 'age', node: 'dcid:Count_Death_5YearsPlus'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "7"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'dcid:geoId/CA', type: 'Thing'",
-    "counterKey": "Sanity_MissingOrEmpty_typeOf"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "15"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: 'Statistical\nPopulation', invalid-chars: '\', property: 'typeOf', node: 'CityStats/E3/2'",
-    "counterKey": "Sanity_InvalidChars_typeOf"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "23"
-    },
-    "userMessage": "Found a non-ISO8601 compliant date value :: value: '7', property: 'observationDate', node: 'CityStats/E4/2'",
-    "counterKey": "Sanity_InvalidObsDate"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "32"
-    },
-    "userMessage": "Found a non-double Observation value :: value: 'onethousand', property: 'measuredValue', node: 'CityStats/E4/3'",
-    "counterKey": "Sanity_NonDoubleObsValue"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "41"
-    },
-    "userMessage": "Observation node missing value property :: node: 'CityStats/E4/4'",
-    "counterKey": "Sanity_ObsMissingValueProp"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "49"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: 'dc/ 2sffw13', invalid-chars: ' ', property: 'dcid', node: 'CityStats/E5/2'",
-    "counterKey": "Sanity_InvalidChars_dcid"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "49"
-    },
-    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'geoId–SFCounty', type: 'RESOLVED_REF', property: 'location', node: 'CityStats/E5/2'",
-    "counterKey": "Sanity_NonAsciiValueInNonText"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "49"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: 'geoId–SFCounty', invalid-chars: '–', property: 'location', node: 'CityStats/E5/2'",
-    "counterKey": "Sanity_InvalidChars_location"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "67"
-    },
-    "userMessage": "Found dcid with more than one value :: count: 2, node: '\"CANCountry\"'",
-    "counterKey": "Sanity_MultipleDcidValues"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
-    "counterKey": "Sanity_MissingOrEmpty_populationType"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'measuredProperty', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
-    "counterKey": "Sanity_MissingOrEmpty_measuredProperty"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
-    "counterKey": "Sanity_MissingOrEmpty_statType"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Found property name that does not start with a lower-case :: property: 'PopulationType', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "Sanity_NotInitLowerPropName"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_15YearsPlus', type: 'StatisticalVariable'",
-    "counterKey": "Sanity_MissingOrEmpty_populationType"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: '', invalid-chars: '', property: 'domainIncludes', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_InvalidChars_domainIncludes"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Unexpected property in Property node :: property: 'subClassOf', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_UnexpectedPropInProperty"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Schema node has property values with non-ascii characters :: value: 'Beverage–type', property: 'name', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_NonAsciiValueInSchema"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Found a property reference that does not start with a lower-case :: reference: 'BeverageType', property: 'label', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_NotInitLower_labelInProperty"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Found empty property value :: property: 'domainIncludes', node 'dcid:beverageType'",
-    "counterKey": "Sanity_EmptySchemaValue"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Schema node with dcid/name mismatch :: name: 'Beverage–type', dcid: 'beverageType', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_DcidNameMismatchInSchema"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Unexpected property in Class node :: property: 'domainIncludes', node: 'dcid:Pop'",
-    "counterKey": "Sanity_UnexpectedPropInClass"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Found a class reference that does not start with an upper-case :: reference: 'pop', property: 'name', node: 'dcid:Pop'",
-    "counterKey": "Sanity_NotInitUpper_nameInClass"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Schema node with dcid/name mismatch :: name: 'pop', dcid: 'Pop', node: 'dcid:Pop'",
-    "counterKey": "Sanity_DcidNameMismatchInSchema"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'subClassOf', node: 'dcid:Pop', type: 'Class'",
-    "counterKey": "Sanity_MissingOrEmpty_subClassOf"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "145"
-    },
-    "userMessage": "Found same curated ID for different StatVars :: curatedDcid: 'Count_Person', node: 'Count_Person'",
-    "counterKey": "Sanity_SameDcidForDifferentStatVars"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "154"
-    },
-    "userMessage": "Found different curated IDs for same StatVar :: dcid1: 'Count_Person', dcid2: 'Count_Person_Female', node: 'dcid:Count_Person_Female'",
-    "counterKey": "Sanity_DifferentDcidsForSameStatVar"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
-    "counterKey": "Existence_MissingReference_containedIn"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "81"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "88"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "95"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "102"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "130"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
     "level": "LEVEL_WARNING",
     "location": {
       "file": "McfOnly.mcf",
       "lineNumber": "123"
     },
-    "userMessage": "Failed reference existence check :: value-ref: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
-    "counterKey": "Existence_MissingReference_domainIncludes"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "59"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingReference_containedInPlace"
+    "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingReference_Property"
   }, {
     "level": "LEVEL_WARNING",
     "location": {
@@ -443,14 +75,6 @@
       "lineNumber": "59"
     },
     "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingReference_Property"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:Pop'",
     "counterKey": "Existence_MissingReference_Property"
   }, {
     "level": "LEVEL_WARNING",
@@ -472,6 +96,78 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "McfOnly.mcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
+    "counterKey": "Existence_MissingReference_containedIn"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingReference_containedInPlace"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingReference_domainIncludes"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "81"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "130"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "88"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "102"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "95"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
       "lineNumber": "116"
     },
     "userMessage": "Failed reference existence check :: value-ref: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
@@ -480,10 +176,98 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "McfOnly.mcf",
-      "lineNumber": "59"
+      "lineNumber": "67"
     },
-    "userMessage": "Found orphan local ref :: ref: 'l:USACountry', property: 'containedInPlace', node: 'dcid:dc/mx44'",
-    "counterKey": "Resolution_OrphanLocalReference_containedInPlace"
+    "userMessage": "Invalid latitude value; must be decimal degrees with an optional N/S suffix :: value: '-100', property: 'location', node: '\"CANCountry\"'",
+    "counterKey": "MCF_InvalidLatitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "73"
+    },
+    "userMessage": "Invalid longitude value; must be decimal degrees with an optional E/W suffix :: value: '181', property: 'location', node: 'dcid:geoId/sf'",
+    "counterKey": "MCF_InvalidLongitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "8"
+    },
+    "userMessage": "Malformed line without a colon delimiter :: line: ': State'",
+    "counterKey": "MCF_MalformedColonLessLine"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "79"
+    },
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[10 12', property: 'age', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "MCF_MalformedComplexValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "81"
+    },
+    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[10]', components: 1, property: 'age', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "MCF_MalformedComplexValueParts"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "54"
+    },
+    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'USA,Country'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "88"
+    },
+    "userMessage": "Quantity value must be a number :: value: '[5Years 10Years]', property: 'age', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "MCF_QuantityMalformedValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "102"
+    },
+    "userMessage": "Malformed end component in QuantityRange value; must be a number or '-' :: value: 'years', property: 'age', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "95"
+    },
+    "userMessage": "Malformed start component in QuantityRange value; must be a number or '-' :: value: 'less', property: 'age', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "1"
+    },
+    "userMessage": "Property found without a preceding line with 'Node' :: line: 'typeOf: State'",
+    "counterKey": "MCF_UnexpectedProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "7"
+    },
+    "userMessage": "Missing typeOf value for node :: node: 'dcid:geoId/CA'",
+    "counterKey": "Mutator_MissingTypeOf"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -496,17 +280,9 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "McfOnly.mcf",
-      "lineNumber": "41"
+      "lineNumber": "15"
     },
-    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/4'",
-    "counterKey": "Resolution_IrreplaceableLocalRef"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "McfOnly.mcf",
-      "lineNumber": "32"
-    },
-    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/3'",
+    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E2/2', node: 'CityStats/E3/2'",
     "counterKey": "Resolution_IrreplaceableLocalRef"
   }, {
     "level": "LEVEL_ERROR",
@@ -520,9 +296,9 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "McfOnly.mcf",
-      "lineNumber": "15"
+      "lineNumber": "32"
     },
-    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E2/2', node: 'CityStats/E3/2'",
+    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/3'",
     "counterKey": "Resolution_IrreplaceableLocalRef"
   }, {
     "level": "LEVEL_ERROR",
@@ -530,15 +306,23 @@
       "file": "McfOnly.mcf",
       "lineNumber": "41"
     },
-    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/4'",
-    "counterKey": "Resolution_UnassignableNodeDcid"
+    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/4'",
+    "counterKey": "Resolution_IrreplaceableLocalRef"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "McfOnly.mcf",
-      "lineNumber": "32"
+      "lineNumber": "59"
     },
-    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/3'",
+    "userMessage": "Found orphan local ref :: ref: 'l:USACountry', property: 'containedInPlace', node: 'dcid:dc/mx44'",
+    "counterKey": "Resolution_OrphanLocalReference_containedInPlace"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "15"
+    },
+    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E2/2', node: 'CityStats/E3/2'",
     "counterKey": "Resolution_UnassignableNodeDcid"
   }, {
     "level": "LEVEL_ERROR",
@@ -552,10 +336,226 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "McfOnly.mcf",
+      "lineNumber": "32"
+    },
+    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/3'",
+    "counterKey": "Resolution_UnassignableNodeDcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "41"
+    },
+    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/4'",
+    "counterKey": "Resolution_UnassignableNodeDcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Schema node with dcid/name mismatch :: name: 'Beverage–type', dcid: 'beverageType', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_DcidNameMismatchInSchema"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Schema node with dcid/name mismatch :: name: 'pop', dcid: 'Pop', node: 'dcid:Pop'",
+    "counterKey": "Sanity_DcidNameMismatchInSchema"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "154"
+    },
+    "userMessage": "Found different curated IDs for same StatVar :: dcid1: 'Count_Person', dcid2: 'Count_Person_Female', node: 'dcid:Count_Person_Female'",
+    "counterKey": "Sanity_DifferentDcidsForSameStatVar"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Found empty property value :: property: 'domainIncludes', node 'dcid:beverageType'",
+    "counterKey": "Sanity_EmptySchemaValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "49"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'dc/ 2sffw13', invalid-chars: ' ', property: 'dcid', node: 'CityStats/E5/2'",
+    "counterKey": "Sanity_InvalidChars_dcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: '', invalid-chars: '', property: 'domainIncludes', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_InvalidChars_domainIncludes"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "49"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'geoId–SFCounty', invalid-chars: '–', property: 'location', node: 'CityStats/E5/2'",
+    "counterKey": "Sanity_InvalidChars_location"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
       "lineNumber": "15"
     },
-    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E2/2', node: 'CityStats/E3/2'",
-    "counterKey": "Resolution_UnassignableNodeDcid"
+    "userMessage": "Found invalid chars in dcid value :: value: 'Statistical\nPopulation', invalid-chars: '\', property: 'typeOf', node: 'CityStats/E3/2'",
+    "counterKey": "Sanity_InvalidChars_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "23"
+    },
+    "userMessage": "Found a non-ISO8601 compliant date value :: value: '7', property: 'observationDate', node: 'CityStats/E4/2'",
+    "counterKey": "Sanity_InvalidObsDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'measuredProperty', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_measuredProperty"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_populationType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_15YearsPlus', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_populationType"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_statType"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'subClassOf', node: 'dcid:Pop', type: 'Class'",
+    "counterKey": "Sanity_MissingOrEmpty_subClassOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "7"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'dcid:geoId/CA', type: 'Thing'",
+    "counterKey": "Sanity_MissingOrEmpty_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "67"
+    },
+    "userMessage": "Found dcid with more than one value :: count: 2, node: '\"CANCountry\"'",
+    "counterKey": "Sanity_MultipleDcidValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "49"
+    },
+    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'geoId–SFCounty', type: 'RESOLVED_REF', property: 'location', node: 'CityStats/E5/2'",
+    "counterKey": "Sanity_NonAsciiValueInNonText"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Schema node has property values with non-ascii characters :: value: 'Beverage–type', property: 'name', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_NonAsciiValueInSchema"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "32"
+    },
+    "userMessage": "Found a non-double Observation value :: value: 'onethousand', property: 'measuredValue', node: 'CityStats/E4/3'",
+    "counterKey": "Sanity_NonDoubleObsValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Found property name that does not start with a lower-case :: property: 'PopulationType', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "Sanity_NotInitLowerPropName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Found a property reference that does not start with a lower-case :: reference: 'BeverageType', property: 'label', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_NotInitLower_labelInProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Found a class reference that does not start with an upper-case :: reference: 'pop', property: 'name', node: 'dcid:Pop'",
+    "counterKey": "Sanity_NotInitUpper_nameInClass"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "41"
+    },
+    "userMessage": "Observation node missing value property :: node: 'CityStats/E4/4'",
+    "counterKey": "Sanity_ObsMissingValueProp"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "145"
+    },
+    "userMessage": "Found same curated ID for different StatVars :: curatedDcid: 'Count_Person', node: 'Count_Person'",
+    "counterKey": "Sanity_SameDcidForDifferentStatVars"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Unexpected property in Class node :: property: 'domainIncludes', node: 'dcid:Pop'",
+    "counterKey": "Sanity_UnexpectedPropInClass"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "McfOnly.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Unexpected property in Property node :: property: 'subClassOf', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_UnexpectedPropInProperty"
   }],
   "commandArgs": {
     "existenceChecks": true,

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
@@ -66,357 +66,13 @@
     }
   },
   "entries": [{
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "1"
-    },
-    "userMessage": "Property found without a preceding line with 'Node' :: line: 'typeOf: State'",
-    "counterKey": "MCF_UnexpectedProperty"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "8"
-    },
-    "userMessage": "Malformed line without a colon delimiter :: line: ': State'",
-    "counterKey": "MCF_MalformedColonLessLine"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "7"
-    },
-    "userMessage": "Missing typeOf value for node :: node: 'dcid:geoId/CA'",
-    "counterKey": "Mutator_MissingTypeOf"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "54"
-    },
-    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'USA,Country'",
-    "counterKey": "MCF_MalformedNodeName"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "67"
-    },
-    "userMessage": "Invalid latitude value; must be decimal degrees with an optional N/S suffix :: value: '-100', property: 'location', node: '\"CANCountry\"'",
-    "counterKey": "MCF_InvalidLatitude"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "73"
-    },
-    "userMessage": "Invalid longitude value; must be decimal degrees with an optional E/W suffix :: value: '181', property: 'location', node: 'dcid:geoId/sf'",
-    "counterKey": "MCF_InvalidLongitude"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "79"
-    },
-    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[10 12', property: 'age', node: 'dcid:Count_Death_10To12'",
-    "counterKey": "MCF_MalformedComplexValue"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "81"
-    },
-    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[10]', components: 1, property: 'age', node: 'dcid:Count_Death_10YearsPlus'",
-    "counterKey": "MCF_MalformedComplexValueParts"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "88"
-    },
-    "userMessage": "Quantity value must be a number :: value: '[5Years 10Years]', property: 'age', node: 'dcid:Count_Death_5To10'",
-    "counterKey": "MCF_QuantityMalformedValue"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "95"
-    },
-    "userMessage": "Malformed start component in QuantityRange value; must be a number or '-' :: value: 'less', property: 'age', node: 'dcid:Count_Death_YearsLessThan5'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "102"
-    },
-    "userMessage": "Malformed end component in QuantityRange value; must be a number or '-' :: value: 'years', property: 'age', node: 'dcid:Count_Death_5YearsPlus'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "MCF_QuantityRangeMalformedValues"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "7"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'dcid:geoId/CA', type: 'Thing'",
-    "counterKey": "Sanity_MissingOrEmpty_typeOf"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "15"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: 'Statistical\nPopulation', invalid-chars: '\', property: 'typeOf', node: 'CityStats/E3/2'",
-    "counterKey": "Sanity_InvalidChars_typeOf"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "23"
-    },
-    "userMessage": "Found a non-ISO8601 compliant date value :: value: '7', property: 'observationDate', node: 'CityStats/E4/2'",
-    "counterKey": "Sanity_InvalidObsDate"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "32"
-    },
-    "userMessage": "Found a non-double Observation value :: value: 'onethousand', property: 'measuredValue', node: 'CityStats/E4/3'",
-    "counterKey": "Sanity_NonDoubleObsValue"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "41"
-    },
-    "userMessage": "Observation node missing value property :: node: 'CityStats/E4/4'",
-    "counterKey": "Sanity_ObsMissingValueProp"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "49"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: 'dc/ 2sffw13', invalid-chars: ' ', property: 'dcid', node: 'CityStats/E5/2'",
-    "counterKey": "Sanity_InvalidChars_dcid"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "49"
-    },
-    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'geoId–SFCounty', type: 'RESOLVED_REF', property: 'location', node: 'CityStats/E5/2'",
-    "counterKey": "Sanity_NonAsciiValueInNonText"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "49"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: 'geoId–SFCounty', invalid-chars: '–', property: 'location', node: 'CityStats/E5/2'",
-    "counterKey": "Sanity_InvalidChars_location"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "67"
-    },
-    "userMessage": "Found dcid with more than one value :: count: 2, node: '\"CANCountry\"'",
-    "counterKey": "Sanity_MultipleDcidValues"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
-    "counterKey": "Sanity_MissingOrEmpty_populationType"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'measuredProperty', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
-    "counterKey": "Sanity_MissingOrEmpty_measuredProperty"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "77"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
-    "counterKey": "Sanity_MissingOrEmpty_statType"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Found property name that does not start with a lower-case :: property: 'PopulationType', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "Sanity_NotInitLowerPropName"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_15YearsPlus', type: 'StatisticalVariable'",
-    "counterKey": "Sanity_MissingOrEmpty_populationType"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Found invalid chars in dcid value :: value: '', invalid-chars: '', property: 'domainIncludes', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_InvalidChars_domainIncludes"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Unexpected property in Property node :: property: 'subClassOf', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_UnexpectedPropInProperty"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Schema node has property values with non-ascii characters :: value: 'Beverage–type', property: 'name', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_NonAsciiValueInSchema"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Found a property reference that does not start with a lower-case :: reference: 'BeverageType', property: 'label', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_NotInitLower_labelInProperty"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Found empty property value :: property: 'domainIncludes', node 'dcid:beverageType'",
-    "counterKey": "Sanity_EmptySchemaValue"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "116"
-    },
-    "userMessage": "Schema node with dcid/name mismatch :: name: 'Beverage–type', dcid: 'beverageType', node: 'dcid:beverageType'",
-    "counterKey": "Sanity_DcidNameMismatchInSchema"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Unexpected property in Class node :: property: 'domainIncludes', node: 'dcid:Pop'",
-    "counterKey": "Sanity_UnexpectedPropInClass"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Found a class reference that does not start with an upper-case :: reference: 'pop', property: 'name', node: 'dcid:Pop'",
-    "counterKey": "Sanity_NotInitUpper_nameInClass"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Schema node with dcid/name mismatch :: name: 'pop', dcid: 'Pop', node: 'dcid:Pop'",
-    "counterKey": "Sanity_DcidNameMismatchInSchema"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'subClassOf', node: 'dcid:Pop', type: 'Class'",
-    "counterKey": "Sanity_MissingOrEmpty_subClassOf"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "3"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
-    "counterKey": "Existence_MissingReference_containedIn"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "81"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "88"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "95"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "102"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "109"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
-    "counterKey": "Existence_MissingReference_statType"
-  }, {
     "level": "LEVEL_WARNING",
     "location": {
       "file": "NoCsv.mcf",
       "lineNumber": "123"
     },
-    "userMessage": "Failed reference existence check :: value-ref: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
-    "counterKey": "Existence_MissingReference_domainIncludes"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "59"
-    },
-    "userMessage": "Failed reference existence check :: value-ref: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingReference_containedInPlace"
+    "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingReference_Property"
   }, {
     "level": "LEVEL_WARNING",
     "location": {
@@ -424,14 +80,6 @@
       "lineNumber": "59"
     },
     "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:dc/mx44'",
-    "counterKey": "Existence_MissingReference_Property"
-  }, {
-    "level": "LEVEL_WARNING",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "123"
-    },
-    "userMessage": "Failed reference existence check :: property-ref: 'inCounty', node: 'dcid:Pop'",
     "counterKey": "Existence_MissingReference_Property"
   }, {
     "level": "LEVEL_WARNING",
@@ -453,6 +101,70 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "NoCsv.mcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: '90062', property: 'containedIn', node: 'dcid:geoId/la'",
+    "counterKey": "Existence_MissingReference_containedIn"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "59"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'dc/4fef4e', property: 'containedInPlace', node: 'dcid:dc/mx44'",
+    "counterKey": "Existence_MissingReference_containedInPlace"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'PopEnums', property: 'domainIncludes', node: 'dcid:Pop'",
+    "counterKey": "Existence_MissingReference_domainIncludes"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "81"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "88"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "102"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "95"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'MeasuredValue', property: 'statType', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "Existence_MissingReference_statType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
       "lineNumber": "116"
     },
     "userMessage": "Failed reference existence check :: value-ref: 'substanceType', property: 'subClassOf', node: 'dcid:beverageType'",
@@ -461,10 +173,138 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "NoCsv.mcf",
-      "lineNumber": "59"
+      "lineNumber": "67"
     },
-    "userMessage": "Found orphan local ref :: ref: 'l:USACountry', property: 'containedInPlace', node: 'dcid:dc/mx44'",
-    "counterKey": "Resolution_OrphanLocalReference_containedInPlace"
+    "userMessage": "Invalid latitude value; must be decimal degrees with an optional N/S suffix :: value: '-100', property: 'location', node: '\"CANCountry\"'",
+    "counterKey": "MCF_InvalidLatitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "73"
+    },
+    "userMessage": "Invalid longitude value; must be decimal degrees with an optional E/W suffix :: value: '181', property: 'location', node: 'dcid:geoId/sf'",
+    "counterKey": "MCF_InvalidLongitude"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "8"
+    },
+    "userMessage": "Malformed line without a colon delimiter :: line: ': State'",
+    "counterKey": "MCF_MalformedColonLessLine"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.tmcf",
+      "lineNumber": "5"
+    },
+    "userMessage": "Malformed line without a colon delimiter :: line: ': dcs:SV1'",
+    "counterKey": "MCF_MalformedColonLessLine"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.tmcf",
+      "lineNumber": "34"
+    },
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[', property: 'age', node: 'E:SVTest->E4'",
+    "counterKey": "MCF_MalformedComplexValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "79"
+    },
+    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[10 12', property: 'age', node: 'dcid:Count_Death_10To12'",
+    "counterKey": "MCF_MalformedComplexValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "81"
+    },
+    "userMessage": "Complex value must have 2 (e.g., [Years 10]) or 3 (e.g., [Years 10 20]) components :: value: '[10]', components: 1, property: 'age', node: 'dcid:Count_Death_10YearsPlus'",
+    "counterKey": "MCF_MalformedComplexValueParts"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.tmcf",
+      "lineNumber": "29"
+    },
+    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'E:SVTest->E5,E:SVTest->E6'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "54"
+    },
+    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'USA,Country'",
+    "counterKey": "MCF_MalformedNodeName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "88"
+    },
+    "userMessage": "Quantity value must be a number :: value: '[5Years 10Years]', property: 'age', node: 'dcid:Count_Death_5To10'",
+    "counterKey": "MCF_QuantityMalformedValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "102"
+    },
+    "userMessage": "Malformed end component in QuantityRange value; must be a number or '-' :: value: 'years', property: 'age', node: 'dcid:Count_Death_5YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "95"
+    },
+    "userMessage": "Malformed start component in QuantityRange value; must be a number or '-' :: value: 'less', property: 'age', node: 'dcid:Count_Death_YearsLessThan5'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Malformed start+end components in QuantityRange value; one of them must be a number  :: startValue: '-', endValue: '-', property: 'age', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "MCF_QuantityRangeMalformedValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.tmcf",
+      "lineNumber": "1"
+    },
+    "userMessage": "Property found without a preceding line with 'Node' :: line: 'typeOf dcs:StatVarObservation'",
+    "counterKey": "MCF_UnexpectedProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "1"
+    },
+    "userMessage": "Property found without a preceding line with 'Node' :: line: 'typeOf: State'",
+    "counterKey": "MCF_UnexpectedProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.tmcf",
+      "lineNumber": "32"
+    },
+    "userMessage": "Missing typeOf value for node :: node: 'E:SVTest->E4'",
+    "counterKey": "Mutator_MissingTypeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "7"
+    },
+    "userMessage": "Missing typeOf value for node :: node: 'dcid:geoId/CA'",
+    "counterKey": "Mutator_MissingTypeOf"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -477,17 +317,9 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "NoCsv.mcf",
-      "lineNumber": "41"
+      "lineNumber": "15"
     },
-    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/4'",
-    "counterKey": "Resolution_IrreplaceableLocalRef"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.mcf",
-      "lineNumber": "32"
-    },
-    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/3'",
+    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E2/2', node: 'CityStats/E3/2'",
     "counterKey": "Resolution_IrreplaceableLocalRef"
   }, {
     "level": "LEVEL_ERROR",
@@ -501,9 +333,9 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "NoCsv.mcf",
-      "lineNumber": "15"
+      "lineNumber": "32"
     },
-    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E2/2', node: 'CityStats/E3/2'",
+    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/3'",
     "counterKey": "Resolution_IrreplaceableLocalRef"
   }, {
     "level": "LEVEL_ERROR",
@@ -511,15 +343,23 @@
       "file": "NoCsv.mcf",
       "lineNumber": "41"
     },
-    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/4'",
-    "counterKey": "Resolution_UnassignableNodeDcid"
+    "userMessage": "Unable to replace a local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/4'",
+    "counterKey": "Resolution_IrreplaceableLocalRef"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "NoCsv.mcf",
-      "lineNumber": "32"
+      "lineNumber": "59"
     },
-    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/3'",
+    "userMessage": "Found orphan local ref :: ref: 'l:USACountry', property: 'containedInPlace', node: 'dcid:dc/mx44'",
+    "counterKey": "Resolution_OrphanLocalReference_containedInPlace"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "15"
+    },
+    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E2/2', node: 'CityStats/E3/2'",
     "counterKey": "Resolution_UnassignableNodeDcid"
   }, {
     "level": "LEVEL_ERROR",
@@ -533,34 +373,162 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "NoCsv.mcf",
-      "lineNumber": "15"
+      "lineNumber": "32"
     },
-    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E2/2', node: 'CityStats/E3/2'",
+    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/3'",
     "counterKey": "Resolution_UnassignableNodeDcid"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
-      "file": "NoCsv.tmcf",
-      "lineNumber": "1"
+      "file": "NoCsv.mcf",
+      "lineNumber": "41"
     },
-    "userMessage": "Property found without a preceding line with 'Node' :: line: 'typeOf dcs:StatVarObservation'",
-    "counterKey": "MCF_UnexpectedProperty"
+    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'CityStats/E3/2', node: 'CityStats/E4/4'",
+    "counterKey": "Resolution_UnassignableNodeDcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Schema node with dcid/name mismatch :: name: 'Beverage–type', dcid: 'beverageType', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_DcidNameMismatchInSchema"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Schema node with dcid/name mismatch :: name: 'pop', dcid: 'Pop', node: 'dcid:Pop'",
+    "counterKey": "Sanity_DcidNameMismatchInSchema"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "NoCsv.tmcf",
-      "lineNumber": "5"
+      "lineNumber": "32"
     },
-    "userMessage": "Malformed line without a colon delimiter :: line: ': dcs:SV1'",
-    "counterKey": "MCF_MalformedColonLessLine"
+    "userMessage": "Value of dcid property must not be an 'E:' reference :: value: 'E:SVTest->E1', node: 'E:SVTest->E4'",
+    "counterKey": "Sanity_DcidTableEntity"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Found empty property value :: property: 'domainIncludes', node 'dcid:beverageType'",
+    "counterKey": "Sanity_EmptySchemaValue"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "49"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'dc/ 2sffw13', invalid-chars: ' ', property: 'dcid', node: 'CityStats/E5/2'",
+    "counterKey": "Sanity_InvalidChars_dcid"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: '', invalid-chars: '', property: 'domainIncludes', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_InvalidChars_domainIncludes"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "49"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'geoId–SFCounty', invalid-chars: '–', property: 'location', node: 'CityStats/E5/2'",
+    "counterKey": "Sanity_InvalidChars_location"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "15"
+    },
+    "userMessage": "Found invalid chars in dcid value :: value: 'Statistical\nPopulation', invalid-chars: '\', property: 'typeOf', node: 'CityStats/E3/2'",
+    "counterKey": "Sanity_InvalidChars_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "23"
+    },
+    "userMessage": "Found a non-ISO8601 compliant date value :: value: '7', property: 'observationDate', node: 'CityStats/E4/2'",
+    "counterKey": "Sanity_InvalidObsDate"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'measuredProperty', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_measuredProperty"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_populationType"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'populationType', node: 'dcid:Count_Death_15YearsPlus', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_populationType"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "77"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'statType', node: 'dcid:Count_Death_10To12', type: 'StatisticalVariable'",
+    "counterKey": "Sanity_MissingOrEmpty_statType"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'subClassOf', node: 'dcid:Pop', type: 'Class'",
+    "counterKey": "Sanity_MissingOrEmpty_subClassOf"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "NoCsv.tmcf",
-      "lineNumber": "11"
+      "lineNumber": "32"
     },
-    "userMessage": "Found malformed entity name that is not an entity prefix (E:) :: name: '\"E:SVTest->E1\"'",
-    "counterKey": "TMCF_MalformedEntity"
+    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'E:SVTest->E4', type: 'Thing'",
+    "counterKey": "Sanity_MissingOrEmpty_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "7"
+    },
+    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'dcid:geoId/CA', type: 'Thing'",
+    "counterKey": "Sanity_MissingOrEmpty_typeOf"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "67"
+    },
+    "userMessage": "Found dcid with more than one value :: count: 2, node: '\"CANCountry\"'",
+    "counterKey": "Sanity_MultipleDcidValues"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.tmcf",
+      "lineNumber": "19"
+    },
+    "userMessage": "Found dcid with more than one value :: count: 3, node: 'E:SVTest->E3'",
+    "counterKey": "Sanity_MultipleDcidValues"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -580,59 +548,27 @@
   }, {
     "level": "LEVEL_ERROR",
     "location": {
-      "file": "NoCsv.tmcf",
-      "lineNumber": "3"
+      "file": "NoCsv.mcf",
+      "lineNumber": "49"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E3', property: 'observationAbout' node: 'E:SVTest->E0'",
-    "counterKey": "Sanity_TmcfMissingEntityDef"
+    "userMessage": "Found non-ascii characters in a value that is not text :: value: 'geoId–SFCounty', type: 'RESOLVED_REF', property: 'location', node: 'CityStats/E5/2'",
+    "counterKey": "Sanity_NonAsciiValueInNonText"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
-      "file": "NoCsv.tmcf",
-      "lineNumber": "3"
+      "file": "NoCsv.mcf",
+      "lineNumber": "116"
     },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E30', property: 'observationAbout' node: 'E:SVTest->E0'",
-    "counterKey": "Sanity_TmcfMissingEntityDef"
+    "userMessage": "Schema node has property values with non-ascii characters :: value: 'Beverage–type', property: 'name', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_NonAsciiValueInSchema"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
-      "file": "NoCsv.tmcf",
-      "lineNumber": "22"
+      "file": "NoCsv.mcf",
+      "lineNumber": "32"
     },
-    "userMessage": "Malformed column value; must have a '->' delimiter :: value: 'C:SVTest>Place_Name', property: 'name', node: 'E:SVTest->E3'",
-    "counterKey": "TMCF_MalformedSchemaTerm"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.tmcf",
-      "lineNumber": "25"
-    },
-    "userMessage": "Found malformed entity name that is not an entity prefix (E:) :: name: 'C:SVTest->NodeDcid'",
-    "counterKey": "TMCF_MalformedEntity"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.tmcf",
-      "lineNumber": "27"
-    },
-    "userMessage": "TMCF properties cannot refer to CSV columns yet :: value: 'SVTest->Property: C:SVTest->Property_Value', property: 'C', node: 'E:SVTest->E3'",
-    "counterKey": "TMCF_UnsupportedColumnNameInProperty"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.tmcf",
-      "lineNumber": "29"
-    },
-    "userMessage": "Found malformed Node value with a comma; must be a unary value :: node: 'E:SVTest->E5,E:SVTest->E6'",
-    "counterKey": "MCF_MalformedNodeName"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.tmcf",
-      "lineNumber": "19"
-    },
-    "userMessage": "Found dcid with more than one value :: count: 3, node: 'E:SVTest->E3'",
-    "counterKey": "Sanity_MultipleDcidValues"
+    "userMessage": "Found a non-double Observation value :: value: 'onethousand', property: 'measuredValue', node: 'CityStats/E4/3'",
+    "counterKey": "Sanity_NonDoubleObsValue"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -641,6 +577,46 @@
     },
     "userMessage": "Found property name that does not start with a lower-case :: property: 'Dcid', node: 'E:SVTest->E3'",
     "counterKey": "Sanity_NotInitLowerPropName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "109"
+    },
+    "userMessage": "Found property name that does not start with a lower-case :: property: 'PopulationType', node: 'dcid:Count_Death_15YearsPlus'",
+    "counterKey": "Sanity_NotInitLowerPropName"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Found a property reference that does not start with a lower-case :: reference: 'BeverageType', property: 'label', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_NotInitLower_labelInProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Found a class reference that does not start with an upper-case :: reference: 'pop', property: 'name', node: 'dcid:Pop'",
+    "counterKey": "Sanity_NotInitUpper_nameInClass"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "41"
+    },
+    "userMessage": "Observation node missing value property :: node: 'CityStats/E4/4'",
+    "counterKey": "Sanity_ObsMissingValueProp"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.tmcf",
+      "lineNumber": "32"
+    },
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E1', property: 'dcid' node: 'E:SVTest->E4'",
+    "counterKey": "Sanity_TmcfMissingEntityDef"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
@@ -661,42 +637,66 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "NoCsv.tmcf",
-      "lineNumber": "34"
+      "lineNumber": "3"
     },
-    "userMessage": "Found malformed Complex value without a closing ] bracket :: value: '[', property: 'age', node: 'E:SVTest->E4'",
-    "counterKey": "MCF_MalformedComplexValue"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.tmcf",
-      "lineNumber": "32"
-    },
-    "userMessage": "Missing typeOf value for node :: node: 'E:SVTest->E4'",
-    "counterKey": "Mutator_MissingTypeOf"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.tmcf",
-      "lineNumber": "32"
-    },
-    "userMessage": "Found a missing or empty property value :: property: 'typeOf', node: 'E:SVTest->E4', type: 'Thing'",
-    "counterKey": "Sanity_MissingOrEmpty_typeOf"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.tmcf",
-      "lineNumber": "32"
-    },
-    "userMessage": "Value of dcid property must not be an 'E:' reference :: value: 'E:SVTest->E1', node: 'E:SVTest->E4'",
-    "counterKey": "Sanity_DcidTableEntity"
-  }, {
-    "level": "LEVEL_ERROR",
-    "location": {
-      "file": "NoCsv.tmcf",
-      "lineNumber": "32"
-    },
-    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E1', property: 'dcid' node: 'E:SVTest->E4'",
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E3', property: 'observationAbout' node: 'E:SVTest->E0'",
     "counterKey": "Sanity_TmcfMissingEntityDef"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.tmcf",
+      "lineNumber": "3"
+    },
+    "userMessage": "No definition found for a referenced 'E:' value :: reference: 'E:SVTest->E30', property: 'observationAbout' node: 'E:SVTest->E0'",
+    "counterKey": "Sanity_TmcfMissingEntityDef"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "123"
+    },
+    "userMessage": "Unexpected property in Class node :: property: 'domainIncludes', node: 'dcid:Pop'",
+    "counterKey": "Sanity_UnexpectedPropInClass"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.mcf",
+      "lineNumber": "116"
+    },
+    "userMessage": "Unexpected property in Property node :: property: 'subClassOf', node: 'dcid:beverageType'",
+    "counterKey": "Sanity_UnexpectedPropInProperty"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.tmcf",
+      "lineNumber": "25"
+    },
+    "userMessage": "Found malformed entity name that is not an entity prefix (E:) :: name: 'C:SVTest->NodeDcid'",
+    "counterKey": "TMCF_MalformedEntity"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.tmcf",
+      "lineNumber": "11"
+    },
+    "userMessage": "Found malformed entity name that is not an entity prefix (E:) :: name: '\"E:SVTest->E1\"'",
+    "counterKey": "TMCF_MalformedEntity"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.tmcf",
+      "lineNumber": "22"
+    },
+    "userMessage": "Malformed column value; must have a '->' delimiter :: value: 'C:SVTest>Place_Name', property: 'name', node: 'E:SVTest->E3'",
+    "counterKey": "TMCF_MalformedSchemaTerm"
+  }, {
+    "level": "LEVEL_ERROR",
+    "location": {
+      "file": "NoCsv.tmcf",
+      "lineNumber": "27"
+    },
+    "userMessage": "TMCF properties cannot refer to CSV columns yet :: value: 'SVTest->Property: C:SVTest->Property_Value', property: 'C', node: 'E:SVTest->E3'",
+    "counterKey": "TMCF_UnsupportedColumnNameInProperty"
   }],
   "commandArgs": {
     "existenceChecks": true,

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -222,7 +222,6 @@ public class LogWrapper {
 
   public void addEntry(
       Debug.Log.Level level, String counter, String message, String file, long lno) {
-    if (TEST_MODE) System.err.println(counter + " - " + message);
     String counterName = counter == null || counter.isEmpty() ? "MissingCounterName" : counter;
     incrementCounterBy(level, counterName, 1);
 

--- a/util/src/main/java/org/datacommons/util/LogWrapper.java
+++ b/util/src/main/java/org/datacommons/util/LogWrapper.java
@@ -25,6 +25,8 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -32,6 +34,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.datacommons.proto.Debug;
+import org.datacommons.proto.Debug.Log;
 import org.datacommons.proto.Debug.StatValidationResult;
 
 // The class that provides logging functionality.  This class is Thread Safe.
@@ -149,6 +152,11 @@ public class LogWrapper {
 
   private void persistLog(boolean silent) throws IOException {
     refreshCounters();
+
+    if (LogWrapper.TEST_MODE) {
+      sortLogEntries();
+    }
+
     File logFile = new File(logPath.toString());
     FileUtils.writeStringToFile(logFile, StringUtil.msgToJson(log.build()), StandardCharsets.UTF_8);
     if (!silent) {
@@ -244,5 +252,30 @@ public class LogWrapper {
     Debug.Log.Location.Builder l = e.getLocationBuilder();
     l.setFile(file);
     l.setLineNumber(lno);
+  }
+
+  private void sortLogEntries() {
+    class SortByCounterKeyThenUserMessage implements Comparator<Log.Entry> {
+      public int compare(Log.Entry a, Log.Entry b) {
+        int counterKeyCompare = a.getCounterKey().compareTo(b.getCounterKey());
+        // When counter keys are equivalent, sort by user message as secondary sort key
+        if (counterKeyCompare == 0) {
+          return a.getUserMessage().compareTo(b.getUserMessage());
+        }
+        return counterKeyCompare;
+      }
+    }
+
+    List<Log.Entry.Builder> entriesBuilders = log.getEntriesBuilderList();
+    List<Log.Entry> entries = new ArrayList<Log.Entry>();
+
+    for (Debug.Log.Entry.Builder builder : entriesBuilders) {
+      Log.Entry entry = builder.build();
+      entries.add(entry);
+    }
+
+    Collections.sort(entries, new SortByCounterKeyThenUserMessage());
+    log.clearEntries();
+    log.addAllEntries(entries);
   }
 }

--- a/util/src/test/java/org/datacommons/util/LogWrapperTest.java
+++ b/util/src/test/java/org/datacommons/util/LogWrapperTest.java
@@ -29,11 +29,17 @@ import org.junit.rules.TemporaryFolder;
 public class LogWrapperTest {
   @Rule public TemporaryFolder testFolder = new TemporaryFolder();
 
-  @Test
-  public void main() throws IOException {
+  private LogWrapper setupLogWrapper() {
     Debug.Log.Builder logCtx = Debug.Log.newBuilder();
     // First use LogWrapper to update logCtx
+    LogWrapper.TEST_MODE = true;
     LogWrapper lw = new LogWrapper(logCtx, testFolder.getRoot().toPath());
+    return lw;
+  }
+
+  @Test
+  public void main() throws IOException {
+    LogWrapper lw = setupLogWrapper();
     lw.addEntry(
         Debug.Log.Level.LEVEL_ERROR, "MCF_NoColonFound", "Missing Colon", "TestInput.mcf", 10);
     lw.addEntry(
@@ -55,9 +61,7 @@ public class LogWrapperTest {
 
   @Test
   public void tooManyErrors() throws IOException {
-    Debug.Log.Builder logCtx = Debug.Log.newBuilder();
-    // First use LogWrapper to update logCtx
-    LogWrapper lw = new LogWrapper(logCtx, testFolder.getRoot().toPath());
+    LogWrapper lw = setupLogWrapper();
     for (int i = 1; i <= 50; i++) {
       lw.addEntry(
           Debug.Log.Level.LEVEL_ERROR, "MCF_ErrorCounter" + i, "Foo Error", "TestInput.mcf", i);

--- a/util/src/test/resources/org/datacommons/util/LogWrapperTest_result.json
+++ b/util/src/test/resources/org/datacommons/util/LogWrapperTest_result.json
@@ -22,13 +22,13 @@
     }
   },
   "entries": [{
-    "level": "LEVEL_ERROR",
+    "level": "LEVEL_FATAL",
     "location": {
-      "file": "TestInput.mcf",
-      "lineNumber": "10"
+      "file": "TestInput.csv",
+      "lineNumber": "30"
     },
-    "userMessage": "Missing Colon",
-    "counterKey": "MCF_NoColonFound"
+    "userMessage": "Found a Time Bomb",
+    "counterKey": "CSV_FoundABomb"
   }, {
     "level": "LEVEL_WARNING",
     "location": {
@@ -38,12 +38,12 @@
     "userMessage": "Empty value",
     "counterKey": "MCF_EmptyValue"
   }, {
-    "level": "LEVEL_FATAL",
+    "level": "LEVEL_ERROR",
     "location": {
-      "file": "TestInput.csv",
-      "lineNumber": "30"
+      "file": "TestInput.mcf",
+      "lineNumber": "10"
     },
-    "userMessage": "Found a Time Bomb",
-    "counterKey": "CSV_FoundABomb"
+    "userMessage": "Missing Colon",
+    "counterKey": "MCF_NoColonFound"
   }]
 }


### PR DESCRIPTION
Closes #166 

### Changes
- LogWrapper.java calls sortLogEntries() when LogWrapper.TEST_MODE is
  true
  - sortLogEntries() sorts entries by building each entry, and then
    sorting using custom sort defined in SortByCounterKeyThenUserMessage
  - the Comparator function uses CounterKey as the first key, and if
    that is equal between to Log.Entry objects, uses UserMessage
  - Updated GenMcfTest.java and LintTest.java to correctly set
    LogWrapper.TEST_MODE to true
  - Updated LogWrapperTest.java to to set TEST_MODE to true. While doing
    this, refactored the common set up between two test functions in
    that file.
- Re-generated goldens with sorted counter keys
  - updated tool/**/report.json
  - updated LogWrapperTest_result.json
- remove unused print statement in LogWrapper.java

### Testing

Tested that this change addresses the flakiness by running `mvn clean && mvn golden` and observing no diffs detected by git.

Performed this 6 times back to back with no diffs.