### PR TITLE
Support pre-resolved entities.

### DIFF
--- a/simple/stats/constants.py
+++ b/simple/stats/constants.py
@@ -22,6 +22,8 @@ DEFAULT_OUTPUT_DIR = os.path.join(DEFAULT_DATA_DIR, "output")
 OBSERVATIONS_FILE_NAME = "observations.csv"
 DEBUG_RESOLVE_FILE_NAME = "debug_resolve.csv"
 
+DCID_OVERRIDE_PREFIX = "dcid:"
+
 # Observations CSV columns.
 COLUMN_DCID = "dcid"
 COLUMN_VARIABLE = "variable"

--- a/simple/stats/sample/countries/debug_resolve.csv
+++ b/simple/stats/sample/countries/debug_resolve.csv
@@ -1,6 +1,6 @@
 name,dcid,link
 West Bank and Gaza,*UNRESOLVED*,
-Cabo Verde,*UNRESOLVED*,
+dcid: wikidataId/Q22062741,wikidataId/Q22062741,https://datacommons.org/browser/wikidataId/Q22062741
 Afghanistan,country/AFG,https://datacommons.org/browser/country/AFG
 Albania,country/ALB,https://datacommons.org/browser/country/ALB
 Algeria,country/DZA,https://datacommons.org/browser/country/DZA

--- a/simple/stats/sample/countries/input.csv
+++ b/simple/stats/sample/countries/input.csv
@@ -5,7 +5,7 @@ Angola,2023,0.29,6
 Zambia,2023,0.31,34
 Zimbabwe,2023,0.37,76
 Albania,2023,0.50,34
-Cabo Verde,2023,0.50,97
+dcid: wikidataId/Q22062741,2023,0.50,97
 Algeria,2023,0.52,92
 West Bank and Gaza,2023,0.53,64
 Andorra,2023,0.76,9

--- a/simple/stats/sample/countries/observations.csv
+++ b/simple/stats/sample/countries/observations.csv
@@ -5,6 +5,7 @@ country/AGO,var1,2023,0.29
 country/ZMB,var1,2023,0.31
 country/ZWE,var1,2023,0.37
 country/ALB,var1,2023,0.5
+wikidataId/Q22062741,var1,2023,0.5
 country/DZA,var1,2023,0.52
 country/AND,var1,2023,0.76
 country/AFG,var2,2023,6.0
@@ -13,6 +14,7 @@ country/AGO,var2,2023,6.0
 country/ZMB,var2,2023,34.0
 country/ZWE,var2,2023,76.0
 country/ALB,var2,2023,34.0
+wikidataId/Q22062741,var2,2023,97.0
 country/DZA,var2,2023,92.0
 country/AND,var2,2023,9.0
 country/ASM,var2,2023,34.0


### PR DESCRIPTION
* Entity values prefixed with `dcid:` are considered pre-resolved.
* Allows users to manually override dcids.