### PR TITLE
Fix TmcfCsvParser last line number is not incremented

### DIFF
--- a/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/failed_table_mcf_nodes_covid.mcf
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/failed_table_mcf_nodes_covid.mcf
@@ -1,15 +1,15 @@
-# From covid.csv:2
-# Error: Failed to assign DCID :: type: 'Place', node: 'COVID19_cases_india/E1/1'
-Node: COVID19_cases_india/E1/1
+# From covid.csv:3
+# Error: Failed to assign DCID :: type: 'Place', node: 'COVID19_cases_india/E1/2'
+Node: COVID19_cases_india/E1/2
 isoCode: "pseudoIsoCodeDiverging"
 wikidataId: "pseudoWikidataIdDiverging"
 typeOf: dcid:Place
 
-# From covid.csv:2
-# Error: Unable to assign DCID due to unresolved local reference :: ref: 'COVID19_cases_india/E1/1', node: 'COVID19_cases_india/E0/1'
-Node: COVID19_cases_india/E0/1
+# From covid.csv:3
+# Error: Unable to assign DCID due to unresolved local reference :: ref: 'COVID19_cases_india/E1/2', node: 'COVID19_cases_india/E0/2'
+Node: COVID19_cases_india/E0/2
 observationDate: "2020-01-02"
-observationAbout: l:COVID19_cases_india/E1/1
+observationAbout: l:COVID19_cases_india/E1/2
 variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive
 value: 2
 typeOf: dcid:StatVarObservation

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/report.json
@@ -22,33 +22,33 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "covid.csv",
-      "lineNumber": "2"
+      "lineNumber": "3"
     },
-    "userMessage": "Failed to assign DCID :: type: 'Place', node: 'COVID19_cases_india/E1/1'",
+    "userMessage": "Failed to assign DCID :: type: 'Place', node: 'COVID19_cases_india/E1/2'",
     "counterKey": "Resolution_DcidAssignmentFailure_Place"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "covid.csv",
-      "lineNumber": "2"
+      "lineNumber": "3"
     },
-    "userMessage": "Found diverging DCIDs for external IDs :: extId1: 'pseudoIsoCodeDiverging, dcid1: 'pseudoPlaceDivergent_AAA', property1: 'isoCode, extId2: 'pseudoWikidataIdDiverging', dcid2:pseudoPlaceDivergent_BBB, property2: 'wikidataId', node: 'COVID19_cases_india/E1/1'",
+    "userMessage": "Found diverging DCIDs for external IDs :: extId1: 'pseudoIsoCodeDiverging, dcid1: 'pseudoPlaceDivergent_AAA', property1: 'isoCode, extId2: 'pseudoWikidataIdDiverging', dcid2:pseudoPlaceDivergent_BBB, property2: 'wikidataId', node: 'COVID19_cases_india/E1/2'",
     "counterKey": "Resolution_DivergingDcidsForExternalIds_isoCode_wikidataId"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "covid.csv",
-      "lineNumber": "2"
+      "lineNumber": "3"
     },
-    "userMessage": "Unable to replace a local reference :: ref: 'COVID19_cases_india/E1/1', node: 'COVID19_cases_india/E0/1'",
+    "userMessage": "Unable to replace a local reference :: ref: 'COVID19_cases_india/E1/2', node: 'COVID19_cases_india/E0/2'",
     "counterKey": "Resolution_IrreplaceableLocalRef"
   }, {
     "level": "LEVEL_ERROR",
     "location": {
       "file": "covid.csv",
-      "lineNumber": "2"
+      "lineNumber": "3"
     },
-    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'COVID19_cases_india/E1/1', node: 'COVID19_cases_india/E0/1'",
+    "userMessage": "Unable to assign DCID due to unresolved local reference :: ref: 'COVID19_cases_india/E1/2', node: 'COVID19_cases_india/E0/2'",
     "counterKey": "Resolution_UnassignableNodeDcid"
   }],
   "commandArgs": {

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/measurementresult/output/table_mcf_nodes_acre.mcf
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/measurementresult/output/table_mcf_nodes_acre.mcf
@@ -16,7 +16,7 @@ typeOf: dcid:StatVarObservation
 keyString: "observationAbout=geoId/01variableMeasured=Acre_MeasurementResult_StatVarobservationDate=2020-01-01value=Acre10.0"
 dcid: "dc/o/ndyt1vgyp01ld"
 
-Node: Acre_Table/E0/2
+Node: Acre_Table/E0/3
 observationDate: "2020-01-01"
 observationAbout: dcid:geoId/01
 variableMeasured: dcid:Acre_MeasurementResult_StatVar

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/statchecks/output/table_mcf_nodes_covid.mcf
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/statchecks/output/table_mcf_nodes_covid.mcf
@@ -538,7 +538,7 @@ observationPeriod: "P1Y"
 keyString: "observationAbout=geoId/27111variableMeasured=CumulativeCount_MedicalTest_ConditionCOVID_19_PositiveobservationDate=2020-06-02value=1observationPeriod=P1Y"
 dcid: "dc/o/2pyydweng49e2"
 
-Node: COVID19_cases_india/E0/54
+Node: COVID19_cases_india/E0/55
 observationDate: "2020-06-02"
 observationAbout: dcid:geoId/28111
 variableMeasured: dcid:CumulativeCount_MedicalTest_ConditionCOVID_19_Positive

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/output/report.json
@@ -176,7 +176,7 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "SuccessTmcf.csv",
-      "lineNumber": "16"
+      "lineNumber": "17"
     },
     "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
     "counterKey": "Existence_MissingReference_measurementMethod"
@@ -264,7 +264,7 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "SuccessTmcf.csv",
-      "lineNumber": "16"
+      "lineNumber": "17"
     },
     "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
     "counterKey": "Existence_MissingReference_measurementMethod"
@@ -368,7 +368,7 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "SuccessTmcf.csv",
-      "lineNumber": "16"
+      "lineNumber": "17"
     },
     "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
     "counterKey": "Existence_MissingReference_variableMeasured"
@@ -456,7 +456,7 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "SuccessTmcf.csv",
-      "lineNumber": "16"
+      "lineNumber": "17"
     },
     "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
     "counterKey": "Existence_MissingReference_variableMeasured"
@@ -536,7 +536,7 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "SuccessTmcf.csv",
-      "lineNumber": "16"
+      "lineNumber": "17"
     },
     "userMessage": "Found invalid chars in dcid value :: value: 'Administrative–Area1', invalid-chars: '–', property: 'typeOf', node: 'E:SVTest->E3'",
     "counterKey": "Sanity_InvalidChars_typeOf"
@@ -632,7 +632,7 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "SuccessTmcf.csv",
-      "lineNumber": "16"
+      "lineNumber": "17"
     },
     "userMessage": "Found non-ascii characters in a value that is not text :: value: 'Administrative–Area1', type: 'RESOLVED_REF', property: 'typeOf', node: 'E:SVTest->E3'",
     "counterKey": "Sanity_NonAsciiValueInNonText"
@@ -687,7 +687,7 @@
           "value": 0.0,
           "locations": [{
             "file": "SuccessTmcf.csv",
-            "lineNumber": "16"
+            "lineNumber": "17"
           }]
         }]
       }, {

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/output/table_mcf_nodes_SuccessTmcf.mcf
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/output/table_mcf_nodes_SuccessTmcf.mcf
@@ -248,7 +248,7 @@ typeOf: dcid:StatVarObservation
 keyString: "observationAbout=CA-ABvariableMeasured=SV2observationDate=2017-09-01value=2measurementMethod=SVTest"
 dcid: "dc/o/gk7mjz5641fvd"
 
-Node: SVTest/E0/15
+Node: SVTest/E0/16
 observationDate: "2011-01-01"
 observationAbout: dcid:CA-AB
 variableMeasured: dcid:SV1
@@ -258,7 +258,7 @@ typeOf: dcid:StatVarObservation
 keyString: "observationAbout=CA-ABvariableMeasured=SV1observationDate=2011-01-01value=0measurementMethod=SVTest"
 dcid: "dc/o/jthmwgr5pvym7"
 
-Node: SVTest/E1/15
+Node: SVTest/E1/16
 observationDate: "2011-01-01"
 observationAbout: dcid:CA-AB
 variableMeasured: dcid:SV2

--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
@@ -212,7 +212,7 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.csv",
-      "lineNumber": "11"
+      "lineNumber": "12"
     },
     "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
     "counterKey": "Existence_MissingReference_measurementMethod"
@@ -260,7 +260,7 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.csv",
-      "lineNumber": "11"
+      "lineNumber": "12"
     },
     "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E1'",
     "counterKey": "Existence_MissingReference_measurementMethod"
@@ -356,7 +356,7 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.csv",
-      "lineNumber": "11"
+      "lineNumber": "12"
     },
     "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
     "counterKey": "Existence_MissingReference_variableMeasured"
@@ -404,7 +404,7 @@
     "level": "LEVEL_WARNING",
     "location": {
       "file": "AllFileTypes.csv",
-      "lineNumber": "11"
+      "lineNumber": "12"
     },
     "userMessage": "Failed reference existence check :: value-ref: 'SV2', property: 'variableMeasured', node: 'E:SVTest->E1'",
     "counterKey": "Existence_MissingReference_variableMeasured"
@@ -484,7 +484,7 @@
     "level": "LEVEL_ERROR",
     "location": {
       "file": "AllFileTypes.csv",
-      "lineNumber": "11"
+      "lineNumber": "12"
     },
     "userMessage": "Quantity value must be a number :: value: '[Lat Long]', property: 'location', node: 'dcid:CA-MN'",
     "counterKey": "MCF_QuantityMalformedValue"

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -37,6 +37,9 @@ public class TmcfCsvParser {
 
   private Mcf.McfGraph tmcf;
   private char delimiter;
+  // We track the line number using a private variable instead of using
+  // csvparser.getCurrentLineNumber() because that function does not increment
+  // the line number for the last line that does not end in a newline.
   private long currentLineNumber;
   private String csvFileName;
   private CSVParser csvParser;
@@ -373,9 +376,6 @@ public class TmcfCsvParser {
 
   // Returns the current line in the CSV.
   private long getCurrentLineNumber() {
-    // We track the line number using a private variable instead of using
-    // csvparser.getCurrentLineNumber() because that function does not increment
-    // the line number for the last line that does not end in a newline.
     return currentLineNumber;
   }
 }

--- a/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
+++ b/util/src/main/java/org/datacommons/util/TmcfCsvParser.java
@@ -32,13 +32,12 @@ import org.datacommons.proto.Mcf;
 //
 // NOTE: Sets the location file in LogWrapper (at different times to point to TMCF and CSV).
 // TODO: Add more column info in generated MCF, even when values are missing.
-// TODO: CSV Parser's getCurrentLineNumber() appears to return not increment line-number for the
-//       last line if it does not end with a newline. Consider tracking line-number directly.
 public class TmcfCsvParser {
   public static boolean TEST_mode = false;
 
   private Mcf.McfGraph tmcf;
   private char delimiter;
+  private long currentLineNumber;
   private String csvFileName;
   private CSVParser csvParser;
   private LogWrapper logCtx;
@@ -51,6 +50,7 @@ public class TmcfCsvParser {
     TmcfCsvParser tmcfCsvParser = new TmcfCsvParser();
     tmcfCsvParser.tmcf = McfParser.parseTemplateMcfFile(tmcfFile, logCtx);
     tmcfCsvParser.logCtx = logCtx;
+    tmcfCsvParser.currentLineNumber = 1;
     tmcfCsvParser.csvParser =
         CSVParser.parse(
             new FileReader(csvFile),
@@ -72,6 +72,7 @@ public class TmcfCsvParser {
           "Unable to parse header from CSV file :: file: '" + csvFile + "'",
           tmcfCsvParser.csvFileName,
           0);
+
       return null;
     }
     // Check TMCF.
@@ -103,6 +104,7 @@ public class TmcfCsvParser {
       return null;
     }
     RowProcessor processor = new RowProcessor();
+    currentLineNumber++;
     processor.process(csvParser.iterator().next());
     return processor.instanceMcf();
   }
@@ -119,7 +121,7 @@ public class TmcfCsvParser {
       instanceMcf = Mcf.McfGraph.newBuilder();
       instanceMcf.setType(Mcf.McfType.INSTANCE_MCF);
       entityToDcid = new HashMap<>();
-      rowId = TEST_mode ? String.valueOf(csvParser.getCurrentLineNumber() - 1) : newUUID();
+      rowId = TEST_mode ? String.valueOf(getCurrentLineNumber()) : newUUID();
     }
 
     public Mcf.McfGraph instanceMcf() {
@@ -136,8 +138,7 @@ public class TmcfCsvParser {
       }
 
       LogCb logCb =
-          new LogCb(
-              logCtx, Debug.Log.Level.LEVEL_ERROR, csvFileName, csvParser.getCurrentLineNumber());
+          new LogCb(logCtx, Debug.Log.Level.LEVEL_ERROR, csvFileName, getCurrentLineNumber());
 
       // Process DCIDs from all the nodes first and add to entityToDcid map, which will be consulted
       // to resolve entity references in processValues() function.
@@ -205,7 +206,7 @@ public class TmcfCsvParser {
         nodeBuilder.setTemplateNode(tableEntity.getKey());
         Debug.Log.Location.Builder loc = nodeBuilder.addLocationsBuilder();
         loc.setFile(csvFileName);
-        loc.setLineNumber(csvParser.getCurrentLineNumber());
+        loc.setLineNumber(getCurrentLineNumber());
 
         Mcf.McfGraph.PropertyValues newNode = nodeBuilder.build();
         boolean success =
@@ -225,19 +226,11 @@ public class TmcfCsvParser {
 
       // Used for parseSchemaTerm() and splitAndStripWithQuoteEscape()
       LogCb errCb =
-          new LogCb(
-                  logCtx,
-                  Debug.Log.Level.LEVEL_ERROR,
-                  csvFileName,
-                  csvParser.getCurrentLineNumber())
+          new LogCb(logCtx, Debug.Log.Level.LEVEL_ERROR, csvFileName, getCurrentLineNumber())
               .setDetail(LogCb.PROP_KEY, currentProp)
               .setDetail(LogCb.NODE_KEY, templateEntity);
       LogCb warnCb =
-          new LogCb(
-                  logCtx,
-                  Debug.Log.Level.LEVEL_WARNING,
-                  csvFileName,
-                  csvParser.getCurrentLineNumber())
+          new LogCb(logCtx, Debug.Log.Level.LEVEL_WARNING, csvFileName, getCurrentLineNumber())
               .setDetail(LogCb.PROP_KEY, currentProp)
               .setDetail(LogCb.NODE_KEY, templateEntity);
 
@@ -375,6 +368,14 @@ public class TmcfCsvParser {
   }
 
   private void addLog(Debug.Log.Level level, String counter, String message) {
-    logCtx.addEntry(level, counter, message, csvFileName, csvParser.getCurrentLineNumber());
+    logCtx.addEntry(level, counter, message, csvFileName, getCurrentLineNumber());
+  }
+
+  // Returns the current line in the CSV.
+  private long getCurrentLineNumber() {
+    // We track the line number using a private variable instead of using
+    // csvparser.getCurrentLineNumber() because that function does not increment
+    // the line number for the last line that does not end in a newline.
+    return currentLineNumber;
   }
 }


### PR DESCRIPTION
### What this PR Fixes

https://github.com/datacommonsorg/import/blob/d995b5c52d2750cb8ec4b5cce564209edda18e02/util/src/main/java/org/datacommons/util/TmcfCsvParser.java#L35-L36

### Implementation

Switch implementation to use a private variable because csvParser.getCurrentLineNumber() does not increment last line when the row does not end in a newline.

### Testing

Unit tests pass. I reviewed the goldens by hand to make sure that the only changes were the IDs of the last rows in the inputs. Specifically, these should increment by one since they were previously one less than the correct value.