### PR TITLE
Add support for GCS paths.

### DIFF
--- a/simple/requirements.txt
+++ b/simple/requirements.txt
@@ -1,6 +1,7 @@
 absl-py==1.4.0
 certifi==2023.7.22
 charset-normalizer==3.2.0
+google-cloud-storage==2.11.0
 idna==3.4
 importlib-metadata==6.8.0
 numpy==1.25.2

--- a/simple/util/filehandler.py
+++ b/simple/util/filehandler.py
@@ -1,0 +1,98 @@
+# Copyright 2023 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A generic FileHandler abstraction that allows clients to work seamlessly with 
+local and GCS files and directories.
+"""
+
+import os
+import io
+import logging
+from google.cloud import storage
+
+_GCS_PATH_PREFIX = "gs://"
+
+
+class FileHandler:
+
+    def __init__(self, path: str, isdir: bool) -> None:
+        self.path = path
+        self.isdir = isdir
+
+    def __str__(self) -> str:
+        return self.path
+
+    def read_string(self) -> str:
+        pass
+
+    def read_string_io(self) -> io.StringIO:
+        return io.StringIO(self.read_string())
+
+    def write_string(self, content: str) -> None:
+        pass
+
+    def make_file(self, file_name: str) -> "FileHandler":
+        pass
+
+    def make_dirs(self) -> None:
+        pass
+
+
+class LocalFileHandler(FileHandler):
+
+    def __init__(self, path: str) -> None:
+        isdir = os.path.isdir(path)
+        super().__init__(path, isdir)
+
+    def read_string(self) -> str:
+        with open(self.path, "r") as f:
+            return f.read()
+
+    def write_string(self, content: str) -> None:
+        with open(self.path, "w") as f:
+            f.write(content)
+
+    def make_file(self, file_name: str) -> FileHandler:
+        return LocalFileHandler(os.path.join(self.path, file_name))
+
+    def make_dirs(self) -> None:
+        return os.makedirs(self.path, exist_ok=True)
+
+
+class GcsFileHandler(FileHandler):
+    gcs_client = storage.Client()
+    logging.info("Using GCP Project: %s", gcs_client.project)
+
+    def __init__(self, path: str) -> None:
+        if not path.startswith(_GCS_PATH_PREFIX):
+            raise ValueError(f"Expected {_GCS_PATH_PREFIX} prefix, got {path}")
+        bucket_name, blob_name = path[len(_GCS_PATH_PREFIX):].split('/', 1)
+        self.bucket = GcsFileHandler.gcs_client.bucket(bucket_name)
+        self.blob = self.bucket.blob(blob_name)
+        super().__init__(path, path.endswith("/"))
+
+    def read_string(self) -> str:
+        return self.blob.download_as_string().decode("utf-8")
+
+    def write_string(self, content: str) -> None:
+        self.blob.upload_from_string(content)
+
+    def make_file(self, file_name: str) -> FileHandler:
+        return GcsFileHandler(
+            f"{self.path}{'' if self.isdir else '/'}{file_name}")
+
+
+def create_file_handler(path: str) -> FileHandler:
+    if path.startswith(_GCS_PATH_PREFIX):
+        return GcsFileHandler(path)
+    return LocalFileHandler(path)

--- a/simple/util/filehandler.py
+++ b/simple/util/filehandler.py
@@ -17,13 +17,13 @@ local and GCS files and directories.
 
 import os
 import io
-import logging
 from google.cloud import storage
 
 _GCS_PATH_PREFIX = "gs://"
 
 
 class FileHandler:
+    """(Abstract) base class that should be extended by concrete implementations."""
 
     def __init__(self, path: str, isdir: bool) -> None:
         self.path = path
@@ -71,7 +71,8 @@ class LocalFileHandler(FileHandler):
 
 class GcsFileHandler(FileHandler):
     gcs_client = storage.Client()
-    logging.info("Using GCP Project: %s", gcs_client.project)
+    # Using print instead of logging since the class is loaded before logging is initialized.
+    print("Using GCP Project:", gcs_client.project)
 
     def __init__(self, path: str) -> None:
         if not path.startswith(_GCS_PATH_PREFIX):


### PR DESCRIPTION
* Created a generic `FileHandler` abstraction with local and GCS implementations.
* GCS paths must begin with `gs://`.
* Example of GCS usage:
   + `python3 main.py --input_path=gs://datcom-floret-dev-resources/data/observations-floretcountrydata.csv --output_dir=gs://datcom-floret-dev-resources/temp/`
   + The above command read the CSV from the GCS path and output the files to another GCS path [here](https://screenshot.googleplex.com/8DZktSQaTxV2QNw).
* A mix of local and GCS paths for inputs / outputs is also supported.
   + e.g. `python3 main.py --input_path=gs://datcom-floret-dev-resources/data/observations-floretcountrydata.csv --output_dir=data/`
* Note that input folders are not yet supported. That will be implemented soon. 