### PR TITLE
Add support for coordinates resolution.

### DIFF
--- a/tool/src/main/java/org/datacommons/tool/Args.java
+++ b/tool/src/main/java/org/datacommons/tool/Args.java
@@ -11,6 +11,7 @@ import org.datacommons.util.FileGroup;
 class Args {
   public boolean doExistenceChecks = false;
   public ResolutionMode resolutionMode = ResolutionMode.NONE;
+  public boolean doCoordinatesResolution = false;
   public boolean doStatChecks = false;
   public List<String> samplePlaces = null;
   public boolean verbose = false;
@@ -32,6 +33,7 @@ class Args {
     }
     argStr.append(" existence-checks=" + doExistenceChecks);
     argStr.append(", resolution=" + resolutionMode.name());
+    argStr.append(", coordinates-resolution=" + doCoordinatesResolution);
     argStr.append(", num-threads=" + numThreads);
     argStr.append(", stat-checks=" + doStatChecks);
     if (samplePlaces != null) {
@@ -55,6 +57,7 @@ class Args {
     } else if (resolutionMode == ResolutionMode.FULL) {
       argsBuilder.setResolution(Debug.CommandArgs.ResolutionMode.RESOLUTION_MODE_FULL);
     }
+    argsBuilder.setCoordinatesResolution(doCoordinatesResolution);
     argsBuilder.setStatChecks(doStatChecks);
     if (samplePlaces != null) argsBuilder.addAllSamplePlaces(samplePlaces);
     argsBuilder.setObservationAbout(checkObservationAbout);

--- a/tool/src/main/java/org/datacommons/tool/GenMcf.java
+++ b/tool/src/main/java/org/datacommons/tool/GenMcf.java
@@ -58,6 +58,7 @@ class GenMcf implements Callable<Integer> {
     Args args = new Args();
     args.doExistenceChecks = parent.doExistenceChecks;
     args.resolutionMode = parent.resolutionMode;
+    args.doCoordinatesResolution = parent.doCoordinatesResolution;
     args.doStatChecks = parent.doStatChecks;
     args.samplePlaces = parent.samplePlaces;
     args.numThreads = parent.numThreads;

--- a/tool/src/main/java/org/datacommons/tool/Lint.java
+++ b/tool/src/main/java/org/datacommons/tool/Lint.java
@@ -56,6 +56,7 @@ class Lint implements Callable<Integer> {
     Args args = new Args();
     args.doExistenceChecks = parent.doExistenceChecks;
     args.resolutionMode = parent.resolutionMode;
+    args.doCoordinatesResolution = parent.doCoordinatesResolution;
     args.doStatChecks = parent.doStatChecks;
     args.samplePlaces = parent.samplePlaces;
     args.numThreads = parent.numThreads;

--- a/tool/src/main/java/org/datacommons/tool/Main.java
+++ b/tool/src/main/java/org/datacommons/tool/Main.java
@@ -68,6 +68,14 @@ class Main {
   public Args.ResolutionMode resolutionMode = Args.ResolutionMode.NONE;
 
   @CommandLine.Option(
+      names = {"-cr", "--coordinates-resolution"},
+      defaultValue = "false",
+      scope = CommandLine.ScopeType.INHERIT,
+      description =
+          "If set, resolves lat-lng coordinates by making DC Recon API calls. This flag is only application in full resolution mode.")
+  public boolean doCoordinatesResolution;
+
+  @CommandLine.Option(
       names = {"-s", "--stat-checks"},
       defaultValue = "true",
       scope = CommandLine.ScopeType.INHERIT,

--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -131,7 +131,9 @@ public class Processor {
       existenceChecker = new ExistenceChecker(this.httpClient, args.verbose, logCtx);
     }
     if (args.resolutionMode == Args.ResolutionMode.FULL) {
-      idResolver = new ExternalIdResolver(this.httpClient, args.verbose, logCtx);
+      idResolver =
+          new ExternalIdResolver(
+              this.httpClient, args.doCoordinatesResolution, args.verbose, logCtx);
     }
     statVarState = new StatVarState(this.httpClient, logCtx);
     if (args.doStatChecks) {

--- a/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
+++ b/tool/src/test/java/org/datacommons/tool/GenMcfTest.java
@@ -54,13 +54,22 @@ public class GenMcfTest {
   // count here.
   private static Map<String, Integer> EXPECTED_FILES_TO_CHECK =
       Map.of(
-          "fataltmcf", 2,
-          "resolution", 5,
-          "statchecks", 3,
-          "successtmcf", 3,
-          "measurementresult", 4,
-          "localidresolution", 5,
-          "manyinconsistent", 4);
+          "fataltmcf",
+          2,
+          "resolution",
+          5,
+          "latlngresolution",
+          3,
+          "statchecks",
+          3,
+          "successtmcf",
+          3,
+          "measurementresult",
+          4,
+          "localidresolution",
+          5,
+          "manyinconsistent",
+          4);
 
   // Skip testing the following files. If this List is non-empty, the flaky files should be fixed
   // and removed from this list.

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/fataltmcf/output/report.json
@@ -196,6 +196,7 @@
     "numThreads": 1,
     "statChecks": true,
     "observationAbout": false,
-    "allowNanSvobs": false
+    "allowNanSvobs": false,
+    "coordinatesResolution": false
   }
 }

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/latlngresolution/input/LatLng.csv
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/latlngresolution/input/LatLng.csv
@@ -1,0 +1,6 @@
+Year,Place_Name,Lat,Lng,SV1
+2019,British–Columbia,53,-127,1
+2019,Saskatchewan,43,-116,5
+2019,San Francisco,37.77493,-122.41942,1
+2019,California,36,-119.4,1
+2019,Alberta,53.9,-116,6

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/latlngresolution/input/LatLng.tmcf
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/latlngresolution/input/LatLng.tmcf
@@ -1,0 +1,13 @@
+Node: E:SVTest->E0
+typeOf: dcs:StatVarObservation
+variableMeasured: dcs:SV1
+measurementMethod: dcs:SVTest
+observationAbout: E:SVTest->E3
+observationDate: C:SVTest->Year
+value: C:SVTest->SV1
+
+Node: E:SVTest->E3
+typeOf: dcid:Place
+name: C:SVTest->Place_Name
+latitude: C:SVTest->Lat
+longitude: C:SVTest->Lng

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/latlngresolution/input/args.txt
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/latlngresolution/input/args.txt
@@ -1,0 +1,1 @@
+--coordinates-resolution=true

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/latlngresolution/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/latlngresolution/output/report.json
@@ -1,0 +1,110 @@
+{
+  "levelSummary": {
+    "LEVEL_INFO": {
+      "counters": {
+        "NumRowSuccesses": "5",
+        "NumPVSuccesses": "65",
+        "Existence_NumChecks": "65",
+        "NumNodeSuccesses": "10",
+        "ReconClient_NumApiCalls": "1",
+        "Existence_NumDcCalls": "1"
+      }
+    },
+    "LEVEL_WARNING": {
+      "counters": {
+        "Existence_MissingReference_measurementMethod": "5",
+        "Existence_MissingReference_variableMeasured": "5"
+      }
+    }
+  },
+  "entries": [{
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "LatLng.csv",
+      "lineNumber": "2"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "LatLng.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "LatLng.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "LatLng.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "LatLng.csv",
+      "lineNumber": "6"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SVTest', property: 'measurementMethod', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_measurementMethod"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "LatLng.csv",
+      "lineNumber": "2"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "LatLng.csv",
+      "lineNumber": "3"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "LatLng.csv",
+      "lineNumber": "4"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "LatLng.csv",
+      "lineNumber": "5"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }, {
+    "level": "LEVEL_WARNING",
+    "location": {
+      "file": "LatLng.csv",
+      "lineNumber": "6"
+    },
+    "userMessage": "Failed reference existence check :: value-ref: 'SV1', property: 'variableMeasured', node: 'E:SVTest->E0'",
+    "counterKey": "Existence_MissingReference_variableMeasured"
+  }],
+  "commandArgs": {
+    "existenceChecks": true,
+    "resolution": "RESOLUTION_MODE_FULL",
+    "numThreads": 1,
+    "statChecks": true,
+    "observationAbout": false,
+    "allowNanSvobs": false,
+    "coordinatesResolution": true
+  }
+}

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/latlngresolution/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/latlngresolution/output/summary_report.html
@@ -1,0 +1,622 @@
+<html>
+  <head>
+    <title>Summary Report</title>
+    <!-- required by DataTables -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js" type="text/javascript"></script>
+
+    <!-- DataTables documentation: https://datatables.net/ -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.12.1/datatables.min.css"/>
+    <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.12.1/datatables.min.js"></script>
+  </head>
+  <body>
+    <style>
+      table,
+      td,
+      th {
+        border: 1px solid black;
+        border-collapse: collapse;
+        padding: 5px;
+      }
+      td, th {
+        max-width: 25rem;
+        word-wrap: break-word;
+        vertical-align: top;
+      }
+      tbody tr:hover {
+        background-color: #ccc;
+      }
+      .datatables-table{
+        border: 0;
+      }
+      .place-series-summary {
+        cursor: pointer;
+        font-size: 1.2rem;
+        font-weight: bold;
+        padding-bottom: 1rem;
+      }
+      .place-series-details {
+        padding-bottom: 1rem;
+      }
+      .toc-details-ul {
+        list-style: none;
+        padding-left: 0;
+      }
+      #go-to-top{
+        position: fixed;
+        bottom: 10px;
+        right: 10px;
+      }
+    </style>
+    <a name="top"></a>
+    <div id="go-to-top">
+      <a href="#top">Go to Top</a>
+    </div>
+    <h1>Summary Report</h1>
+    <h3>Table of Contents</h3>
+    <button onclick="open_all_details()">Expand All</button>
+    <button onclick="close_all_details()">Collapse All</button>
+    <ul>
+      <li><a href="#import-run-details">Import Run Details</a></li>
+      <li><a href="#counters">Counters</a></li>
+      <ul class="toc-details-ul">
+                  <li>
+            <details>
+              <summary>
+                <a href="#counters--LEVEL_INFO">
+                  LEVEL_INFO
+                </a>
+              </summary>
+              <ul>
+                <li>
+                  <a href="#counters--LEVEL_INFO--NumRowSuccesses">NumRowSuccesses</a>
+                </li>
+                <li>
+                  <a href="#counters--LEVEL_INFO--NumPVSuccesses">NumPVSuccesses</a>
+                </li>
+                <li>
+                  <a href="#counters--LEVEL_INFO--Existence_NumChecks">Existence_NumChecks</a>
+                </li>
+                <li>
+                  <a href="#counters--LEVEL_INFO--NumNodeSuccesses">NumNodeSuccesses</a>
+                </li>
+                <li>
+                  <a href="#counters--LEVEL_INFO--ReconClient_NumApiCalls">ReconClient_NumApiCalls</a>
+                </li>
+                <li>
+                  <a href="#counters--LEVEL_INFO--Existence_NumDcCalls">Existence_NumDcCalls</a>
+                </li>
+              </ul>
+            </details>
+          </li>
+          <li>
+            <details>
+              <summary>
+                <a href="#counters--LEVEL_WARNING">
+                  LEVEL_WARNING
+                </a>
+              </summary>
+              <ul>
+                <li>
+                  <a href="#counters--LEVEL_WARNING--Existence_MissingReference_measurementMethod">Existence_MissingReference_measurementMethod</a>
+                </li>
+                <li>
+                  <a href="#counters--LEVEL_WARNING--Existence_MissingReference_variableMeasured">Existence_MissingReference_variableMeasured</a>
+                </li>
+              </ul>
+            </details>
+          </li>
+      </ul>
+      
+        <li><a href="#statvars"">StatVarObservations by StatVar</a></li>
+          <details>
+            <summary>StatVars</summary>
+              <ul>
+                  <li>
+                    <a href="#statvars--SV1">SV1</a>
+                  </li>
+              </ul>
+          </details>
+
+        <li><a href="#places"">Series Summaries for Sample Places</a></li>
+        <ul class="toc-details-ul">
+            <li>
+              <details>
+                <summary>
+                  <a href="#places--country/CAN">Canada (country/CAN)</a>
+                </summary>
+                <ul>
+                  <li>
+                    <a href="#places--country/CAN--SV1">SV1</a>
+                  </li>
+                </ul>
+              </details>
+            </li>
+            <li>
+              <details>
+                <summary>
+                  <a href="#places--ipcc_50/53.75_-115.75_CAN">53.75,-115.75 CAN (ipcc_50/53.75_-115.75_CAN)</a>
+                </summary>
+                <ul>
+                  <li>
+                    <a href="#places--ipcc_50/53.75_-115.75_CAN--SV1">SV1</a>
+                  </li>
+                </ul>
+              </details>
+            </li>
+            <li>
+              <details>
+                <summary>
+                  <a href="#places--zip/83624">83624 (zip/83624)</a>
+                </summary>
+                <ul>
+                  <li>
+                    <a href="#places--zip/83624--SV1">SV1</a>
+                  </li>
+                </ul>
+              </details>
+            </li>
+            <li>
+              <details>
+                <summary>
+                  <a href="#places--zip/93212">93212 (zip/93212)</a>
+                </summary>
+                <ul>
+                  <li>
+                    <a href="#places--zip/93212--SV1">SV1</a>
+                  </li>
+                </ul>
+              </details>
+            </li>
+            <li>
+              <details>
+                <summary>
+                  <a href="#places--zip/94103">94103 (zip/94103)</a>
+                </summary>
+                <ul>
+                  <li>
+                    <a href="#places--zip/94103--SV1">SV1</a>
+                  </li>
+                </ul>
+              </details>
+            </li>
+        </ul>
+    </ul>
+
+    <div>
+      <h2>
+        <a name="import-run-details" href="#import-run-details">Import Run Details</a>
+      </h2>  
+      <table>
+        <tr>
+          <td>Existence Checks Enabled</td>
+          <td>yes</td>
+        </tr>
+        <tr>
+          <td>Resolution Mode</td>
+          <td>RESOLUTION_MODE_FULL</td>
+        </tr>
+        <tr>
+          <td>Num Threads</td>
+          <td>1</td>
+        </tr>
+        <tr>
+          <td>Stat Checks Enabled</td>
+          <td>yes</td>
+        </tr>
+        <tr>
+          <td>Sample Places Entered</td>
+          <td></td>
+        </tr>
+      </table>
+    </div>
+
+    
+    <div>
+      <h2>
+        <a name="counters" href="#counters">Counters</a>
+      </h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Counter Name</th>
+            <th>Num Occurences</th>
+          </tr>
+        </thead>
+            <tbody>
+              <tr>
+                <th colspan="2" align="left"><a href="#counters--LEVEL_INFO" name="counters--LEVEL_INFO">LEVEL_INFO</a></th>
+              </tr>
+                <tr>
+                  <td><a href="#counters--LEVEL_INFO--NumRowSuccesses" name="counters--LEVEL_INFO--NumRowSuccesses">NumRowSuccesses</a></td>
+                  <td>5</td>
+                </tr>
+                <tr>
+                  <td><a href="#counters--LEVEL_INFO--NumPVSuccesses" name="counters--LEVEL_INFO--NumPVSuccesses">NumPVSuccesses</a></td>
+                  <td>65</td>
+                </tr>
+                <tr>
+                  <td><a href="#counters--LEVEL_INFO--Existence_NumChecks" name="counters--LEVEL_INFO--Existence_NumChecks">Existence_NumChecks</a></td>
+                  <td>65</td>
+                </tr>
+                <tr>
+                  <td><a href="#counters--LEVEL_INFO--NumNodeSuccesses" name="counters--LEVEL_INFO--NumNodeSuccesses">NumNodeSuccesses</a></td>
+                  <td>10</td>
+                </tr>
+                <tr>
+                  <td><a href="#counters--LEVEL_INFO--ReconClient_NumApiCalls" name="counters--LEVEL_INFO--ReconClient_NumApiCalls">ReconClient_NumApiCalls</a></td>
+                  <td>1</td>
+                </tr>
+                <tr>
+                  <td><a href="#counters--LEVEL_INFO--Existence_NumDcCalls" name="counters--LEVEL_INFO--Existence_NumDcCalls">Existence_NumDcCalls</a></td>
+                  <td>1</td>
+                </tr>
+            </tbody>
+            <tbody>
+              <tr>
+                <th colspan="2" align="left"><a href="#counters--LEVEL_WARNING" name="counters--LEVEL_WARNING">LEVEL_WARNING</a></th>
+              </tr>
+                <tr>
+                  <td><a href="#counters--LEVEL_WARNING--Existence_MissingReference_measurementMethod" name="counters--LEVEL_WARNING--Existence_MissingReference_measurementMethod">Existence_MissingReference_measurementMethod</a></td>
+                  <td>5</td>
+                </tr>
+                <tr>
+                  <td><a href="#counters--LEVEL_WARNING--Existence_MissingReference_variableMeasured" name="counters--LEVEL_WARNING--Existence_MissingReference_variableMeasured">Existence_MissingReference_variableMeasured</a></td>
+                  <td>5</td>
+                </tr>
+            </tbody>
+      </table>
+    </div>
+      
+      <div>
+        <h2>
+          <a name="statvars" href="#statvars">StatVarObservations by StatVar</a>
+        </h2>
+        <!-- 
+          classes here provide styling through DataTables.
+          documentation:
+          - hover: https://datatables.net/examples/styling/hover.html
+          - order-column: https://datatables.net/examples/styling/order-column.html
+        -->
+        <table id="statvars-table" class="datatables-table hover order-column" width="95%">
+          <thead>
+            <tr>
+              <th>StatVar</th>
+              <th>Num Places</th>
+              <th>Num Observations</th>
+              <th>Num Observation Dates</th>
+              <th>Min Date</th>
+              <th>Max Date</th>
+              <th>Measurement Methods</th>
+              <th>Units</th>
+              <th>Scaling Factors</th>
+              <th>Observation Periods</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a name="statvars--SV1" href="#statvars--SV1">SV1</a></td>
+              <td>5</td>
+              <td>5</td>
+              <td>1</td>
+              <td>2019</td>
+              <td>2019</td>
+              <td>
+                <div>SVTest</div>
+              </td>
+              <td>
+                <div></div>
+              </td>
+              <td>
+                <div></div>
+              </td>
+              <td>
+                <div></div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <h2>
+          <a name="places" href="#places">Series Summaries for Sample Places</a>
+        </h2>
+
+          <details class="place-series-details">
+            <summary class="place-series-summary"><a name="places--country/CAN" href="#places--country/CAN">Canada (country/CAN)</a></summary>
+            <a href="https://datacommons.org/browser/country/CAN" target="_blank">Open this place (country/CAN) in Data Commons browser.</a>
+            <table id="sampleplaces-table--1" class="datatables-table hover order-column" width="95%">
+              <thead>
+                <tr>
+                  <th>StatVar</th>
+                  <th>Num Observations</th>
+                  <th>Dates</th>
+                  <th>Corresponding Values</th>
+                  <th>Measurement Method</th>
+                  <th>Unit</th>
+                  <th>Scaling Factor</th>
+                  <th>Observation Period</th>
+                  <th>Time Series Chart</th>
+                </tr>
+              </thead>
+              <tbody>
+                    <tr>
+                      <td><a href="#places--country/CAN--SV1" name="places--country/CAN--SV1">SV1</a></td>
+                      <td>1</td>
+                      <td>2019</td>
+                      <td>1</td>
+                      <td>
+                        <div>SVTest</div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+<defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
+<clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
+</defs>
+<rect x="0" y="0" width="500" height="250" style="fill: rgb(255,255,255); fill-opacity: 1.0" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><rect x="52" y="10" width="436" height="217" style="fill: rgb(255,255,255); fill-opacity: 1.0" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="52" y1="231" x2="488" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="21" y="245.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">2018-12-31</text></g><line x1="52" y1="233" x2="52" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="239" y="245.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">2019-01-01</text></g><line x1="270" y1="233" x2="270" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="48" y1="10" x2="48" y2="227" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="231.39" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.0</text></g><line x1="46" y1="227" x2="48" y2="227" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="209.69" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.2</text></g><line x1="46" y1="205.3" x2="48" y2="205.3" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="187.99" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.4</text></g><line x1="46" y1="183.6" x2="48" y2="183.6" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="166.29" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.6</text></g><line x1="46" y1="161.9" x2="48" y2="161.9" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="144.59" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.8</text></g><line x1="46" y1="140.2" x2="48" y2="140.2" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="122.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.0</text></g><line x1="46" y1="118.5" x2="48" y2="118.5" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="101.19" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.2</text></g><line x1="46" y1="96.8" x2="48" y2="96.8" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="79.49" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.4</text></g><line x1="46" y1="75.1" x2="48" y2="75.1" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="57.79" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.6</text></g><line x1="46" y1="53.4" x2="48" y2="53.4" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="36.09" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.8</text></g><line x1="46" y1="31.7" x2="48" y2="31.7" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="14.39" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">2.0</text></g><line x1="46" y1="10" x2="48" y2="10" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="52" y1="10" x2="52" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="270" y1="10" x2="270" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="227" x2="488" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="205.3" x2="488" y2="205.3" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="183.6" x2="488" y2="183.6" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="161.9" x2="488" y2="161.9" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="140.2" x2="488" y2="140.2" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="118.5" x2="488" y2="118.5" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="96.8" x2="488" y2="96.8" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="75.1" x2="488" y2="75.1" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="53.4" x2="488" y2="53.4" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="31.7" x2="488" y2="31.7" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="10" x2="488" y2="10" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><g style="fill: rgb(255,0,0); fill-opacity: 1.0; stroke: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"><path d="M 272 118.5 C 272 119.6 271.1 120.5 270 120.5 C 268.9 120.5 268 119.6 268 118.5 C 268 117.4 268.9 116.5 270 116.5 C 271.1 116.5 272 117.4 272 118.5 Z "/></g><g style="stroke-width: 1.0;stroke: rgb(255,0,0);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:geometricPrecision;; fill: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"><path d="M 272 118.5 C 272 119.6 271.1 120.5 270 120.5 C 268.9 120.5 268 119.6 268 118.5 C 268 117.4 268.9 116.5 270 116.5 C 271.1 116.5 272 117.4 272 118.5 Z "/></g><rect x="52" y="10" width="436" height="217" style="stroke-width: 0.5;stroke: rgb(0,0,0);stroke-opacity: 1.0;stroke-linecap: round;stroke-linejoin: round;shape-rendering:crispEdges;; fill: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/></svg></td>
+                    </tr>
+              </tbody>
+            </table>
+          </details>
+          <details class="place-series-details">
+            <summary class="place-series-summary"><a name="places--ipcc_50/53.75_-115.75_CAN" href="#places--ipcc_50/53.75_-115.75_CAN">53.75,-115.75 CAN (ipcc_50/53.75_-115.75_CAN)</a></summary>
+            <a href="https://datacommons.org/browser/ipcc_50/53.75_-115.75_CAN" target="_blank">Open this place (ipcc_50/53.75_-115.75_CAN) in Data Commons browser.</a>
+            <table id="sampleplaces-table--2" class="datatables-table hover order-column" width="95%">
+              <thead>
+                <tr>
+                  <th>StatVar</th>
+                  <th>Num Observations</th>
+                  <th>Dates</th>
+                  <th>Corresponding Values</th>
+                  <th>Measurement Method</th>
+                  <th>Unit</th>
+                  <th>Scaling Factor</th>
+                  <th>Observation Period</th>
+                  <th>Time Series Chart</th>
+                </tr>
+              </thead>
+              <tbody>
+                    <tr>
+                      <td><a href="#places--ipcc_50/53.75_-115.75_CAN--SV1" name="places--ipcc_50/53.75_-115.75_CAN--SV1">SV1</a></td>
+                      <td>1</td>
+                      <td>2019</td>
+                      <td>6</td>
+                      <td>
+                        <div>SVTest</div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+<defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
+<clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
+</defs>
+<rect x="0" y="0" width="500" height="250" style="fill: rgb(255,255,255); fill-opacity: 1.0" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><rect x="52" y="10" width="436" height="217" style="fill: rgb(255,255,255); fill-opacity: 1.0" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="52" y1="231" x2="488" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="21" y="245.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">2018-12-31</text></g><line x1="52" y1="233" x2="52" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="239" y="245.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">2019-01-01</text></g><line x1="270" y1="233" x2="270" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="48" y1="10" x2="48" y2="227" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="231.39" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">5.0</text></g><line x1="46" y1="227" x2="48" y2="227" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="209.69" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">5.2</text></g><line x1="46" y1="205.3" x2="48" y2="205.3" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="187.99" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">5.4</text></g><line x1="46" y1="183.6" x2="48" y2="183.6" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="166.29" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">5.6</text></g><line x1="46" y1="161.9" x2="48" y2="161.9" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="144.59" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">5.8</text></g><line x1="46" y1="140.2" x2="48" y2="140.2" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="122.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">6.0</text></g><line x1="46" y1="118.5" x2="48" y2="118.5" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="101.19" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">6.2</text></g><line x1="46" y1="96.8" x2="48" y2="96.8" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="79.49" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">6.4</text></g><line x1="46" y1="75.1" x2="48" y2="75.1" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="57.79" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">6.6</text></g><line x1="46" y1="53.4" x2="48" y2="53.4" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="36.09" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">6.8</text></g><line x1="46" y1="31.7" x2="48" y2="31.7" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="14.39" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">7.0</text></g><line x1="46" y1="10" x2="48" y2="10" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="52" y1="10" x2="52" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="270" y1="10" x2="270" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="227" x2="488" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="205.3" x2="488" y2="205.3" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="183.6" x2="488" y2="183.6" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="161.9" x2="488" y2="161.9" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="140.2" x2="488" y2="140.2" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="118.5" x2="488" y2="118.5" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="96.8" x2="488" y2="96.8" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="75.1" x2="488" y2="75.1" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="53.4" x2="488" y2="53.4" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="31.7" x2="488" y2="31.7" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="10" x2="488" y2="10" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><g style="fill: rgb(255,0,0); fill-opacity: 1.0; stroke: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"><path d="M 272 118.5 C 272 119.6 271.1 120.5 270 120.5 C 268.9 120.5 268 119.6 268 118.5 C 268 117.4 268.9 116.5 270 116.5 C 271.1 116.5 272 117.4 272 118.5 Z "/></g><g style="stroke-width: 1.0;stroke: rgb(255,0,0);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:geometricPrecision;; fill: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"><path d="M 272 118.5 C 272 119.6 271.1 120.5 270 120.5 C 268.9 120.5 268 119.6 268 118.5 C 268 117.4 268.9 116.5 270 116.5 C 271.1 116.5 272 117.4 272 118.5 Z "/></g><rect x="52" y="10" width="436" height="217" style="stroke-width: 0.5;stroke: rgb(0,0,0);stroke-opacity: 1.0;stroke-linecap: round;stroke-linejoin: round;shape-rendering:crispEdges;; fill: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/></svg></td>
+                    </tr>
+              </tbody>
+            </table>
+          </details>
+          <details class="place-series-details">
+            <summary class="place-series-summary"><a name="places--zip/83624" href="#places--zip/83624">83624 (zip/83624)</a></summary>
+            <a href="https://datacommons.org/browser/zip/83624" target="_blank">Open this place (zip/83624) in Data Commons browser.</a>
+            <table id="sampleplaces-table--3" class="datatables-table hover order-column" width="95%">
+              <thead>
+                <tr>
+                  <th>StatVar</th>
+                  <th>Num Observations</th>
+                  <th>Dates</th>
+                  <th>Corresponding Values</th>
+                  <th>Measurement Method</th>
+                  <th>Unit</th>
+                  <th>Scaling Factor</th>
+                  <th>Observation Period</th>
+                  <th>Time Series Chart</th>
+                </tr>
+              </thead>
+              <tbody>
+                    <tr>
+                      <td><a href="#places--zip/83624--SV1" name="places--zip/83624--SV1">SV1</a></td>
+                      <td>1</td>
+                      <td>2019</td>
+                      <td>5</td>
+                      <td>
+                        <div>SVTest</div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+<defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
+<clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
+</defs>
+<rect x="0" y="0" width="500" height="250" style="fill: rgb(255,255,255); fill-opacity: 1.0" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><rect x="52" y="10" width="436" height="217" style="fill: rgb(255,255,255); fill-opacity: 1.0" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="52" y1="231" x2="488" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="21" y="245.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">2018-12-31</text></g><line x1="52" y1="233" x2="52" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="239" y="245.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">2019-01-01</text></g><line x1="270" y1="233" x2="270" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="48" y1="10" x2="48" y2="227" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="231.39" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">4.0</text></g><line x1="46" y1="227" x2="48" y2="227" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="209.69" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">4.2</text></g><line x1="46" y1="205.3" x2="48" y2="205.3" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="187.99" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">4.4</text></g><line x1="46" y1="183.6" x2="48" y2="183.6" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="166.29" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">4.6</text></g><line x1="46" y1="161.9" x2="48" y2="161.9" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="144.59" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">4.8</text></g><line x1="46" y1="140.2" x2="48" y2="140.2" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="122.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">5.0</text></g><line x1="46" y1="118.5" x2="48" y2="118.5" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="101.19" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">5.2</text></g><line x1="46" y1="96.8" x2="48" y2="96.8" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="79.49" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">5.4</text></g><line x1="46" y1="75.1" x2="48" y2="75.1" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="57.79" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">5.6</text></g><line x1="46" y1="53.4" x2="48" y2="53.4" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="36.09" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">5.8</text></g><line x1="46" y1="31.7" x2="48" y2="31.7" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="14.39" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">6.0</text></g><line x1="46" y1="10" x2="48" y2="10" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="52" y1="10" x2="52" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="270" y1="10" x2="270" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="227" x2="488" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="205.3" x2="488" y2="205.3" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="183.6" x2="488" y2="183.6" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="161.9" x2="488" y2="161.9" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="140.2" x2="488" y2="140.2" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="118.5" x2="488" y2="118.5" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="96.8" x2="488" y2="96.8" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="75.1" x2="488" y2="75.1" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="53.4" x2="488" y2="53.4" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="31.7" x2="488" y2="31.7" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="10" x2="488" y2="10" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><g style="fill: rgb(255,0,0); fill-opacity: 1.0; stroke: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"><path d="M 272 118.5 C 272 119.6 271.1 120.5 270 120.5 C 268.9 120.5 268 119.6 268 118.5 C 268 117.4 268.9 116.5 270 116.5 C 271.1 116.5 272 117.4 272 118.5 Z "/></g><g style="stroke-width: 1.0;stroke: rgb(255,0,0);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:geometricPrecision;; fill: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"><path d="M 272 118.5 C 272 119.6 271.1 120.5 270 120.5 C 268.9 120.5 268 119.6 268 118.5 C 268 117.4 268.9 116.5 270 116.5 C 271.1 116.5 272 117.4 272 118.5 Z "/></g><rect x="52" y="10" width="436" height="217" style="stroke-width: 0.5;stroke: rgb(0,0,0);stroke-opacity: 1.0;stroke-linecap: round;stroke-linejoin: round;shape-rendering:crispEdges;; fill: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/></svg></td>
+                    </tr>
+              </tbody>
+            </table>
+          </details>
+          <details class="place-series-details">
+            <summary class="place-series-summary"><a name="places--zip/93212" href="#places--zip/93212">93212 (zip/93212)</a></summary>
+            <a href="https://datacommons.org/browser/zip/93212" target="_blank">Open this place (zip/93212) in Data Commons browser.</a>
+            <table id="sampleplaces-table--4" class="datatables-table hover order-column" width="95%">
+              <thead>
+                <tr>
+                  <th>StatVar</th>
+                  <th>Num Observations</th>
+                  <th>Dates</th>
+                  <th>Corresponding Values</th>
+                  <th>Measurement Method</th>
+                  <th>Unit</th>
+                  <th>Scaling Factor</th>
+                  <th>Observation Period</th>
+                  <th>Time Series Chart</th>
+                </tr>
+              </thead>
+              <tbody>
+                    <tr>
+                      <td><a href="#places--zip/93212--SV1" name="places--zip/93212--SV1">SV1</a></td>
+                      <td>1</td>
+                      <td>2019</td>
+                      <td>1</td>
+                      <td>
+                        <div>SVTest</div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+<defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
+<clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
+</defs>
+<rect x="0" y="0" width="500" height="250" style="fill: rgb(255,255,255); fill-opacity: 1.0" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><rect x="52" y="10" width="436" height="217" style="fill: rgb(255,255,255); fill-opacity: 1.0" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="52" y1="231" x2="488" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="21" y="245.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">2018-12-31</text></g><line x1="52" y1="233" x2="52" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="239" y="245.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">2019-01-01</text></g><line x1="270" y1="233" x2="270" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="48" y1="10" x2="48" y2="227" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="231.39" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.0</text></g><line x1="46" y1="227" x2="48" y2="227" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="209.69" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.2</text></g><line x1="46" y1="205.3" x2="48" y2="205.3" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="187.99" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.4</text></g><line x1="46" y1="183.6" x2="48" y2="183.6" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="166.29" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.6</text></g><line x1="46" y1="161.9" x2="48" y2="161.9" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="144.59" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.8</text></g><line x1="46" y1="140.2" x2="48" y2="140.2" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="122.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.0</text></g><line x1="46" y1="118.5" x2="48" y2="118.5" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="101.19" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.2</text></g><line x1="46" y1="96.8" x2="48" y2="96.8" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="79.49" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.4</text></g><line x1="46" y1="75.1" x2="48" y2="75.1" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="57.79" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.6</text></g><line x1="46" y1="53.4" x2="48" y2="53.4" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="36.09" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.8</text></g><line x1="46" y1="31.7" x2="48" y2="31.7" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="14.39" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">2.0</text></g><line x1="46" y1="10" x2="48" y2="10" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="52" y1="10" x2="52" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="270" y1="10" x2="270" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="227" x2="488" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="205.3" x2="488" y2="205.3" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="183.6" x2="488" y2="183.6" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="161.9" x2="488" y2="161.9" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="140.2" x2="488" y2="140.2" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="118.5" x2="488" y2="118.5" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="96.8" x2="488" y2="96.8" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="75.1" x2="488" y2="75.1" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="53.4" x2="488" y2="53.4" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="31.7" x2="488" y2="31.7" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="10" x2="488" y2="10" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><g style="fill: rgb(255,0,0); fill-opacity: 1.0; stroke: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"><path d="M 272 118.5 C 272 119.6 271.1 120.5 270 120.5 C 268.9 120.5 268 119.6 268 118.5 C 268 117.4 268.9 116.5 270 116.5 C 271.1 116.5 272 117.4 272 118.5 Z "/></g><g style="stroke-width: 1.0;stroke: rgb(255,0,0);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:geometricPrecision;; fill: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"><path d="M 272 118.5 C 272 119.6 271.1 120.5 270 120.5 C 268.9 120.5 268 119.6 268 118.5 C 268 117.4 268.9 116.5 270 116.5 C 271.1 116.5 272 117.4 272 118.5 Z "/></g><rect x="52" y="10" width="436" height="217" style="stroke-width: 0.5;stroke: rgb(0,0,0);stroke-opacity: 1.0;stroke-linecap: round;stroke-linejoin: round;shape-rendering:crispEdges;; fill: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/></svg></td>
+                    </tr>
+              </tbody>
+            </table>
+          </details>
+          <details class="place-series-details">
+            <summary class="place-series-summary"><a name="places--zip/94103" href="#places--zip/94103">94103 (zip/94103)</a></summary>
+            <a href="https://datacommons.org/browser/zip/94103" target="_blank">Open this place (zip/94103) in Data Commons browser.</a>
+            <table id="sampleplaces-table--5" class="datatables-table hover order-column" width="95%">
+              <thead>
+                <tr>
+                  <th>StatVar</th>
+                  <th>Num Observations</th>
+                  <th>Dates</th>
+                  <th>Corresponding Values</th>
+                  <th>Measurement Method</th>
+                  <th>Unit</th>
+                  <th>Scaling Factor</th>
+                  <th>Observation Period</th>
+                  <th>Time Series Chart</th>
+                </tr>
+              </thead>
+              <tbody>
+                    <tr>
+                      <td><a href="#places--zip/94103--SV1" name="places--zip/94103--SV1">SV1</a></td>
+                      <td>1</td>
+                      <td>2019</td>
+                      <td>1</td>
+                      <td>
+                        <div>SVTest</div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td>
+                        <div></div>
+                      </td>
+                      <td style="max-width:none;text-align: -webkit-center;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:jfreesvg="http://www.jfree.org/jfreesvg/svg" width="500" height="250" text-rendering="auto" shape-rendering="auto">
+<defs><clipPath id="testclip-0"><path d="M 0 0 L 500 0 L 500 250 L 0 250 L 0 0 Z "/></clipPath>
+<clipPath id="testclip-1"><path d="M 52 10 L 52 227 L 488 227 L 488 10 Z "/></clipPath>
+</defs>
+<rect x="0" y="0" width="500" height="250" style="fill: rgb(255,255,255); fill-opacity: 1.0" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><rect x="52" y="10" width="436" height="217" style="fill: rgb(255,255,255); fill-opacity: 1.0" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="52" y1="231" x2="488" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="21" y="245.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">2018-12-31</text></g><line x1="52" y1="233" x2="52" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="239" y="245.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">2019-01-01</text></g><line x1="270" y1="233" x2="270" y2="231" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="48" y1="10" x2="48" y2="227" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="231.39" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.0</text></g><line x1="46" y1="227" x2="48" y2="227" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="209.69" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.2</text></g><line x1="46" y1="205.3" x2="48" y2="205.3" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="187.99" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.4</text></g><line x1="46" y1="183.6" x2="48" y2="183.6" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="166.29" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.6</text></g><line x1="46" y1="161.9" x2="48" y2="161.9" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="144.59" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">0.8</text></g><line x1="46" y1="140.2" x2="48" y2="140.2" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="122.89" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.0</text></g><line x1="46" y1="118.5" x2="48" y2="118.5" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="101.19" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.2</text></g><line x1="46" y1="96.8" x2="48" y2="96.8" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="79.49" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.4</text></g><line x1="46" y1="75.1" x2="48" y2="75.1" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="57.79" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.6</text></g><line x1="46" y1="53.4" x2="48" y2="53.4" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="36.09" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">1.8</text></g><line x1="46" y1="31.7" x2="48" y2="31.7" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><g transform="matrix(1,0,0,1,0,0)"><text x="26" y="14.39" style="fill: rgb(64,64,64); fill-opacity: 1.0; font-family: sans-serif; font-size: 10px;" clip-path="url(#testclip-0)">2.0</text></g><line x1="46" y1="10" x2="48" y2="10" style="stroke-width: 0.5;stroke: rgb(128,128,128);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/><line x1="52" y1="10" x2="52" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="270" y1="10" x2="270" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="227" x2="488" y2="227" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="205.3" x2="488" y2="205.3" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="183.6" x2="488" y2="183.6" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="161.9" x2="488" y2="161.9" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="140.2" x2="488" y2="140.2" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="118.5" x2="488" y2="118.5" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="96.8" x2="488" y2="96.8" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="75.1" x2="488" y2="75.1" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="53.4" x2="488" y2="53.4" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="31.7" x2="488" y2="31.7" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><line x1="52" y1="10" x2="488" y2="10" style="stroke-width: 0.5;stroke: rgb(255,255,255);stroke-opacity: 1.0;stroke-linejoin: bevel;stroke-dasharray: 2.0, 2.0;shape-rendering:crispEdges;" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"/><g style="fill: rgb(255,0,0); fill-opacity: 1.0; stroke: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"><path d="M 272 118.5 C 272 119.6 271.1 120.5 270 120.5 C 268.9 120.5 268 119.6 268 118.5 C 268 117.4 268.9 116.5 270 116.5 C 271.1 116.5 272 117.4 272 118.5 Z "/></g><g style="stroke-width: 1.0;stroke: rgb(255,0,0);stroke-opacity: 1.0;stroke-linecap: square;shape-rendering:geometricPrecision;; fill: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-1)"><path d="M 272 118.5 C 272 119.6 271.1 120.5 270 120.5 C 268.9 120.5 268 119.6 268 118.5 C 268 117.4 268.9 116.5 270 116.5 C 271.1 116.5 272 117.4 272 118.5 Z "/></g><rect x="52" y="10" width="436" height="217" style="stroke-width: 0.5;stroke: rgb(0,0,0);stroke-opacity: 1.0;stroke-linecap: round;stroke-linejoin: round;shape-rendering:crispEdges;; fill: none" transform="matrix(1,0,0,1,0,0)" clip-path="url(#testclip-0)"/></svg></td>
+                    </tr>
+              </tbody>
+            </table>
+          </details>
+      </div>
+    <script>
+      function handle_hash_change(){
+        /*
+        When the hash part of the location has changed, open the <detail> tag
+        closest to the anchor that is being linked to.
+        */
+
+        const new_hash = CSS.escape( // we will use the location hash in a CSS selector, so we need to escape it
+          location.hash // get the hash
+          .substring(1) // drop the initial `#` character
+          );
+
+        const anchor_selector = "a[name=" + new_hash +"]";
+        const anchor_element = document.querySelectorAll(anchor_selector)[0];
+        const parent_details_tag = anchor_element.closest("details")
+
+        if (parent_details_tag !== null){ // if tag exists
+          parent_details_tag.open = true; // open it.
+        }
+      }
+
+      window.onhashchange = handle_hash_change; // dynamically react to hash changes
+      document.addEventListener('DOMContentLoaded', handle_hash_change, false); // if page loaded with a location hash, also react to that.
+    </script>
+  </body>
+  <script>
+    function make_table_DataTable(id){
+      // given a CSS selector for a <table> element, adds DataTable to it
+      // with only sorting enabled, and with no default order column.
+      
+      $(id).DataTable({
+        paging: false,
+        searching: false,
+        info: false,
+        order: [] // don't apply initial ordering (which is turned on by default)
+      });
+
+      // DataTables seem to add a class "no-footer" to the tables managed by it,
+      // which has no behavior effects but adds a weird 1px gray bottom-border,
+      // so we remove that class after initializing the table as a DataTable.
+      // reference for another post mentioning this issue:
+      // https://datatables.net/forums/discussion/53837/class-no-footer-applied-to-table-despite-a-footer-is-present
+      $(id).removeClass("no-footer");
+    }
+
+    // Set the "open" attribute of all 'details' tags to `new_value`.
+    // `new_value` should be boolean; true for open, false for close.
+    function set_all_details(new_value){
+      const tags = document.querySelectorAll('details');
+      tags.forEach(tag=>{
+          tag.open = new_value
+        });
+    }
+
+    function close_all_details(tags){
+      set_all_details(false)
+    }
+    function open_all_details(tags){
+      set_all_details(true)
+    }
+
+    $(document).ready(function () {
+      const sampleplace_table_ids = [
+          "#sampleplaces-table--1",
+          "#sampleplaces-table--2",
+          "#sampleplaces-table--3",
+          "#sampleplaces-table--4",
+          "#sampleplaces-table--5",
+      ]
+
+      make_table_DataTable("#statvars-table");
+      sampleplace_table_ids.forEach(( id ) => {
+        make_table_DataTable(id)
+      })
+    });
+
+  </script>
+</html>

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/latlngresolution/output/table_mcf_nodes_LatLng.mcf
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/latlngresolution/output/table_mcf_nodes_LatLng.mcf
@@ -1,0 +1,85 @@
+Node: SVTest/E3/1
+latitude: 53
+name: "British–Columbia"
+typeOf: dcid:Place
+longitude: -127
+dcid: "country/CAN"
+
+Node: SVTest/E0/1
+observationDate: 2019
+observationAbout: dcid:country/CAN
+variableMeasured: dcid:SV1
+measurementMethod: dcid:SVTest
+value: 1
+typeOf: dcid:StatVarObservation
+keyString: "observationAbout=country/CANvariableMeasured=SV1observationDate=2019value=1measurementMethod=SVTest"
+dcid: "dc/o/6v44zdhbcq8"
+
+Node: SVTest/E3/2
+latitude: 43
+name: "Saskatchewan"
+typeOf: dcid:Place
+longitude: -116
+dcid: "zip/83624"
+
+Node: SVTest/E0/2
+observationDate: 2019
+observationAbout: dcid:zip/83624
+variableMeasured: dcid:SV1
+measurementMethod: dcid:SVTest
+value: 5
+typeOf: dcid:StatVarObservation
+keyString: "observationAbout=zip/83624variableMeasured=SV1observationDate=2019value=5measurementMethod=SVTest"
+dcid: "dc/o/tjm0x6y8jv26f"
+
+Node: SVTest/E3/3
+latitude: 37.77493
+name: "San Francisco"
+typeOf: dcid:Place
+longitude: -122.41942
+dcid: "zip/94103"
+
+Node: SVTest/E0/3
+observationDate: 2019
+observationAbout: dcid:zip/94103
+variableMeasured: dcid:SV1
+measurementMethod: dcid:SVTest
+value: 1
+typeOf: dcid:StatVarObservation
+keyString: "observationAbout=zip/94103variableMeasured=SV1observationDate=2019value=1measurementMethod=SVTest"
+dcid: "dc/o/1jm50b24f2mg"
+
+Node: SVTest/E3/4
+latitude: 36
+name: "California"
+typeOf: dcid:Place
+longitude: -119.4
+dcid: "zip/93212"
+
+Node: SVTest/E0/4
+observationDate: 2019
+observationAbout: dcid:zip/93212
+variableMeasured: dcid:SV1
+measurementMethod: dcid:SVTest
+value: 1
+typeOf: dcid:StatVarObservation
+keyString: "observationAbout=zip/93212variableMeasured=SV1observationDate=2019value=1measurementMethod=SVTest"
+dcid: "dc/o/0r93tc1txjj1h"
+
+Node: SVTest/E3/5
+latitude: 53.9
+name: "Alberta"
+typeOf: dcid:Place
+longitude: -116
+dcid: "ipcc_50/53.75_-115.75_CAN"
+
+Node: SVTest/E0/5
+observationDate: 2019
+observationAbout: dcid:ipcc_50/53.75_-115.75_CAN
+variableMeasured: dcid:SV1
+measurementMethod: dcid:SVTest
+value: 6
+typeOf: dcid:StatVarObservation
+keyString: "observationAbout=ipcc_50/53.75_-115.75_CANvariableMeasured=SV1observationDate=2019value=6measurementMethod=SVTest"
+dcid: "dc/o/bf7wjkynq5sl"
+

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/report.json
@@ -57,6 +57,7 @@
     "numThreads": 1,
     "statChecks": true,
     "observationAbout": false,
-    "allowNanSvobs": false
+    "allowNanSvobs": false,
+    "coordinatesResolution": false
   }
 }

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/manyinconsistent/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/manyinconsistent/output/report.json
@@ -106,6 +106,7 @@
     "numThreads": 1,
     "statChecks": true,
     "observationAbout": false,
-    "allowNanSvobs": false
+    "allowNanSvobs": false,
+    "coordinatesResolution": false
   }
 }

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/measurementresult/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/measurementresult/output/report.json
@@ -132,6 +132,7 @@
     "numThreads": 1,
     "statChecks": true,
     "observationAbout": false,
-    "allowNanSvobs": true
+    "allowNanSvobs": true,
+    "coordinatesResolution": false
   }
 }

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/report.json
@@ -196,6 +196,7 @@
     "numThreads": 1,
     "statChecks": true,
     "observationAbout": false,
-    "allowNanSvobs": false
+    "allowNanSvobs": false,
+    "coordinatesResolution": false
   }
 }

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/statchecks/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/statchecks/output/report.json
@@ -237,6 +237,7 @@
     "numThreads": 1,
     "statChecks": true,
     "observationAbout": false,
-    "allowNanSvobs": false
+    "allowNanSvobs": false,
+    "coordinatesResolution": false
   }
 }

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/successtmcf/output/report.json
@@ -720,6 +720,7 @@
     "numThreads": 1,
     "statChecks": true,
     "observationAbout": false,
-    "allowNanSvobs": true
+    "allowNanSvobs": true,
+    "coordinatesResolution": false
   }
 }

--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
@@ -935,6 +935,7 @@
     "numThreads": 1,
     "statChecks": true,
     "observationAbout": false,
-    "allowNanSvobs": false
+    "allowNanSvobs": false,
+    "coordinatesResolution": false
   }
 }

--- a/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
@@ -563,6 +563,7 @@
     "numThreads": 1,
     "statChecks": true,
     "observationAbout": false,
-    "allowNanSvobs": false
+    "allowNanSvobs": false,
+    "coordinatesResolution": false
   }
 }

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
@@ -704,6 +704,7 @@
     "numThreads": 1,
     "statChecks": true,
     "observationAbout": false,
-    "allowNanSvobs": false
+    "allowNanSvobs": false,
+    "coordinatesResolution": false
   }
 }

--- a/tool/src/test/resources/org/datacommons/tool/lint/statchecks/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/statchecks/output/report.json
@@ -130,6 +130,7 @@
     "numThreads": 1,
     "statChecks": true,
     "observationAbout": false,
-    "allowNanSvobs": false
+    "allowNanSvobs": false,
+    "coordinatesResolution": false
   }
 }

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -75,6 +75,12 @@
         </dependency>
         <dependency>
             <groupId>com.google.truth.extensions</groupId>
+            <artifactId>truth-java8-extension</artifactId>
+            <version>0.46</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.truth.extensions</groupId>
             <artifactId>truth-proto-extension</artifactId>
             <version>0.46</version>
             <scope>test</scope>

--- a/util/src/main/java/org/datacommons/proto/Debug.java
+++ b/util/src/main/java/org/datacommons/proto/Debug.java
@@ -4476,6 +4476,19 @@ public final class Debug {
      * @return The checkMeasurementResult.
      */
     boolean getCheckMeasurementResult();
+
+    /**
+     * <code>optional bool coordinates_resolution = 9;</code>
+     *
+     * @return Whether the coordinatesResolution field is set.
+     */
+    boolean hasCoordinatesResolution();
+    /**
+     * <code>optional bool coordinates_resolution = 9;</code>
+     *
+     * @return The coordinatesResolution.
+     */
+    boolean getCoordinatesResolution();
   }
   /** Protobuf type {@code org.datacommons.proto.CommandArgs} */
   public static final class CommandArgs extends com.google.protobuf.GeneratedMessageV3
@@ -4581,6 +4594,12 @@ public final class Debug {
               {
                 bitField0_ |= 0x00000040;
                 checkMeasurementResult_ = input.readBool();
+                break;
+              }
+            case 72:
+              {
+                bitField0_ |= 0x00000080;
+                coordinatesResolution_ = input.readBool();
                 break;
               }
             default:
@@ -4967,6 +4986,25 @@ public final class Debug {
       return checkMeasurementResult_;
     }
 
+    public static final int COORDINATES_RESOLUTION_FIELD_NUMBER = 9;
+    private boolean coordinatesResolution_;
+    /**
+     * <code>optional bool coordinates_resolution = 9;</code>
+     *
+     * @return Whether the coordinatesResolution field is set.
+     */
+    public boolean hasCoordinatesResolution() {
+      return ((bitField0_ & 0x00000080) != 0);
+    }
+    /**
+     * <code>optional bool coordinates_resolution = 9;</code>
+     *
+     * @return The coordinatesResolution.
+     */
+    public boolean getCoordinatesResolution() {
+      return coordinatesResolution_;
+    }
+
     private byte memoizedIsInitialized = -1;
 
     @java.lang.Override
@@ -5005,6 +5043,9 @@ public final class Debug {
       if (((bitField0_ & 0x00000040) != 0)) {
         output.writeBool(8, checkMeasurementResult_);
       }
+      if (((bitField0_ & 0x00000080) != 0)) {
+        output.writeBool(9, coordinatesResolution_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -5042,6 +5083,9 @@ public final class Debug {
       }
       if (((bitField0_ & 0x00000040) != 0)) {
         size += com.google.protobuf.CodedOutputStream.computeBoolSize(8, checkMeasurementResult_);
+      }
+      if (((bitField0_ & 0x00000080) != 0)) {
+        size += com.google.protobuf.CodedOutputStream.computeBoolSize(9, coordinatesResolution_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -5087,6 +5131,10 @@ public final class Debug {
       if (hasCheckMeasurementResult()) {
         if (getCheckMeasurementResult() != other.getCheckMeasurementResult()) return false;
       }
+      if (hasCoordinatesResolution() != other.hasCoordinatesResolution()) return false;
+      if (hasCoordinatesResolution()) {
+        if (getCoordinatesResolution() != other.getCoordinatesResolution()) return false;
+      }
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -5129,6 +5177,10 @@ public final class Debug {
       if (hasCheckMeasurementResult()) {
         hash = (37 * hash) + CHECK_MEASUREMENT_RESULT_FIELD_NUMBER;
         hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(getCheckMeasurementResult());
+      }
+      if (hasCoordinatesResolution()) {
+        hash = (37 * hash) + COORDINATES_RESOLUTION_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(getCoordinatesResolution());
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -5285,6 +5337,8 @@ public final class Debug {
         bitField0_ = (bitField0_ & ~0x00000040);
         checkMeasurementResult_ = false;
         bitField0_ = (bitField0_ & ~0x00000080);
+        coordinatesResolution_ = false;
+        bitField0_ = (bitField0_ & ~0x00000100);
         return this;
       }
 
@@ -5346,6 +5400,10 @@ public final class Debug {
         if (((from_bitField0_ & 0x00000080) != 0)) {
           result.checkMeasurementResult_ = checkMeasurementResult_;
           to_bitField0_ |= 0x00000040;
+        }
+        if (((from_bitField0_ & 0x00000100) != 0)) {
+          result.coordinatesResolution_ = coordinatesResolution_;
+          to_bitField0_ |= 0x00000080;
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -5429,6 +5487,9 @@ public final class Debug {
         }
         if (other.hasCheckMeasurementResult()) {
           setCheckMeasurementResult(other.getCheckMeasurementResult());
+        }
+        if (other.hasCoordinatesResolution()) {
+          setCoordinatesResolution(other.getCoordinatesResolution());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -5913,6 +5974,47 @@ public final class Debug {
       public Builder clearCheckMeasurementResult() {
         bitField0_ = (bitField0_ & ~0x00000080);
         checkMeasurementResult_ = false;
+        onChanged();
+        return this;
+      }
+
+      private boolean coordinatesResolution_;
+      /**
+       * <code>optional bool coordinates_resolution = 9;</code>
+       *
+       * @return Whether the coordinatesResolution field is set.
+       */
+      public boolean hasCoordinatesResolution() {
+        return ((bitField0_ & 0x00000100) != 0);
+      }
+      /**
+       * <code>optional bool coordinates_resolution = 9;</code>
+       *
+       * @return The coordinatesResolution.
+       */
+      public boolean getCoordinatesResolution() {
+        return coordinatesResolution_;
+      }
+      /**
+       * <code>optional bool coordinates_resolution = 9;</code>
+       *
+       * @param value The coordinatesResolution to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCoordinatesResolution(boolean value) {
+        bitField0_ |= 0x00000100;
+        coordinatesResolution_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool coordinates_resolution = 9;</code>
+       *
+       * @return This builder for chaining.
+       */
+      public Builder clearCoordinatesResolution() {
+        bitField0_ = (bitField0_ & ~0x00000100);
+        coordinatesResolution_ = false;
         onChanged();
         return this;
       }
@@ -12295,33 +12397,34 @@ public final class Debug {
           + " \001(\0132%.org.datacommons.proto.Log.Counter"
           + "Set:\0028\001\"c\n\005Level\022\025\n\021LEVEL_UNSPECIFIED\020\000\022"
           + "\016\n\nLEVEL_INFO\020\001\022\021\n\rLEVEL_WARNING\020\002\022\017\n\013LE"
-          + "VEL_ERROR\020\003\022\017\n\013LEVEL_FATAL\020\004J\004\010\002\020\003\"\210\003\n\013C"
+          + "VEL_ERROR\020\003\022\017\n\013LEVEL_FATAL\020\004J\004\010\002\020\003\"\250\003\n\013C"
           + "ommandArgs\022\030\n\020existence_checks\030\001 \001(\010\022E\n\n"
           + "resolution\030\002 \001(\01621.org.datacommons.proto"
           + ".CommandArgs.ResolutionMode\022\023\n\013num_threa"
           + "ds\030\003 \001(\005\022\023\n\013stat_checks\030\004 \001(\010\022\025\n\rsample_"
           + "places\030\005 \003(\t\022\031\n\021observation_about\030\006 \001(\010\022"
           + "\027\n\017allow_nan_svobs\030\007 \001(\010\022 \n\030check_measur"
-          + "ement_result\030\010 \001(\010\"\200\001\n\016ResolutionMode\022\037\n"
-          + "\033RESOLUTION_MODE_UNSPECIFIED\020\000\022\030\n\024RESOLU"
-          + "TION_MODE_NONE\020\001\022\031\n\025RESOLUTION_MODE_LOCA"
-          + "L\020\002\022\030\n\024RESOLUTION_MODE_FULL\020\003\"\321\001\n\tDataPo"
-          + "int\022\014\n\004date\030\001 \001(\t\022:\n\006values\030\002 \003(\0132*.org."
-          + "datacommons.proto.DataPoint.DataValue\032z\n"
-          + "\tDataValue\0229\n\005value\030\001 \001(\0132*.org.datacomm"
-          + "ons.proto.McfGraph.TypedValue\0222\n\tlocatio"
-          + "ns\030\002 \003(\0132\037.org.datacommons.proto.Locatio"
-          + "n\"\234\003\n\024StatValidationResult\022\022\n\nplace_dcid"
-          + "\030\001 \001(\t\022\025\n\rstat_var_dcid\030\002 \001(\t\022\032\n\022measure"
-          + "ment_method\030\003 \001(\t\022\032\n\022observation_period\030"
-          + "\004 \001(\t\022\026\n\016scaling_factor\030\005 \001(\t\022\014\n\004unit\030\006 "
-          + "\001(\t\022\\\n\023validation_counters\030\007 \003(\0132?.org.d"
-          + "atacommons.proto.StatValidationResult.St"
-          + "atValidationEntry\032\234\001\n\023StatValidationEntr"
-          + "y\022\023\n\013counter_key\030\001 \001(\t\0228\n\016problem_points"
-          + "\030\002 \003(\0132 .org.datacommons.proto.DataPoint"
-          + "\022\032\n\022additional_details\030\003 \001(\t\022\032\n\022percent_"
-          + "difference\030\004 \001(\001"
+          + "ement_result\030\010 \001(\010\022\036\n\026coordinates_resolu"
+          + "tion\030\t \001(\010\"\200\001\n\016ResolutionMode\022\037\n\033RESOLUT"
+          + "ION_MODE_UNSPECIFIED\020\000\022\030\n\024RESOLUTION_MOD"
+          + "E_NONE\020\001\022\031\n\025RESOLUTION_MODE_LOCAL\020\002\022\030\n\024R"
+          + "ESOLUTION_MODE_FULL\020\003\"\321\001\n\tDataPoint\022\014\n\004d"
+          + "ate\030\001 \001(\t\022:\n\006values\030\002 \003(\0132*.org.datacomm"
+          + "ons.proto.DataPoint.DataValue\032z\n\tDataVal"
+          + "ue\0229\n\005value\030\001 \001(\0132*.org.datacommons.prot"
+          + "o.McfGraph.TypedValue\0222\n\tlocations\030\002 \003(\013"
+          + "2\037.org.datacommons.proto.Location\"\234\003\n\024St"
+          + "atValidationResult\022\022\n\nplace_dcid\030\001 \001(\t\022\025"
+          + "\n\rstat_var_dcid\030\002 \001(\t\022\032\n\022measurement_met"
+          + "hod\030\003 \001(\t\022\032\n\022observation_period\030\004 \001(\t\022\026\n"
+          + "\016scaling_factor\030\005 \001(\t\022\014\n\004unit\030\006 \001(\t\022\\\n\023v"
+          + "alidation_counters\030\007 \003(\0132?.org.datacommo"
+          + "ns.proto.StatValidationResult.StatValida"
+          + "tionEntry\032\234\001\n\023StatValidationEntry\022\023\n\013cou"
+          + "nter_key\030\001 \001(\t\0228\n\016problem_points\030\002 \003(\0132 "
+          + ".org.datacommons.proto.DataPoint\022\032\n\022addi"
+          + "tional_details\030\003 \001(\t\022\032\n\022percent_differen"
+          + "ce\030\004 \001(\001"
     };
     descriptor =
         com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
@@ -12383,6 +12486,7 @@ public final class Debug {
               "ObservationAbout",
               "AllowNanSvobs",
               "CheckMeasurementResult",
+              "CoordinatesResolution",
             });
     internal_static_org_datacommons_proto_DataPoint_descriptor =
         getDescriptor().getMessageTypes().get(2);

--- a/util/src/main/java/org/datacommons/proto/Recon.java
+++ b/util/src/main/java/org/datacommons/proto/Recon.java
@@ -11439,6 +11439,743 @@ public final class Recon {
               org.datacommons.proto.Recon.ResolveCoordinatesResponse.Builder.class);
     }
 
+    public interface PlaceOrBuilder
+        extends
+        // @@protoc_insertion_point(interface_extends:org.datacommons.proto.ResolveCoordinatesResponse.Place)
+        com.google.protobuf.MessageOrBuilder {
+
+      /**
+       * <code>string dcid = 1;</code>
+       *
+       * @return The dcid.
+       */
+      java.lang.String getDcid();
+      /**
+       * <code>string dcid = 1;</code>
+       *
+       * @return The bytes for dcid.
+       */
+      com.google.protobuf.ByteString getDcidBytes();
+
+      /**
+       * <code>string dominant_type = 2;</code>
+       *
+       * @return The dominantType.
+       */
+      java.lang.String getDominantType();
+      /**
+       * <code>string dominant_type = 2;</code>
+       *
+       * @return The bytes for dominantType.
+       */
+      com.google.protobuf.ByteString getDominantTypeBytes();
+    }
+    /** Protobuf type {@code org.datacommons.proto.ResolveCoordinatesResponse.Place} */
+    public static final class Place extends com.google.protobuf.GeneratedMessageV3
+        implements
+        // @@protoc_insertion_point(message_implements:org.datacommons.proto.ResolveCoordinatesResponse.Place)
+        PlaceOrBuilder {
+      private static final long serialVersionUID = 0L;
+      // Use Place.newBuilder() to construct.
+      private Place(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+        super(builder);
+      }
+
+      private Place() {
+        dcid_ = "";
+        dominantType_ = "";
+      }
+
+      @java.lang.Override
+      @SuppressWarnings({"unused"})
+      protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
+        return new Place();
+      }
+
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
+        return this.unknownFields;
+      }
+
+      private Place(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10:
+                {
+                  java.lang.String s = input.readStringRequireUtf8();
+
+                  dcid_ = s;
+                  break;
+                }
+              case 18:
+                {
+                  java.lang.String s = input.readStringRequireUtf8();
+
+                  dominantType_ = s;
+                  break;
+                }
+              default:
+                {
+                  if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                    done = true;
+                  }
+                  break;
+                }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(this);
+        } finally {
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+
+      public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+        return org.datacommons.proto.Recon
+            .internal_static_org_datacommons_proto_ResolveCoordinatesResponse_Place_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.datacommons.proto.Recon
+            .internal_static_org_datacommons_proto_ResolveCoordinatesResponse_Place_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.class,
+                org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.Builder.class);
+      }
+
+      public static final int DCID_FIELD_NUMBER = 1;
+      private volatile java.lang.Object dcid_;
+      /**
+       * <code>string dcid = 1;</code>
+       *
+       * @return The dcid.
+       */
+      public java.lang.String getDcid() {
+        java.lang.Object ref = dcid_;
+        if (ref instanceof java.lang.String) {
+          return (java.lang.String) ref;
+        } else {
+          com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          dcid_ = s;
+          return s;
+        }
+      }
+      /**
+       * <code>string dcid = 1;</code>
+       *
+       * @return The bytes for dcid.
+       */
+      public com.google.protobuf.ByteString getDcidBytes() {
+        java.lang.Object ref = dcid_;
+        if (ref instanceof java.lang.String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          dcid_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+
+      public static final int DOMINANT_TYPE_FIELD_NUMBER = 2;
+      private volatile java.lang.Object dominantType_;
+      /**
+       * <code>string dominant_type = 2;</code>
+       *
+       * @return The dominantType.
+       */
+      public java.lang.String getDominantType() {
+        java.lang.Object ref = dominantType_;
+        if (ref instanceof java.lang.String) {
+          return (java.lang.String) ref;
+        } else {
+          com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          dominantType_ = s;
+          return s;
+        }
+      }
+      /**
+       * <code>string dominant_type = 2;</code>
+       *
+       * @return The bytes for dominantType.
+       */
+      public com.google.protobuf.ByteString getDominantTypeBytes() {
+        java.lang.Object ref = dominantType_;
+        if (ref instanceof java.lang.String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          dominantType_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+
+      private byte memoizedIsInitialized = -1;
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      @java.lang.Override
+      public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
+        if (!getDcidBytes().isEmpty()) {
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 1, dcid_);
+        }
+        if (!getDominantTypeBytes().isEmpty()) {
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 2, dominantType_);
+        }
+        unknownFields.writeTo(output);
+      }
+
+      @java.lang.Override
+      public int getSerializedSize() {
+        int size = memoizedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        if (!getDcidBytes().isEmpty()) {
+          size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, dcid_);
+        }
+        if (!getDominantTypeBytes().isEmpty()) {
+          size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, dominantType_);
+        }
+        size += unknownFields.getSerializedSize();
+        memoizedSize = size;
+        return size;
+      }
+
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+          return true;
+        }
+        if (!(obj instanceof org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place)) {
+          return super.equals(obj);
+        }
+        org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place other =
+            (org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place) obj;
+
+        if (!getDcid().equals(other.getDcid())) return false;
+        if (!getDominantType().equals(other.getDominantType())) return false;
+        if (!unknownFields.equals(other.unknownFields)) return false;
+        return true;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptor().hashCode();
+        hash = (37 * hash) + DCID_FIELD_NUMBER;
+        hash = (53 * hash) + getDcid().hashCode();
+        hash = (37 * hash) + DOMINANT_TYPE_FIELD_NUMBER;
+        hash = (53 * hash) + getDominantType().hashCode();
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
+      public static org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place parseFrom(
+          java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+
+      public static org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place parseFrom(
+          java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+
+      public static org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+
+      public static org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+
+      public static org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place parseFrom(
+          byte[] data) throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+
+      public static org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place parseFrom(
+          byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+
+      public static org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place parseFrom(
+          java.io.InputStream input) throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
+      }
+
+      public static org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place parseFrom(
+          java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+            PARSER, input, extensionRegistry);
+      }
+
+      public static org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place parseDelimitedFrom(
+          java.io.InputStream input) throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
+      }
+
+      public static org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place parseDelimitedFrom(
+          java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+            PARSER, input, extensionRegistry);
+      }
+
+      public static org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place parseFrom(
+          com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
+      }
+
+      public static org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+            PARSER, input, extensionRegistry);
+      }
+
+      @java.lang.Override
+      public Builder newBuilderForType() {
+        return newBuilder();
+      }
+
+      public static Builder newBuilder() {
+        return DEFAULT_INSTANCE.toBuilder();
+      }
+
+      public static Builder newBuilder(
+          org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place prototype) {
+        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+      }
+
+      @java.lang.Override
+      public Builder toBuilder() {
+        return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+      }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /** Protobuf type {@code org.datacommons.proto.ResolveCoordinatesResponse.Place} */
+      public static final class Builder
+          extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+          implements
+          // @@protoc_insertion_point(builder_implements:org.datacommons.proto.ResolveCoordinatesResponse.Place)
+          org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+          return org.datacommons.proto.Recon
+              .internal_static_org_datacommons_proto_ResolveCoordinatesResponse_Place_descriptor;
+        }
+
+        @java.lang.Override
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return org.datacommons.proto.Recon
+              .internal_static_org_datacommons_proto_ResolveCoordinatesResponse_Place_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.class,
+                  org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.Builder.class);
+        }
+
+        // Construct using org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
+        }
+
+        @java.lang.Override
+        public Builder clear() {
+          super.clear();
+          dcid_ = "";
+
+          dominantType_ = "";
+
+          return this;
+        }
+
+        @java.lang.Override
+        public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+          return org.datacommons.proto.Recon
+              .internal_static_org_datacommons_proto_ResolveCoordinatesResponse_Place_descriptor;
+        }
+
+        @java.lang.Override
+        public org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place
+            getDefaultInstanceForType() {
+          return org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.getDefaultInstance();
+        }
+
+        @java.lang.Override
+        public org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place build() {
+          org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        @java.lang.Override
+        public org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place buildPartial() {
+          org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place result =
+              new org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place(this);
+          result.dcid_ = dcid_;
+          result.dominantType_ = dominantType_;
+          onBuilt();
+          return result;
+        }
+
+        @java.lang.Override
+        public Builder clone() {
+          return super.clone();
+        }
+
+        @java.lang.Override
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
+          return super.setField(field, value);
+        }
+
+        @java.lang.Override
+        public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return super.clearField(field);
+        }
+
+        @java.lang.Override
+        public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return super.clearOneof(oneof);
+        }
+
+        @java.lang.Override
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index,
+            java.lang.Object value) {
+          return super.setRepeatedField(field, index, value);
+        }
+
+        @java.lang.Override
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
+          return super.addRepeatedField(field, value);
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place) {
+            return mergeFrom((org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place) other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(
+            org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place other) {
+          if (other
+              == org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.getDefaultInstance())
+            return this;
+          if (!other.getDcid().isEmpty()) {
+            dcid_ = other.dcid_;
+            onChanged();
+          }
+          if (!other.getDominantType().isEmpty()) {
+            dominantType_ = other.dominantType_;
+            onChanged();
+          }
+          this.mergeUnknownFields(other.unknownFields);
+          onChanged();
+          return this;
+        }
+
+        @java.lang.Override
+        public final boolean isInitialized() {
+          return true;
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage =
+                (org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place)
+                    e.getUnfinishedMessage();
+            throw e.unwrapIOException();
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+
+        private java.lang.Object dcid_ = "";
+        /**
+         * <code>string dcid = 1;</code>
+         *
+         * @return The dcid.
+         */
+        public java.lang.String getDcid() {
+          java.lang.Object ref = dcid_;
+          if (!(ref instanceof java.lang.String)) {
+            com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            dcid_ = s;
+            return s;
+          } else {
+            return (java.lang.String) ref;
+          }
+        }
+        /**
+         * <code>string dcid = 1;</code>
+         *
+         * @return The bytes for dcid.
+         */
+        public com.google.protobuf.ByteString getDcidBytes() {
+          java.lang.Object ref = dcid_;
+          if (ref instanceof String) {
+            com.google.protobuf.ByteString b =
+                com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+            dcid_ = b;
+            return b;
+          } else {
+            return (com.google.protobuf.ByteString) ref;
+          }
+        }
+        /**
+         * <code>string dcid = 1;</code>
+         *
+         * @param value The dcid to set.
+         * @return This builder for chaining.
+         */
+        public Builder setDcid(java.lang.String value) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+
+          dcid_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>string dcid = 1;</code>
+         *
+         * @return This builder for chaining.
+         */
+        public Builder clearDcid() {
+
+          dcid_ = getDefaultInstance().getDcid();
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>string dcid = 1;</code>
+         *
+         * @param value The bytes for dcid to set.
+         * @return This builder for chaining.
+         */
+        public Builder setDcidBytes(com.google.protobuf.ByteString value) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          checkByteStringIsUtf8(value);
+
+          dcid_ = value;
+          onChanged();
+          return this;
+        }
+
+        private java.lang.Object dominantType_ = "";
+        /**
+         * <code>string dominant_type = 2;</code>
+         *
+         * @return The dominantType.
+         */
+        public java.lang.String getDominantType() {
+          java.lang.Object ref = dominantType_;
+          if (!(ref instanceof java.lang.String)) {
+            com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            dominantType_ = s;
+            return s;
+          } else {
+            return (java.lang.String) ref;
+          }
+        }
+        /**
+         * <code>string dominant_type = 2;</code>
+         *
+         * @return The bytes for dominantType.
+         */
+        public com.google.protobuf.ByteString getDominantTypeBytes() {
+          java.lang.Object ref = dominantType_;
+          if (ref instanceof String) {
+            com.google.protobuf.ByteString b =
+                com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+            dominantType_ = b;
+            return b;
+          } else {
+            return (com.google.protobuf.ByteString) ref;
+          }
+        }
+        /**
+         * <code>string dominant_type = 2;</code>
+         *
+         * @param value The dominantType to set.
+         * @return This builder for chaining.
+         */
+        public Builder setDominantType(java.lang.String value) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+
+          dominantType_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>string dominant_type = 2;</code>
+         *
+         * @return This builder for chaining.
+         */
+        public Builder clearDominantType() {
+
+          dominantType_ = getDefaultInstance().getDominantType();
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>string dominant_type = 2;</code>
+         *
+         * @param value The bytes for dominantType to set.
+         * @return This builder for chaining.
+         */
+        public Builder setDominantTypeBytes(com.google.protobuf.ByteString value) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          checkByteStringIsUtf8(value);
+
+          dominantType_ = value;
+          onChanged();
+          return this;
+        }
+
+        @java.lang.Override
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFields(unknownFields);
+        }
+
+        @java.lang.Override
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
+        // @@protoc_insertion_point(builder_scope:org.datacommons.proto.ResolveCoordinatesResponse.Place)
+      }
+
+      // @@protoc_insertion_point(class_scope:org.datacommons.proto.ResolveCoordinatesResponse.Place)
+      private static final org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place
+          DEFAULT_INSTANCE;
+
+      static {
+        DEFAULT_INSTANCE = new org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place();
+      }
+
+      public static org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place
+          getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+      }
+
+      private static final com.google.protobuf.Parser<Place> PARSER =
+          new com.google.protobuf.AbstractParser<Place>() {
+            @java.lang.Override
+            public Place parsePartialFrom(
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+              return new Place(input, extensionRegistry);
+            }
+          };
+
+      public static com.google.protobuf.Parser<Place> parser() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<Place> getParserForType() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place
+          getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+      }
+    }
+
     public interface PlaceCoordinateOrBuilder
         extends
         // @@protoc_insertion_point(interface_extends:org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate)
@@ -11484,6 +12221,30 @@ public final class Recon {
        * @return The bytes of the placeDcids at the given index.
        */
       com.google.protobuf.ByteString getPlaceDcidsBytes(int index);
+
+      /**
+       * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+       */
+      java.util.List<org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place> getPlacesList();
+      /**
+       * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+       */
+      org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place getPlaces(int index);
+      /**
+       * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+       */
+      int getPlacesCount();
+      /**
+       * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+       */
+      java.util.List<
+              ? extends org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceOrBuilder>
+          getPlacesOrBuilderList();
+      /**
+       * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+       */
+      org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceOrBuilder getPlacesOrBuilder(
+          int index);
     }
     /** Protobuf type {@code org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate} */
     public static final class PlaceCoordinate extends com.google.protobuf.GeneratedMessageV3
@@ -11498,6 +12259,7 @@ public final class Recon {
 
       private PlaceCoordinate() {
         placeDcids_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        places_ = java.util.Collections.emptyList();
       }
 
       @java.lang.Override
@@ -11550,6 +12312,20 @@ public final class Recon {
                   placeDcids_.add(s);
                   break;
                 }
+              case 34:
+                {
+                  if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+                    places_ =
+                        new java.util.ArrayList<
+                            org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place>();
+                    mutable_bitField0_ |= 0x00000002;
+                  }
+                  places_.add(
+                      input.readMessage(
+                          org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.parser(),
+                          extensionRegistry));
+                  break;
+                }
               default:
                 {
                   if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
@@ -11567,6 +12343,9 @@ public final class Recon {
         } finally {
           if (((mutable_bitField0_ & 0x00000001) != 0)) {
             placeDcids_ = placeDcids_.getUnmodifiableView();
+          }
+          if (((mutable_bitField0_ & 0x00000002) != 0)) {
+            places_ = java.util.Collections.unmodifiableList(places_);
           }
           this.unknownFields = unknownFields.build();
           makeExtensionsImmutable();
@@ -11648,6 +12427,43 @@ public final class Recon {
         return placeDcids_.getByteString(index);
       }
 
+      public static final int PLACES_FIELD_NUMBER = 4;
+      private java.util.List<org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place> places_;
+      /**
+       * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+       */
+      public java.util.List<org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place>
+          getPlacesList() {
+        return places_;
+      }
+      /**
+       * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+       */
+      public java.util.List<
+              ? extends org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceOrBuilder>
+          getPlacesOrBuilderList() {
+        return places_;
+      }
+      /**
+       * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+       */
+      public int getPlacesCount() {
+        return places_.size();
+      }
+      /**
+       * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+       */
+      public org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place getPlaces(int index) {
+        return places_.get(index);
+      }
+      /**
+       * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+       */
+      public org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceOrBuilder
+          getPlacesOrBuilder(int index) {
+        return places_.get(index);
+      }
+
       private byte memoizedIsInitialized = -1;
 
       @java.lang.Override
@@ -11670,6 +12486,9 @@ public final class Recon {
         }
         for (int i = 0; i < placeDcids_.size(); i++) {
           com.google.protobuf.GeneratedMessageV3.writeString(output, 3, placeDcids_.getRaw(i));
+        }
+        for (int i = 0; i < places_.size(); i++) {
+          output.writeMessage(4, places_.get(i));
         }
         unknownFields.writeTo(output);
       }
@@ -11694,6 +12513,9 @@ public final class Recon {
           size += dataSize;
           size += 1 * getPlaceDcidsList().size();
         }
+        for (int i = 0; i < places_.size(); i++) {
+          size += com.google.protobuf.CodedOutputStream.computeMessageSize(4, places_.get(i));
+        }
         size += unknownFields.getSerializedSize();
         memoizedSize = size;
         return size;
@@ -11716,6 +12538,7 @@ public final class Recon {
         if (java.lang.Double.doubleToLongBits(getLongitude())
             != java.lang.Double.doubleToLongBits(other.getLongitude())) return false;
         if (!getPlaceDcidsList().equals(other.getPlaceDcidsList())) return false;
+        if (!getPlacesList().equals(other.getPlacesList())) return false;
         if (!unknownFields.equals(other.unknownFields)) return false;
         return true;
       }
@@ -11740,6 +12563,10 @@ public final class Recon {
         if (getPlaceDcidsCount() > 0) {
           hash = (37 * hash) + PLACE_DCIDS_FIELD_NUMBER;
           hash = (53 * hash) + getPlaceDcidsList().hashCode();
+        }
+        if (getPlacesCount() > 0) {
+          hash = (37 * hash) + PLACES_FIELD_NUMBER;
+          hash = (53 * hash) + getPlacesList().hashCode();
         }
         hash = (29 * hash) + unknownFields.hashCode();
         memoizedHashCode = hash;
@@ -11885,7 +12712,9 @@ public final class Recon {
         }
 
         private void maybeForceBuilderInitialization() {
-          if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
+          if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {
+            getPlacesFieldBuilder();
+          }
         }
 
         @java.lang.Override
@@ -11897,6 +12726,12 @@ public final class Recon {
 
           placeDcids_ = com.google.protobuf.LazyStringArrayList.EMPTY;
           bitField0_ = (bitField0_ & ~0x00000001);
+          if (placesBuilder_ == null) {
+            places_ = java.util.Collections.emptyList();
+            bitField0_ = (bitField0_ & ~0x00000002);
+          } else {
+            placesBuilder_.clear();
+          }
           return this;
         }
 
@@ -11936,6 +12771,15 @@ public final class Recon {
             bitField0_ = (bitField0_ & ~0x00000001);
           }
           result.placeDcids_ = placeDcids_;
+          if (placesBuilder_ == null) {
+            if (((bitField0_ & 0x00000002) != 0)) {
+              places_ = java.util.Collections.unmodifiableList(places_);
+              bitField0_ = (bitField0_ & ~0x00000002);
+            }
+            result.places_ = places_;
+          } else {
+            result.places_ = placesBuilder_.build();
+          }
           onBuilt();
           return result;
         }
@@ -12007,6 +12851,33 @@ public final class Recon {
               placeDcids_.addAll(other.placeDcids_);
             }
             onChanged();
+          }
+          if (placesBuilder_ == null) {
+            if (!other.places_.isEmpty()) {
+              if (places_.isEmpty()) {
+                places_ = other.places_;
+                bitField0_ = (bitField0_ & ~0x00000002);
+              } else {
+                ensurePlacesIsMutable();
+                places_.addAll(other.places_);
+              }
+              onChanged();
+            }
+          } else {
+            if (!other.places_.isEmpty()) {
+              if (placesBuilder_.isEmpty()) {
+                placesBuilder_.dispose();
+                placesBuilder_ = null;
+                places_ = other.places_;
+                bitField0_ = (bitField0_ & ~0x00000002);
+                placesBuilder_ =
+                    com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders
+                        ? getPlacesFieldBuilder()
+                        : null;
+              } else {
+                placesBuilder_.addAllMessages(other.places_);
+              }
+            }
           }
           this.mergeUnknownFields(other.unknownFields);
           onChanged();
@@ -12220,6 +13091,268 @@ public final class Recon {
           placeDcids_.add(value);
           onChanged();
           return this;
+        }
+
+        private java.util.List<org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place>
+            places_ = java.util.Collections.emptyList();
+
+        private void ensurePlacesIsMutable() {
+          if (!((bitField0_ & 0x00000002) != 0)) {
+            places_ =
+                new java.util.ArrayList<
+                    org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place>(places_);
+            bitField0_ |= 0x00000002;
+          }
+        }
+
+        private com.google.protobuf.RepeatedFieldBuilderV3<
+                org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place,
+                org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.Builder,
+                org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceOrBuilder>
+            placesBuilder_;
+
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public java.util.List<org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place>
+            getPlacesList() {
+          if (placesBuilder_ == null) {
+            return java.util.Collections.unmodifiableList(places_);
+          } else {
+            return placesBuilder_.getMessageList();
+          }
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public int getPlacesCount() {
+          if (placesBuilder_ == null) {
+            return places_.size();
+          } else {
+            return placesBuilder_.getCount();
+          }
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place getPlaces(int index) {
+          if (placesBuilder_ == null) {
+            return places_.get(index);
+          } else {
+            return placesBuilder_.getMessage(index);
+          }
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public Builder setPlaces(
+            int index, org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place value) {
+          if (placesBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            ensurePlacesIsMutable();
+            places_.set(index, value);
+            onChanged();
+          } else {
+            placesBuilder_.setMessage(index, value);
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public Builder setPlaces(
+            int index,
+            org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.Builder builderForValue) {
+          if (placesBuilder_ == null) {
+            ensurePlacesIsMutable();
+            places_.set(index, builderForValue.build());
+            onChanged();
+          } else {
+            placesBuilder_.setMessage(index, builderForValue.build());
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public Builder addPlaces(
+            org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place value) {
+          if (placesBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            ensurePlacesIsMutable();
+            places_.add(value);
+            onChanged();
+          } else {
+            placesBuilder_.addMessage(value);
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public Builder addPlaces(
+            int index, org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place value) {
+          if (placesBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            ensurePlacesIsMutable();
+            places_.add(index, value);
+            onChanged();
+          } else {
+            placesBuilder_.addMessage(index, value);
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public Builder addPlaces(
+            org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.Builder builderForValue) {
+          if (placesBuilder_ == null) {
+            ensurePlacesIsMutable();
+            places_.add(builderForValue.build());
+            onChanged();
+          } else {
+            placesBuilder_.addMessage(builderForValue.build());
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public Builder addPlaces(
+            int index,
+            org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.Builder builderForValue) {
+          if (placesBuilder_ == null) {
+            ensurePlacesIsMutable();
+            places_.add(index, builderForValue.build());
+            onChanged();
+          } else {
+            placesBuilder_.addMessage(index, builderForValue.build());
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public Builder addAllPlaces(
+            java.lang.Iterable<
+                    ? extends org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place>
+                values) {
+          if (placesBuilder_ == null) {
+            ensurePlacesIsMutable();
+            com.google.protobuf.AbstractMessageLite.Builder.addAll(values, places_);
+            onChanged();
+          } else {
+            placesBuilder_.addAllMessages(values);
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public Builder clearPlaces() {
+          if (placesBuilder_ == null) {
+            places_ = java.util.Collections.emptyList();
+            bitField0_ = (bitField0_ & ~0x00000002);
+            onChanged();
+          } else {
+            placesBuilder_.clear();
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public Builder removePlaces(int index) {
+          if (placesBuilder_ == null) {
+            ensurePlacesIsMutable();
+            places_.remove(index);
+            onChanged();
+          } else {
+            placesBuilder_.remove(index);
+          }
+          return this;
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.Builder
+            getPlacesBuilder(int index) {
+          return getPlacesFieldBuilder().getBuilder(index);
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceOrBuilder
+            getPlacesOrBuilder(int index) {
+          if (placesBuilder_ == null) {
+            return places_.get(index);
+          } else {
+            return placesBuilder_.getMessageOrBuilder(index);
+          }
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public java.util.List<
+                ? extends org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceOrBuilder>
+            getPlacesOrBuilderList() {
+          if (placesBuilder_ != null) {
+            return placesBuilder_.getMessageOrBuilderList();
+          } else {
+            return java.util.Collections.unmodifiableList(places_);
+          }
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.Builder
+            addPlacesBuilder() {
+          return getPlacesFieldBuilder()
+              .addBuilder(
+                  org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place
+                      .getDefaultInstance());
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.Builder
+            addPlacesBuilder(int index) {
+          return getPlacesFieldBuilder()
+              .addBuilder(
+                  index,
+                  org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place
+                      .getDefaultInstance());
+        }
+        /**
+         * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
+         */
+        public java.util.List<org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.Builder>
+            getPlacesBuilderList() {
+          return getPlacesFieldBuilder().getBuilderList();
+        }
+
+        private com.google.protobuf.RepeatedFieldBuilderV3<
+                org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place,
+                org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.Builder,
+                org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceOrBuilder>
+            getPlacesFieldBuilder() {
+          if (placesBuilder_ == null) {
+            placesBuilder_ =
+                new com.google.protobuf.RepeatedFieldBuilderV3<
+                    org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place,
+                    org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place.Builder,
+                    org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceOrBuilder>(
+                    places_, ((bitField0_ & 0x00000002) != 0), getParentForChildren(), isClean());
+            places_ = null;
+          }
+          return placesBuilder_;
         }
 
         @java.lang.Override
@@ -13103,6 +14236,10 @@ public final class Recon {
   private static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_org_datacommons_proto_ResolveCoordinatesResponse_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+      internal_static_org_datacommons_proto_ResolveCoordinatesResponse_Place_descriptor;
+  private static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_org_datacommons_proto_ResolveCoordinatesResponse_Place_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
       internal_static_org_datacommons_proto_ResolveCoordinatesResponse_PlaceCoordinate_descriptor;
   private static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_org_datacommons_proto_ResolveCoordinatesResponse_PlaceCoordinate_fieldAccessorTable;
@@ -13147,12 +14284,15 @@ public final class Recon {
           + "dinatesRequest\022P\n\013coordinates\030\001 \003(\0132;.or"
           + "g.datacommons.proto.ResolveCoordinatesRe"
           + "quest.Coordinate\0321\n\nCoordinate\022\020\n\010latitu"
-          + "de\030\001 \001(\001\022\021\n\tlongitude\030\002 \001(\001\"\307\001\n\032ResolveC"
+          + "de\030\001 \001(\001\022\021\n\tlongitude\030\002 \001(\001\"\277\002\n\032ResolveC"
           + "oordinatesResponse\022\\\n\021place_coordinates\030"
           + "\001 \003(\0132A.org.datacommons.proto.ResolveCoo"
-          + "rdinatesResponse.PlaceCoordinate\032K\n\017Plac"
-          + "eCoordinate\022\020\n\010latitude\030\001 \001(\001\022\021\n\tlongitu"
-          + "de\030\002 \001(\001\022\023\n\013place_dcids\030\003 \003(\tb\006proto3"
+          + "rdinatesResponse.PlaceCoordinate\032,\n\005Plac"
+          + "e\022\014\n\004dcid\030\001 \001(\t\022\025\n\rdominant_type\030\002 \001(\t\032\224"
+          + "\001\n\017PlaceCoordinate\022\020\n\010latitude\030\001 \001(\001\022\021\n\t"
+          + "longitude\030\002 \001(\001\022\023\n\013place_dcids\030\003 \003(\t\022G\n\006"
+          + "places\030\004 \003(\01327.org.datacommons.proto.Res"
+          + "olveCoordinatesResponse.Placeb\006proto3"
     };
     descriptor =
         com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
@@ -13280,15 +14420,25 @@ public final class Recon {
             new java.lang.String[] {
               "PlaceCoordinates",
             });
-    internal_static_org_datacommons_proto_ResolveCoordinatesResponse_PlaceCoordinate_descriptor =
+    internal_static_org_datacommons_proto_ResolveCoordinatesResponse_Place_descriptor =
         internal_static_org_datacommons_proto_ResolveCoordinatesResponse_descriptor
             .getNestedTypes()
             .get(0);
+    internal_static_org_datacommons_proto_ResolveCoordinatesResponse_Place_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_org_datacommons_proto_ResolveCoordinatesResponse_Place_descriptor,
+            new java.lang.String[] {
+              "Dcid", "DominantType",
+            });
+    internal_static_org_datacommons_proto_ResolveCoordinatesResponse_PlaceCoordinate_descriptor =
+        internal_static_org_datacommons_proto_ResolveCoordinatesResponse_descriptor
+            .getNestedTypes()
+            .get(1);
     internal_static_org_datacommons_proto_ResolveCoordinatesResponse_PlaceCoordinate_fieldAccessorTable =
         new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
             internal_static_org_datacommons_proto_ResolveCoordinatesResponse_PlaceCoordinate_descriptor,
             new java.lang.String[] {
-              "Latitude", "Longitude", "PlaceDcids",
+              "Latitude", "Longitude", "PlaceDcids", "Places",
             });
     org.datacommons.proto.Mcf.getDescriptor();
   }

--- a/util/src/main/java/org/datacommons/util/CoordinatesResolver.java
+++ b/util/src/main/java/org/datacommons/util/CoordinatesResolver.java
@@ -1,0 +1,96 @@
+package org.datacommons.util;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import org.datacommons.proto.Mcf.McfGraph.PropertyValues;
+import org.datacommons.proto.Mcf.McfGraph.Values;
+import org.datacommons.proto.Mcf.ValueType;
+import org.datacommons.proto.Recon.ResolveCoordinatesRequest;
+import org.datacommons.proto.Recon.ResolveCoordinatesRequest.Coordinate;
+import org.datacommons.proto.Recon.ResolveCoordinatesResponse;
+import org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place;
+
+/** Resolves nodes with lat-lngs by calling the DC coordinates resolution API. */
+final class CoordinatesResolver {
+  private final Set<Coordinate> resolveCoordinates = ConcurrentHashMap.newKeySet();
+
+  private final ConcurrentHashMap<Coordinate, Set<String>> resolvedCoordinates =
+      new ConcurrentHashMap<>();
+
+  private final ReconClient client;
+
+  CoordinatesResolver(ReconClient client) {
+    this.client = client;
+  }
+
+  boolean submit(PropertyValues node) {
+    return getCoordinate(node).map(resolveCoordinates::add).map(unused -> true).orElse(false);
+  }
+
+  void drain() {
+    if (!resolveCoordinates.isEmpty()) {
+      populateResolvedCandidates(
+          client.resolveCoordinates(
+              ResolveCoordinatesRequest.newBuilder()
+                  .addAllCoordinates(resolveCoordinates)
+                  .build()));
+    }
+  }
+
+  Optional<String> resolve(PropertyValues node) {
+    return getCoordinate(node)
+        .filter(resolvedCoordinates::containsKey)
+        .flatMap(coordinate -> resolvedCoordinates.get(coordinate).stream().findFirst());
+  }
+
+  private void populateResolvedCandidates(ResolveCoordinatesResponse response) {
+    response
+        .getPlaceCoordinatesList()
+        .forEach(
+            placeCoordinate -> {
+              if (placeCoordinate.getPlacesCount() > 0) {
+                resolvedCoordinates.put(
+                    Coordinate.newBuilder()
+                        .setLatitude(placeCoordinate.getLatitude())
+                        .setLongitude(placeCoordinate.getLongitude())
+                        .build(),
+                    new LinkedHashSet<>(
+                        placeCoordinate.getPlacesList().stream()
+                            .map(Place::getDcid)
+                            .collect(toList())));
+              }
+            });
+  }
+
+  private static Optional<Coordinate> getCoordinate(PropertyValues node) {
+    if (node.containsPvs(Vocabulary.LATITUDE) && node.containsPvs(Vocabulary.LONGITUDE)) {
+
+      Optional<Double> optLat = getDoubleValue(node.getPvsMap().get(Vocabulary.LATITUDE));
+      Optional<Double> optLng = getDoubleValue(node.getPvsMap().get(Vocabulary.LONGITUDE));
+
+      if (optLat.isPresent() && optLng.isPresent()) {
+        double lat = optLat.get();
+        double lng = optLng.get();
+
+        if (!Double.isNaN(lat) && !Double.isNaN(lng)) {
+          return Optional.of(Coordinate.newBuilder().setLatitude(lat).setLongitude(lng).build());
+        }
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  // TODO: Add support for other formats of values (e.g. 12.34N, 45.56W, etc.)
+  private static Optional<Double> getDoubleValue(Values prop) {
+    return prop.getTypedValuesList().stream()
+        .filter(
+            typedValue ->
+                ValueType.NUMBER.equals(typedValue.getType())
+                    || ValueType.TEXT.equals(typedValue.getType()))
+        .findFirst()
+        .map(typedValue -> Double.parseDouble(typedValue.getValue()));
+  }
+}

--- a/util/src/main/java/org/datacommons/util/CoordinatesResolver.java
+++ b/util/src/main/java/org/datacommons/util/CoordinatesResolver.java
@@ -13,6 +13,7 @@ import org.datacommons.proto.Recon.ResolveCoordinatesResponse;
 import org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place;
 
 /** Resolves nodes with lat-lngs by calling the DC coordinates resolution API. */
+// TODO: Add counters for errors.
 final class CoordinatesResolver {
   private final Set<Coordinate> resolveCoordinates = ConcurrentHashMap.newKeySet();
 
@@ -26,7 +27,12 @@ final class CoordinatesResolver {
   }
 
   boolean submit(PropertyValues node) {
-    return getCoordinate(node).map(resolveCoordinates::add).map(unused -> true).orElse(false);
+    Optional<Coordinate> optionalCoordinate = getCoordinate(node);
+    if (optionalCoordinate.isPresent()) {
+      resolveCoordinates.add(optionalCoordinate.get());
+      return true;
+    }
+    return false;
   }
 
   void drain() {

--- a/util/src/main/java/org/datacommons/util/ReconClient.java
+++ b/util/src/main/java/org/datacommons/util/ReconClient.java
@@ -1,51 +1,130 @@
 package org.datacommons.util;
 
+import static com.google.common.collect.Lists.partition;
 import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.util.stream.Collectors.toList;
+import static org.datacommons.util.StringUtil.msgToJson;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import org.datacommons.proto.Recon.ResolveCoordinatesRequest;
 import org.datacommons.proto.Recon.ResolveCoordinatesResponse;
 
 /**
  * Client to the DC resolution APIs.
  *
- * <p>Currently it only resolves coordinates.
+ * <p>Currently it only resolves coordinates. If the number of coordinates to resolve are greater
+ * than {@code chunkSize}, the API calls will be partitioned into max {@code chunkSize}d batches.
  */
 public class ReconClient {
   private static final String RESOLVE_COORDINATES_API_URL =
       "https://api.datacommons.org/v1/recon/resolve/coordinate";
 
+  private static final String RESOLVE_ENTITIES_API_URL =
+      "https://api.datacommons.org/v1/recon/entity/resolve";
+
+  static final String NUM_API_CALLS_COUNTER = "ReconClient_NumApiCalls";
+
+  private static final int DEFAULT_CHUNK_SIZE = 500;
+
+  private final int chunkSize;
+
   private final HttpClient httpClient;
 
-  public ReconClient(HttpClient httpClient) {
+  private final LogWrapper logWrapper;
+
+  public ReconClient(HttpClient httpClient, LogWrapper logWrapper) {
+    this(httpClient, logWrapper, DEFAULT_CHUNK_SIZE);
+  }
+
+  public ReconClient(HttpClient httpClient, LogWrapper logWrapper, int chunkSize) {
     this.httpClient = httpClient;
+    this.logWrapper = logWrapper;
+    this.chunkSize = chunkSize;
   }
 
-  public ResolveCoordinatesResponse resolveCoordinates(ResolveCoordinatesRequest request)
-      throws IOException, InterruptedException {
-    return callApi(
-        RESOLVE_COORDINATES_API_URL, request, ResolveCoordinatesResponse.getDefaultInstance());
+  public ResolveCoordinatesResponse resolveCoordinates(ResolveCoordinatesRequest request) {
+    try {
+      return resolveCoordinatesAsync(request).get();
+    } catch (Exception e) {
+      throw new RuntimeException("Error resolving candidates", e);
+    }
   }
 
-  private <T extends Message> T callApi(
-      String apiUrl, Message requestMessage, T responseDefaultInstance)
-      throws IOException, InterruptedException {
-    var request =
+  public CompletableFuture<ResolveCoordinatesResponse> resolveCoordinatesAsync(
+      ResolveCoordinatesRequest request) {
+    ResolveCoordinatesResponse defaultResponse = ResolveCoordinatesResponse.getDefaultInstance();
+    if (request.getCoordinatesCount() < 1) {
+      return CompletableFuture.completedFuture(defaultResponse);
+    }
+
+    return toFutureOfList(
+            partition(request.getCoordinatesList(), chunkSize).stream()
+                .map(
+                    chunk ->
+                        request.toBuilder().clearCoordinates().addAllCoordinates(chunk).build())
+                .map(
+                    chunkedRequest ->
+                        callApi(RESOLVE_COORDINATES_API_URL, chunkedRequest, defaultResponse))
+                .collect(toList()))
+        .thenApply(
+            chunkedResponses ->
+                ResolveCoordinatesResponse.newBuilder()
+                    .addAllPlaceCoordinates(
+                        chunkedResponses.stream()
+                            .flatMap(
+                                chunkedResponse ->
+                                    chunkedResponse.getPlaceCoordinatesList().stream())
+                            .collect(toList()))
+                    .build());
+  }
+
+  private <T extends Message> CompletableFuture<T> callApi(
+      String apiUrl, Message requestMessage, T responseDefaultInstance) {
+    logWrapper.incrementInfoCounterBy(NUM_API_CALLS_COUNTER, 1);
+    HttpRequest request =
         HttpRequest.newBuilder(URI.create(apiUrl))
             .version(HTTP_1_1)
             .header("accept", "application/json")
-            .POST(BodyPublishers.ofString(StringUtil.msgToJson(requestMessage)))
+            .POST(BodyPublishers.ofString(toJson(requestMessage)))
             .build();
-    var response = httpClient.send(request, BodyHandlers.ofString());
-    var responseMessageBuilder = responseDefaultInstance.newBuilderForType();
-    JsonFormat.parser().merge(response.body().trim(), responseMessageBuilder);
-    return (T) responseMessageBuilder.build();
+    return httpClient
+        .sendAsync(request, BodyHandlers.ofString())
+        .thenApply(
+            response -> {
+              Message.Builder responseMessageBuilder = responseDefaultInstance.newBuilderForType();
+              fromJson(response.body().trim(), responseMessageBuilder);
+              return (T) responseMessageBuilder.build();
+            });
+  }
+
+  private static <T> CompletableFuture<List<T>> toFutureOfList(List<CompletableFuture<T>> futures) {
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+        .thenApply(v -> futures.stream().map(CompletableFuture::join).collect(Collectors.toList()));
+  }
+
+  private static String toJson(Message message) {
+    try {
+      return msgToJson(message);
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void fromJson(String json, Message.Builder builder) {
+    try {
+      JsonFormat.parser().merge(json, builder);
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/util/src/main/proto/Debug.proto
+++ b/util/src/main/proto/Debug.proto
@@ -81,7 +81,8 @@ message CommandArgs {
     optional bool observation_about = 6;
     optional bool allow_nan_svobs = 7;  // allow not-a-number svobs values
     // check the existence of SVObs value references if the SV they are measuring has statType: measurementResult
-    optional bool check_measurement_result = 8; 
+    optional bool check_measurement_result = 8;
+    optional bool coordinates_resolution = 9;
 }
 
 message DataPoint {

--- a/util/src/main/proto/recon.proto
+++ b/util/src/main/proto/recon.proto
@@ -86,10 +86,15 @@ message ResolveCoordinatesRequest {
 }
 
 message ResolveCoordinatesResponse {
+    message Place {
+        string dcid = 1;
+        string dominant_type = 2;
+    }
     message PlaceCoordinate {
         double latitude = 1;
         double longitude = 2;
         repeated string place_dcids = 3;
+        repeated Place places = 4;
     }
     repeated PlaceCoordinate place_coordinates = 1;
 }

--- a/util/src/test/java/org/datacommons/util/CoordinatesResolverTest.java
+++ b/util/src/test/java/org/datacommons/util/CoordinatesResolverTest.java
@@ -1,0 +1,66 @@
+package org.datacommons.util;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+import static java.net.http.HttpClient.newHttpClient;
+import static org.datacommons.util.TestUtil.newLogCtx;
+import static org.datacommons.util.Vocabulary.LATITUDE;
+import static org.datacommons.util.Vocabulary.LONGITUDE;
+
+import java.util.List;
+import java.util.Map;
+import org.datacommons.proto.Mcf.McfGraph.PropertyValues;
+import org.datacommons.proto.Mcf.ValueType;
+import org.junit.Test;
+
+public class CoordinatesResolverTest {
+  private static final PropertyValues SF =
+      newNode("City", Map.of(LATITUDE, "37.77493", LONGITUDE, "-122.41942"));
+  private static final String SF_ZIP_DCID = "zip/94103";
+
+  private static final PropertyValues BIG_BEN =
+      newNode("Place", Map.of(LATITUDE, "51.510357", LONGITUDE, "-0.116773"));
+  private static final String BIG_BEN_NUTS_DCID = "nuts/UKI32";
+
+  private static final PropertyValues NON_LAT_LNG_NODE = newNode("Place", Map.of("isoCode", "IN"));
+
+  private static final List<PropertyValues> TEST_NODES = List.of(SF, BIG_BEN, NON_LAT_LNG_NODE);
+
+  private static final PropertyValues UNSUBMITTED_NODE =
+      newNode("City", Map.of(LATITUDE, "12.34", LONGITUDE, "56.78"));
+
+  @Test
+  public void endToEnd() {
+    CoordinatesResolver resolver =
+        new CoordinatesResolver(new ReconClient(newHttpClient(), newLogCtx()));
+
+    for (PropertyValues node : TEST_NODES) {
+      resolver.submit(node);
+    }
+
+    resolver.drain();
+
+    assertThat(resolver.resolve(SF)).hasValue(SF_ZIP_DCID);
+    assertThat(resolver.resolve(BIG_BEN)).hasValue(BIG_BEN_NUTS_DCID);
+    assertThat(resolver.resolve(UNSUBMITTED_NODE)).isEmpty();
+  }
+
+  @Test
+  public void submitNode() {
+    CoordinatesResolver resolver =
+        new CoordinatesResolver(new ReconClient(newHttpClient(), newLogCtx()));
+
+    assertThat(resolver.submit(SF)).isTrue();
+    assertThat(resolver.submit(BIG_BEN)).isTrue();
+    assertThat(resolver.submit(NON_LAT_LNG_NODE)).isFalse();
+  }
+
+  private static PropertyValues newNode(String typeOf, Map<String, String> props) {
+    PropertyValues.Builder node = PropertyValues.newBuilder();
+    node.putPvs(Vocabulary.TYPE_OF, McfUtil.newValues(ValueType.RESOLVED_REF, typeOf));
+    for (var pv : props.entrySet()) {
+      node.putPvs(pv.getKey(), McfUtil.newValues(ValueType.TEXT, pv.getValue()));
+    }
+    return node.build();
+  }
+}

--- a/util/src/test/java/org/datacommons/util/ReconClientTest.java
+++ b/util/src/test/java/org/datacommons/util/ReconClientTest.java
@@ -1,29 +1,76 @@
 package org.datacommons.util;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.util.stream.Collectors.toList;
+import static org.datacommons.util.ReconClient.NUM_API_CALLS_COUNTER;
+import static org.datacommons.util.TestUtil.getCounter;
+import static org.datacommons.util.TestUtil.newLogCtx;
 
 import java.net.http.HttpClient;
-import org.datacommons.proto.Recon;
+import org.datacommons.proto.Recon.ResolveCoordinatesRequest;
+import org.datacommons.proto.Recon.ResolveCoordinatesRequest.Coordinate;
+import org.datacommons.proto.Recon.ResolveCoordinatesResponse;
 import org.junit.Test;
 
 public class ReconClientTest {
-  @Test
-  public void resolveCoordinates_endToEndApiCall() throws Exception {
-    var client = new ReconClient(HttpClient.newHttpClient());
+  private static final String USA_DCID = "country/USA";
+  private static final String GBR_DCID = "country/GBR";
+  private static final Coordinate SF_COORDINATES =
+      Coordinate.newBuilder().setLatitude(37.77493).setLongitude(-122.41942).build();
+  private static final Coordinate BIG_BEN_COORDINATES =
+      Coordinate.newBuilder().setLatitude(51.510357).setLongitude(-0.116773).build();
 
-    // San Francisco coordinates
-    var request =
-        Recon.ResolveCoordinatesRequest.newBuilder()
-            .addCoordinates(
-                Recon.ResolveCoordinatesRequest.Coordinate.newBuilder()
-                    .setLatitude(37.77493)
-                    .setLongitude(-122.41942)
-                    .build())
+  @Test
+  public void resolveCoordinates() {
+    LogWrapper logWrapper = newLogCtx();
+    ReconClient client = new ReconClient(HttpClient.newHttpClient(), logWrapper);
+
+    ResolveCoordinatesRequest request =
+        ResolveCoordinatesRequest.newBuilder()
+            .addCoordinates(SF_COORDINATES)
+            .addCoordinates(BIG_BEN_COORDINATES)
             .build();
 
-    var result = client.resolveCoordinates(request);
+    ResolveCoordinatesResponse result = client.resolveCoordinates(request);
 
-    assertThat(result.getPlaceCoordinatesCount()).isEqualTo(1);
-    assertThat(result.getPlaceCoordinates(0).getPlaceDcidsList()).contains("country/USA");
+    assertThat(result.getPlaceCoordinatesCount()).isEqualTo(2);
+    assertThat(
+            result.getPlaceCoordinates(0).getPlacesList().stream()
+                .map(ResolveCoordinatesResponse.Place::getDcid)
+                .collect(toList()))
+        .contains(USA_DCID);
+    assertThat(
+            result.getPlaceCoordinates(1).getPlacesList().stream()
+                .map(ResolveCoordinatesResponse.Place::getDcid)
+                .collect(toList()))
+        .contains(GBR_DCID);
+    assertThat(getCounter(logWrapper.getLog(), NUM_API_CALLS_COUNTER)).isEqualTo(1);
+  }
+
+  @Test
+  public void resolveCoordinates_chunked() {
+    LogWrapper logWrapper = newLogCtx();
+    ReconClient client = new ReconClient(HttpClient.newHttpClient(), logWrapper, 1);
+
+    ResolveCoordinatesRequest request =
+        ResolveCoordinatesRequest.newBuilder()
+            .addCoordinates(SF_COORDINATES)
+            .addCoordinates(BIG_BEN_COORDINATES)
+            .build();
+
+    ResolveCoordinatesResponse result = client.resolveCoordinates(request);
+
+    assertThat(result.getPlaceCoordinatesCount()).isEqualTo(2);
+    assertThat(
+            result.getPlaceCoordinates(0).getPlacesList().stream()
+                .map(ResolveCoordinatesResponse.Place::getDcid)
+                .collect(toList()))
+        .contains(USA_DCID);
+    assertThat(
+            result.getPlaceCoordinates(1).getPlacesList().stream()
+                .map(ResolveCoordinatesResponse.Place::getDcid)
+                .collect(toList()))
+        .contains(GBR_DCID);
+    assertThat(getCounter(logWrapper.getLog(), NUM_API_CALLS_COUNTER)).isEqualTo(2);
   }
 }


### PR DESCRIPTION
* For #203 
* Coordinates resolution is only enabled if a new `--coordinates-resolution` flag is set.
* The implementation is intentionally minimally invasive to the existing resolution code path and is executed only when the above flag is set.
* Currently it only supports numeric `latitude` and `longitude` properties and basic validation. Support for more formats and validations will be added subsequently.