### PR TITLE
Output csvs in wide format by default.

### DIFF
--- a/simple/stats/constants.py
+++ b/simple/stats/constants.py
@@ -24,6 +24,8 @@ DEBUG_RESOLVE_FILE_NAME = "debug_resolve.csv"
 
 DCID_OVERRIDE_PREFIX = "dcid:"
 
+UNPIVOT_VARIABLES = False
+
 # Observations CSV columns.
 COLUMN_DCID = "dcid"
 COLUMN_VARIABLE = "variable"

--- a/simple/stats/main.py
+++ b/simple/stats/main.py
@@ -36,6 +36,7 @@ flags.DEFINE_string("input_path", constants.DEFAULT_INPUT_PATH,
                     "The input directory or file.")
 flags.DEFINE_string("output_dir", constants.DEFAULT_OUTPUT_DIR,
                     "The output directory.")
+flags.DEFINE_list("ignore_columns", [], "List of input columns to be ignored.")
 
 
 def main(_):
@@ -43,6 +44,7 @@ def main(_):
         input_path=FLAGS.input_path,
         output_dir=FLAGS.output_dir,
         entity_type=FLAGS.entity_type,
+        ignore_columns=FLAGS.ignore_columns,
     )
     importer.do_import()
 

--- a/simple/util/dc_client.py
+++ b/simple/util/dc_client.py
@@ -28,15 +28,6 @@ _API_ROOT_ENV = "DC_API_ROOT"
 # Default REST API endpoint root.
 _DEFAULT_API_ROOT = "https://api.datacommons.org"
 
-
-def get_api_key():
-    return os.environ.get(_KEY_ENV, "")
-
-
-def get_api_root():
-    return os.environ.get(_API_ROOT_ENV, _DEFAULT_API_ROOT)
-
-
 _DEBUG = True
 _DEBUG_FOLDER = ".data/debug"
 
@@ -47,6 +38,15 @@ _RESOLVE_PLACE_TYPES = set(
     ["Place", "Continent", "Country", "State", "Province", "City"])
 
 _MAX_NODES = 10_000
+
+
+def get_api_key():
+    return os.environ.get(_KEY_ENV, "")
+
+
+def get_api_root():
+    return os.environ.get(_API_ROOT_ENV, _DEFAULT_API_ROOT)
+
 
 if _DEBUG:
     logging.info("DC API Root: %s", get_api_root())

--- a/simple/util/ngram_matcher.py
+++ b/simple/util/ngram_matcher.py
@@ -62,6 +62,9 @@ class NgramMatcher:
     def get_tuples_count(self):
         return len(self._key_values)
 
+    def get_key_values(self):
+        return dict(self._key_values)
+
     def add_keys_values(self, kvs: dict[str, any]) -> None:
         for key, value in kvs.items():
             self.add_key_value(key, value)


### PR DESCRIPTION
* Outputs csvs in wide format by default (i.e. without "unpivotting").
* Allows overriding API root via env variable (e.g. to call autopush api).
* Supports debug flag (in code) to write entities to file for debugging.