### PR TITLE
Remove support for importing individual files.

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -103,7 +103,7 @@ function run_sample {
   rm -f sample/output/datacommons.db
 
   echo "Running sample."
-  python3 -m stats.main --input_path=sample/input --output_dir=sample/output --freeze_time
+  python3 -m stats.main --input_dir=sample/input --output_dir=sample/output --freeze_time
 
   echo "Writing tables to CSVs."
   mkdir -p sample/output/debug

--- a/simple/sample/README.md
+++ b/simple/sample/README.md
@@ -5,7 +5,7 @@ This folder contains sample input files under the `input` folder and the generat
 To run import on the sample input files, `cd` into the `simple` folder and then run:
 
 ```bash
-python3 -m stats.main --input_path=sample/input --output_dir=sample/output
+python3 -m stats.main --input_dir=sample/input --output_dir=sample/output
 ```
 
 If you are planning to checkin the sample outputs to github, 
@@ -13,6 +13,6 @@ consider running with the `--freeze_time` flag.
 This freezes the reporting time to `2023-01-01` and avoids updates to `report.json` on every run.
 
 ```bash
-python3 -m stats.main --input_path=sample/input --output_dir=sample/output --freeze_time
+python3 -m stats.main --input_dir=sample/input --output_dir=sample/output --freeze_time
 ```
 

--- a/simple/stats/constants.py
+++ b/simple/stats/constants.py
@@ -16,7 +16,7 @@ import os
 
 # Defaults.
 DEFAULT_DATA_DIR = ".data"
-DEFAULT_INPUT_PATH = os.path.join(DEFAULT_DATA_DIR, "input")
+DEFAULT_INPUT_DIR = os.path.join(DEFAULT_DATA_DIR, "input")
 DEFAULT_OUTPUT_DIR = os.path.join(DEFAULT_DATA_DIR, "output")
 DEFAULT_FROZEN_TIME = "2023-01-01"
 

--- a/simple/stats/main.py
+++ b/simple/stats/main.py
@@ -23,16 +23,10 @@ from stats.runner import Runner
 
 FLAGS = flags.FLAGS
 
-flags.DEFINE_string(
-    "entity_type",
-    None,
-    "The type of entities in the CSV (e.g. 'City', 'Country', 'Company', etc.).",
-)
-flags.DEFINE_string("input_path", constants.DEFAULT_INPUT_PATH,
-                    "The input directory or file.")
+flags.DEFINE_string("input_dir", constants.DEFAULT_INPUT_DIR,
+                    "The input directory.")
 flags.DEFINE_string("output_dir", constants.DEFAULT_OUTPUT_DIR,
                     "The output directory.")
-flags.DEFINE_list("ignore_columns", [], "List of input columns to be ignored.")
 flags.DEFINE_bool(
     "freeze_time",
     False,
@@ -60,10 +54,8 @@ def _init_logger():
 
 def _run():
   Runner(
-      input_path=FLAGS.input_path,
+      input_dir=FLAGS.input_dir,
       output_dir=FLAGS.output_dir,
-      entity_type=FLAGS.entity_type,
-      ignore_columns=FLAGS.ignore_columns,
   ).run()
 
 


### PR DESCRIPTION
* In practice, RSI is used only for importing directories and not individual files (including by the load data tool).
* This PR removes support for importing individual files to eliminate this tech debt.
* This changes the command line flag from `--input_path` to `--input_dir`. To account for this change in the admin tool, we'll update [this code](https://github.com/datacommonsorg/website/blob/fa272ab47c70de1e5af47c681b887046152b6e25/server/routes/admin/html.py#L64) in the website repo when updating its submodules.