### PR TITLE
Support BOM, propagate exceptions and allow empty column names

### DIFF
--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.logging.log4j.LogManager;
@@ -212,7 +213,16 @@ public class Processor {
             }
           });
     }
-    execService.invokeAll(cbs);
+
+    var futures = execService.invokeAll(cbs);
+    for (var f : futures) {
+      try {
+        f.get();
+      } catch (ExecutionException ex) {
+        ex.getCause().printStackTrace();
+        throw new DCTooManyFailuresException("Fatal error processing CSVs!");
+      }
+    }
 
     if (existenceChecker != null) existenceChecker.drainRemoteCalls();
   }
@@ -361,7 +371,16 @@ public class Processor {
             }
           });
     }
-    execService.invokeAll(cbs);
+
+    var futures = execService.invokeAll(cbs);
+    for (var f : futures) {
+      try {
+        f.get();
+      } catch (ExecutionException ex) {
+        ex.getCause().printStackTrace();
+        throw new DCTooManyFailuresException("Fatal error during resolution!");
+      }
+    }
 
     idResolver.drainRemoteCalls();
   }

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/report.json
@@ -2,7 +2,6 @@
   "levelSummary": {
     "LEVEL_WARNING": {
       "counters": {
-        "API_EmptyDcCallResponse": "1",
         "Sanity_MultipleVals_value": "1"
       }
     },

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/summary_report.html
@@ -68,9 +68,6 @@
               </summary>
               <ul>
                 <li>
-                  <a href="#counters--LEVEL_WARNING--API_EmptyDcCallResponse">API_EmptyDcCallResponse</a>
-                </li>
-                <li>
                   <a href="#counters--LEVEL_WARNING--Sanity_MultipleVals_value">Sanity_MultipleVals_value</a>
                 </li>
               </ul>
@@ -192,10 +189,6 @@
               <tr>
                 <th colspan="2" align="left"><a href="#counters--LEVEL_WARNING" name="counters--LEVEL_WARNING">LEVEL_WARNING</a></th>
               </tr>
-                <tr>
-                  <td><a href="#counters--LEVEL_WARNING--API_EmptyDcCallResponse" name="counters--LEVEL_WARNING--API_EmptyDcCallResponse">API_EmptyDcCallResponse</a></td>
-                  <td>1</td>
-                </tr>
                 <tr>
                   <td><a href="#counters--LEVEL_WARNING--Sanity_MultipleVals_value" name="counters--LEVEL_WARNING--Sanity_MultipleVals_value">Sanity_MultipleVals_value</a></td>
                   <td>1</td>

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/input/SuccessTmcf.csv
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/input/SuccessTmcf.csv
@@ -1,4 +1,4 @@
-Year,Place_Id,Place_Name,Place_Type,LatLong,SV1,SV2
+﻿Year,Place_Id,Place_Name,Place_Type,LatLong,SV1,SV2
 19,US- CA,California,State,[LatLong 36N 1194W],1,2
 2019,"CA-BC,Canada",British–Columbia,AdministrativeArea1,[LatLong 53W 127N],1,2
 2019-06-01,CA-AB,Alberta,Administrative–Area1,[Lat Long 539 116],1,2


### PR DESCRIPTION
This PR makes 3 fixes:

1. Strips out BOM characters apparently found at the beginning of old Excel sheets
2. Propagates exceptions during CSV processing so we fail loudly
3. Allow empty column names in CSVs

The first two issues were found from Techsoup CSVs.