### PR TITLE
Write import info to a new imports table.

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -69,6 +69,8 @@ function update_goldens {
 function py_test {
   # Clear api key to catch any spurious API calls.
   export DC_API_KEY=
+  # Do not use Cloud SQL.
+  export USE_CLOUDSQL=false
 
   python3 -m venv .env
   source .env/bin/activate
@@ -88,6 +90,9 @@ function run_all_tests {
 }
 
 function run_sample {
+  # Do not use Cloud SQL.
+  export USE_CLOUDSQL=false
+
   python3 -m venv .env
   source .env/bin/activate
   

--- a/simple/stats/runner.py
+++ b/simple/stats/runner.py
@@ -21,6 +21,7 @@ from stats.db import create_sqlite_config
 from stats.db import Db
 from stats.db import get_cloud_sql_config_from_env
 from stats.db import get_sqlite_config_from_env
+from stats.db import ImportStatus
 from stats.importer import SimpleStatsImporter
 import stats.nl as nl
 from stats.nodes import Nodes
@@ -101,6 +102,9 @@ class Runner:
       nl.generate_sv_sentences(
           list(self.nodes.variables.values()),
           self.nl_dir_fh.make_file(constants.SENTENCES_FILE_NAME))
+
+      # Write import info to DB.
+      self.db.insert_import_info(status=ImportStatus.SUCCESS)
 
       # Commit and close DB.
       self.db.commit_and_close()

--- a/simple/tests/stats/db_test.py
+++ b/simple/tests/stats/db_test.py
@@ -18,12 +18,14 @@ import tempfile
 import unittest
 from unittest import mock
 
+from freezegun import freeze_time
 from stats.data import Observation
 from stats.data import Triple
 from stats.db import create_sqlite_config
 from stats.db import Db
 from stats.db import get_cloud_sql_config_from_env
 from stats.db import get_sqlite_config_from_env
+from stats.db import ImportStatus
 from stats.db import to_observation_tuple
 from stats.db import to_triple_tuple
 
@@ -40,12 +42,14 @@ _OBSERVATIONS = [
 
 class TestDb(unittest.TestCase):
 
+  @freeze_time("2023-01-01")
   def test_db(self):
     with tempfile.TemporaryDirectory() as temp_dir:
       db_file_path = os.path.join(temp_dir, "datacommons.db")
       db = Db(create_sqlite_config(db_file_path))
       db.insert_triples(_TRIPLES)
       db.insert_observations(_OBSERVATIONS)
+      db.insert_import_info(status=ImportStatus.SUCCESS)
       db.commit_and_close()
 
       sqldb = sqlite3.connect(db_file_path)
@@ -58,6 +62,11 @@ class TestDb(unittest.TestCase):
       self.assertListEqual(
           observations,
           list(map(lambda x: to_observation_tuple(x), _OBSERVATIONS)))
+
+      import_tuple = sqldb.execute("select * from imports").fetchone()
+      self.assertTupleEqual(
+          import_tuple,
+          ("2023-01-01 00:00:00", "SUCCESS", '{"numVars": 1, "numObs": 2}'))
 
   @mock.patch.dict(os.environ, {})
   def test_get_cloud_sql_config_from_env_empty(self):


### PR DESCRIPTION
* Verified against both sqlite and cloud sql.

### Cloud SQL Console snippet

```
mysql> use datacommons;
Database changed
mysql> show tables;
+-----------------------+
| Tables_in_datacommons |
+-----------------------+
| imports               |
| observations          |
| triples               |
+-----------------------+
3 rows in set (0.05 sec)

mysql> select * from imports;
+---------------------+---------+------------------------------+
| imported_at         | status  | metadata                     |
+---------------------+---------+------------------------------+
| 2023-12-12 10:32:16 | SUCCESS | {"numVars": 4, "numObs": 58} |
+---------------------+---------+------------------------------+
1 row in set (0.05 sec)

mysql> 
```