### PR TITLE
Use default GCP creds in docker container.

### DIFF
--- a/build/ci/cloudbuild.push_simple.yaml
+++ b/build/ci/cloudbuild.push_simple.yaml
@@ -21,6 +21,7 @@ steps:
       - |
         set -e
         docker build -f build/simple/Dockerfile \
+          --network=cloudbuild \
           -t gcr.io/datcom-ci/datacommons-simple:$SHORT_SHA \
           -t gcr.io/datcom-ci/datacommons-simple:latest \
           .

--- a/build/simple/run.sh
+++ b/build/simple/run.sh
@@ -25,6 +25,10 @@ else
     export OUTPUT_DIR=/output/
 fi
 
+echo "DC_API_KEY=$DC_API_KEY"
+echo "INPUT_DIR=$INPUT_DIR"
+echo "OUTPUT_DIR=$INPUT_DIR"
+
 python3 -m stats.main \
     --mode=maindc \
     --input_dir=$INPUT_DIR \


### PR DESCRIPTION
* Uses `--network=cloudbuild` flag when building the docker image. This enables the docker container to use default GCP creds. [[Reference]](https://cloud.google.com/build/docs/build-config-file-schema)
* With this change, we can create RSI jobs in Cloud Run that can use the project's service account to read / write from GCS.
* Will create a short guide for the team soon.
![image](https://github.com/datacommonsorg/import/assets/1221814/70980089-1f00-41b4-82f4-c404b1a14e9e)
![image](https://github.com/datacommonsorg/import/assets/1221814/6330f99d-0685-426b-afd2-14889914642c)
![image](https://github.com/datacommonsorg/import/assets/1221814/4a60a093-ec7b-47b7-aa46-44ad2a0be2ff)

