### PR TITLE
Add support for testing SVG hierarchy with MCF inputs.

### DIFF
--- a/simple/kg_util/mcf_parser.py
+++ b/simple/kg_util/mcf_parser.py
@@ -23,8 +23,8 @@ from csv import reader
 import dataclasses
 import sys
 
-_VALUE = 'VALUE'
-_ID = 'ID'
+VALUE = 'VALUE'
+ID = 'ID'
 _node = 'Node'
 _context = 'Context'
 _dcid = 'dcid'
@@ -109,28 +109,28 @@ def _parse_value(prop, value, pc):
         _as_err('malformed string', pc)
     value = _strip_quotes(value)
     if not expect_ref:
-      return (value, _VALUE)
+      return (value, VALUE)
 
   if _is_global_ref(value):
-    return (_strip_ns(value), _ID)
+    return (_strip_ns(value), ID)
 
   if _is_local_ref(value):
     # For local ref, we retain the prefix.
-    return (value, _ID)
+    return (value, ID)
 
   ns_prefix = value.split(':', 1)[0] + _delim
   if ns_prefix != value and ns_prefix in pc.ns_map:
     value = value.replace(ns_prefix, pc.ns_map[ns_prefix], 1)
-    return (value, _ID)
+    return (value, ID)
 
   if expect_ref:
     # If we're here, user likely forgot to add a "dcid:", "dcs:" or
     # "schema:" prefix.  We cannot tell apart if they failed to add an local
     # ref ('l:'), but we err on the side of user being careful about adding
     # local refs and accept the MCF without failing.
-    return (value, _ID)
+    return (value, ID)
 
-  return (value, _VALUE)
+  return (value, VALUE)
 
 
 def _parse_values(prop, values_str, pc):
@@ -208,7 +208,7 @@ def mcf_to_triples(mcf_file):
 
       # Finalize current node.
       if (pc.node and not pc.has_dcid and _is_global_ref(pc.node)):
-        yield [pc.node, _dcid, _strip_ns(pc.node), _VALUE]
+        yield [pc.node, _dcid, _strip_ns(pc.node), VALUE]
 
       # Update to new node.
       pc.node = val_str
@@ -233,7 +233,7 @@ def mcf_to_triples(mcf_file):
 
   # Finalize current node.
   if (pc.node and not pc.has_dcid and _is_global_ref(pc.node)):
-    yield [pc.node, _dcid, _strip_ns(pc.node), _VALUE]
+    yield [pc.node, _dcid, _strip_ns(pc.node), VALUE]
 
 
 if __name__ == '__main__':

--- a/simple/stats/stat_var_hierarchy_generator.py
+++ b/simple/stats/stat_var_hierarchy_generator.py
@@ -235,7 +235,7 @@ def _capitalize(s: str) -> str:
   return s[0].upper() + s[1:]
 
 
-# Capitalizes the first list and then splits any camel case strings.
+# Capitalizes the first letter and then splits any camel case strings.
 # e.g. "energySource" -> "EnergySource" -> "Energy Source"
 def _capitalize_and_split(s: str) -> str:
   return _split_camel_case(_capitalize(s))

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/basic_svgs.json
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/basic_svgs.json
@@ -1,5 +1,50 @@
 [
  {
+  "svg_id": "c/g/Person",
+  "svg_name": "Person",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "dc/g/Root"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Race",
+   "c/g/Person_Gender"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_Gender",
+  "svg_name": "Person With Gender",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Gender-Female"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_Gender-Female",
+  "svg_name": "Person With Gender = Female",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person_Gender"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Gender-Female_Race"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_Gender-Female_Race",
+  "svg_name": "Person With Gender = Female, Race",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person_Gender-Female"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Gender-Female_Race-Asian"
+  ]
+ },
+ {
   "svg_id": "c/g/Person_Gender-Female_Race-Asian",
   "svg_name": "Person With Gender = Female, Race = Asian",
   "sv_ids": [
@@ -23,17 +68,6 @@
   ]
  },
  {
-  "svg_id": "c/g/Person_Race-Asian",
-  "svg_name": "Person With Race = Asian",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Person_Race"
-  ],
-  "child_svg_ids": [
-   "c/g/Person_Gender_Race-Asian"
-  ]
- },
- {
   "svg_id": "c/g/Person_Race",
   "svg_name": "Person With Race",
   "sv_ids": [],
@@ -45,48 +79,14 @@
   ]
  },
  {
-  "svg_id": "c/g/Person",
-  "svg_name": "Person",
+  "svg_id": "c/g/Person_Race-Asian",
+  "svg_name": "Person With Race = Asian",
   "sv_ids": [],
   "parent_svg_ids": [
-   "dc/g/Root"
+   "c/g/Person_Race"
   ],
   "child_svg_ids": [
-   "c/g/Person_Race",
-   "c/g/Person_Gender"
-  ]
- },
- {
-  "svg_id": "c/g/Person_Gender-Female_Race",
-  "svg_name": "Person With Gender = Female, Race",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Person_Gender-Female"
-  ],
-  "child_svg_ids": [
-   "c/g/Person_Gender-Female_Race-Asian"
-  ]
- },
- {
-  "svg_id": "c/g/Person_Gender-Female",
-  "svg_name": "Person With Gender = Female",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Person_Gender"
-  ],
-  "child_svg_ids": [
-   "c/g/Person_Gender-Female_Race"
-  ]
- },
- {
-  "svg_id": "c/g/Person_Gender",
-  "svg_name": "Person With Gender",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Person"
-  ],
-  "child_svg_ids": [
-   "c/g/Person_Gender-Female"
+   "c/g/Person_Gender_Race-Asian"
   ]
  }
 ]

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/main_svgs.json
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/main_svgs.json
@@ -1,0 +1,134 @@
+[
+ {
+  "svg_id": "c/g/Person",
+  "svg_name": "Person",
+  "sv_ids": [
+   "Count_Person",
+   "dc/population"
+  ],
+  "parent_svg_ids": [
+   "dc/g/Root"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Race",
+   "c/g/Person_PovertyStatus"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_PovertyStatus",
+  "svg_name": "Person With Poverty Status",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_PovertyStatus-BelowPovertyLevelInThePast12Months",
+   "c/g/Person_PovertyStatus-AbovePovertyLevelInThePast12Months"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_PovertyStatus-AbovePovertyLevelInThePast12Months",
+  "svg_name": "Person With Poverty Status = Above Poverty Level In The Past12 Months",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person_PovertyStatus"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_PovertyStatus-AbovePovertyLevelInThePast12Months_Race"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_PovertyStatus-AbovePovertyLevelInThePast12Months_Race",
+  "svg_name": "Person With Poverty Status = Above Poverty Level In The Past12 Months, Race",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person_PovertyStatus-AbovePovertyLevelInThePast12Months"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_PovertyStatus-AbovePovertyLevelInThePast12Months_Race-WhiteAlone"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_PovertyStatus-AbovePovertyLevelInThePast12Months_Race-WhiteAlone",
+  "svg_name": "Person With Poverty Status = Above Poverty Level In The Past12 Months, Race = White Alone",
+  "sv_ids": [
+   "Count_Person_AbovePovertyLevelInThePast12Months_WhiteAlone"
+  ],
+  "parent_svg_ids": [
+   "c/g/Person_PovertyStatus_Race-WhiteAlone",
+   "c/g/Person_PovertyStatus-AbovePovertyLevelInThePast12Months_Race"
+  ],
+  "child_svg_ids": []
+ },
+ {
+  "svg_id": "c/g/Person_PovertyStatus-BelowPovertyLevelInThePast12Months",
+  "svg_name": "Person With Poverty Status = Below Poverty Level In The Past12 Months",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person_PovertyStatus"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_PovertyStatus-BelowPovertyLevelInThePast12Months_Race"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_PovertyStatus-BelowPovertyLevelInThePast12Months_Race",
+  "svg_name": "Person With Poverty Status = Below Poverty Level In The Past12 Months, Race",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person_PovertyStatus-BelowPovertyLevelInThePast12Months"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_PovertyStatus-BelowPovertyLevelInThePast12Months_Race-WhiteAlone"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_PovertyStatus-BelowPovertyLevelInThePast12Months_Race-WhiteAlone",
+  "svg_name": "Person With Poverty Status = Below Poverty Level In The Past12 Months, Race = White Alone",
+  "sv_ids": [
+   "UnknownMProp_Person_BelowPovertyLevelInThePast12Months_WhiteAlone",
+   "Count_Person_BelowPovertyLevelInThePast12Months_WhiteAlone"
+  ],
+  "parent_svg_ids": [
+   "c/g/Person_PovertyStatus_Race-WhiteAlone",
+   "c/g/Person_PovertyStatus-BelowPovertyLevelInThePast12Months_Race"
+  ],
+  "child_svg_ids": []
+ },
+ {
+  "svg_id": "c/g/Person_PovertyStatus_Race-WhiteAlone",
+  "svg_name": "Person With Poverty Status, Race = White Alone",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person_Race-WhiteAlone"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_PovertyStatus-BelowPovertyLevelInThePast12Months_Race-WhiteAlone",
+   "c/g/Person_PovertyStatus-AbovePovertyLevelInThePast12Months_Race-WhiteAlone"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_Race",
+  "svg_name": "Person With Race",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Race-WhiteAlone"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_Race-WhiteAlone",
+  "svg_name": "Person With Race = White Alone",
+  "sv_ids": [
+   "Count_Person_WhiteAlone"
+  ],
+  "parent_svg_ids": [
+   "c/g/Person_Race"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_PovertyStatus_Race-WhiteAlone"
+  ]
+ }
+]

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/three_unrelated_svs_svgs.json
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/three_unrelated_svs_svgs.json
@@ -1,19 +1,29 @@
 [
  {
-  "svg_id": "c/g/Person_Gender-Female_Race-Asian",
-  "svg_name": "Person With Gender = Female, Race = Asian",
-  "sv_ids": [
-   "sv1"
-  ],
+  "svg_id": "c/g/Coal",
+  "svg_name": "Coal",
+  "sv_ids": [],
   "parent_svg_ids": [
-   "c/g/Person_Gender_Race-Asian",
-   "c/g/Person_Gender-Female_Race"
+   "dc/g/Root"
   ],
-  "child_svg_ids": []
+  "child_svg_ids": [
+   "c/g/Coal_EnergySource"
+  ]
+ },
+ {
+  "svg_id": "c/g/Coal_EnergySource",
+  "svg_name": "Coal With Energy Source",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Coal"
+  ],
+  "child_svg_ids": [
+   "c/g/Coal_EnergySource-CokeCoal"
+  ]
  },
  {
   "svg_id": "c/g/Coal_EnergySource-CokeCoal",
-  "svg_name": "Coal With EnergySource = CokeCoal",
+  "svg_name": "Coal With Energy Source = Coke Coal",
   "sv_ids": [
    "sv2"
   ],
@@ -23,13 +33,59 @@
   "child_svg_ids": []
  },
  {
-  "svg_id": "c/g/Thing",
-  "svg_name": "Thing",
-  "sv_ids": [
-   "sv3"
-  ],
+  "svg_id": "c/g/Person",
+  "svg_name": "Person",
+  "sv_ids": [],
   "parent_svg_ids": [
    "dc/g/Root"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Race",
+   "c/g/Person_Gender"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_Gender",
+  "svg_name": "Person With Gender",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Gender-Female"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_Gender-Female",
+  "svg_name": "Person With Gender = Female",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person_Gender"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Gender-Female_Race"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_Gender-Female_Race",
+  "svg_name": "Person With Gender = Female, Race",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person_Gender-Female"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Gender-Female_Race-Asian"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_Gender-Female_Race-Asian",
+  "svg_name": "Person With Gender = Female, Race = Asian",
+  "sv_ids": [
+   "sv1"
+  ],
+  "parent_svg_ids": [
+   "c/g/Person_Gender_Race-Asian",
+   "c/g/Person_Gender-Female_Race"
   ],
   "child_svg_ids": []
  },
@@ -45,17 +101,6 @@
   ]
  },
  {
-  "svg_id": "c/g/Person_Race-Asian",
-  "svg_name": "Person With Race = Asian",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Person_Race"
-  ],
-  "child_svg_ids": [
-   "c/g/Person_Gender_Race-Asian"
-  ]
- },
- {
   "svg_id": "c/g/Person_Race",
   "svg_name": "Person With Race",
   "sv_ids": [],
@@ -67,70 +112,25 @@
   ]
  },
  {
-  "svg_id": "c/g/Person",
-  "svg_name": "Person",
+  "svg_id": "c/g/Person_Race-Asian",
+  "svg_name": "Person With Race = Asian",
   "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person_Race"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Gender_Race-Asian"
+  ]
+ },
+ {
+  "svg_id": "c/g/Thing",
+  "svg_name": "Thing",
+  "sv_ids": [
+   "sv3"
+  ],
   "parent_svg_ids": [
    "dc/g/Root"
   ],
-  "child_svg_ids": [
-   "c/g/Person_Race",
-   "c/g/Person_Gender"
-  ]
- },
- {
-  "svg_id": "c/g/Person_Gender-Female_Race",
-  "svg_name": "Person With Gender = Female, Race",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Person_Gender-Female"
-  ],
-  "child_svg_ids": [
-   "c/g/Person_Gender-Female_Race-Asian"
-  ]
- },
- {
-  "svg_id": "c/g/Person_Gender-Female",
-  "svg_name": "Person With Gender = Female",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Person_Gender"
-  ],
-  "child_svg_ids": [
-   "c/g/Person_Gender-Female_Race"
-  ]
- },
- {
-  "svg_id": "c/g/Person_Gender",
-  "svg_name": "Person With Gender",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Person"
-  ],
-  "child_svg_ids": [
-   "c/g/Person_Gender-Female"
-  ]
- },
- {
-  "svg_id": "c/g/Coal_EnergySource",
-  "svg_name": "Coal With EnergySource",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Coal"
-  ],
-  "child_svg_ids": [
-   "c/g/Coal_EnergySource-CokeCoal"
-  ]
- },
- {
-  "svg_id": "c/g/Coal",
-  "svg_name": "Coal",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "dc/g/Root"
-  ],
-  "child_svg_ids": [
-   "c/g/Coal_EnergySource"
-  ]
+  "child_svg_ids": []
  }
 ]

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/two_related_svs_svgs.json
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/two_related_svs_svgs.json
@@ -1,5 +1,51 @@
 [
  {
+  "svg_id": "c/g/Person",
+  "svg_name": "Person",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "dc/g/Root"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Race",
+   "c/g/Person_Gender"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_Gender",
+  "svg_name": "Person With Gender",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Gender-Female",
+   "c/g/Person_Gender-Male"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_Gender-Female",
+  "svg_name": "Person With Gender = Female",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person_Gender"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Gender-Female_Race"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_Gender-Female_Race",
+  "svg_name": "Person With Gender = Female, Race",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person_Gender-Female"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Gender-Female_Race-Asian"
+  ]
+ },
+ {
   "svg_id": "c/g/Person_Gender-Female_Race-Asian",
   "svg_name": "Person With Gender = Female, Race = Asian",
   "sv_ids": [
@@ -10,6 +56,28 @@
    "c/g/Person_Gender-Female_Race"
   ],
   "child_svg_ids": []
+ },
+ {
+  "svg_id": "c/g/Person_Gender-Male",
+  "svg_name": "Person With Gender = Male",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person_Gender"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Gender-Male_Race"
+  ]
+ },
+ {
+  "svg_id": "c/g/Person_Gender-Male_Race",
+  "svg_name": "Person With Gender = Male, Race",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "c/g/Person_Gender-Male"
+  ],
+  "child_svg_ids": [
+   "c/g/Person_Gender-Male_Race-Asian"
+  ]
  },
  {
   "svg_id": "c/g/Person_Gender-Male_Race-Asian",
@@ -36,17 +104,6 @@
   ]
  },
  {
-  "svg_id": "c/g/Person_Race-Asian",
-  "svg_name": "Person With Race = Asian",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Person_Race"
-  ],
-  "child_svg_ids": [
-   "c/g/Person_Gender_Race-Asian"
-  ]
- },
- {
   "svg_id": "c/g/Person_Race",
   "svg_name": "Person With Race",
   "sv_ids": [],
@@ -58,71 +115,14 @@
   ]
  },
  {
-  "svg_id": "c/g/Person",
-  "svg_name": "Person",
+  "svg_id": "c/g/Person_Race-Asian",
+  "svg_name": "Person With Race = Asian",
   "sv_ids": [],
   "parent_svg_ids": [
-   "dc/g/Root"
+   "c/g/Person_Race"
   ],
   "child_svg_ids": [
-   "c/g/Person_Race",
-   "c/g/Person_Gender"
-  ]
- },
- {
-  "svg_id": "c/g/Person_Gender-Female_Race",
-  "svg_name": "Person With Gender = Female, Race",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Person_Gender-Female"
-  ],
-  "child_svg_ids": [
-   "c/g/Person_Gender-Female_Race-Asian"
-  ]
- },
- {
-  "svg_id": "c/g/Person_Gender-Female",
-  "svg_name": "Person With Gender = Female",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Person_Gender"
-  ],
-  "child_svg_ids": [
-   "c/g/Person_Gender-Female_Race"
-  ]
- },
- {
-  "svg_id": "c/g/Person_Gender",
-  "svg_name": "Person With Gender",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Person"
-  ],
-  "child_svg_ids": [
-   "c/g/Person_Gender-Female",
-   "c/g/Person_Gender-Male"
-  ]
- },
- {
-  "svg_id": "c/g/Person_Gender-Male_Race",
-  "svg_name": "Person With Gender = Male, Race",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Person_Gender-Male"
-  ],
-  "child_svg_ids": [
-   "c/g/Person_Gender-Male_Race-Asian"
-  ]
- },
- {
-  "svg_id": "c/g/Person_Gender-Male",
-  "svg_name": "Person With Gender = Male",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "c/g/Person_Gender"
-  ],
-  "child_svg_ids": [
-   "c/g/Person_Gender-Male_Race"
+   "c/g/Person_Gender_Race-Asian"
   ]
  }
 ]

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/input/main.mcf
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/input/main.mcf
@@ -1,0 +1,50 @@
+Node: dcid:Count_Person
+typeOf: dcs:StatisticalVariable
+populationType: schema:Person
+measuredProperty: dcs:count
+statType: dcs:measuredValue
+
+# This should be ignored.
+Node: dcid:dc/population
+typeOf: dcs:StatisticalVariable
+populationType: schema:Person
+measuredProperty: dcs:count
+statType: dcs:measuredValue
+
+# This SV should not cause dc/g/Person_PovertyStatus SVG to go under
+# Uncategorized
+Node: dcid:UnknownMProp_Person_BelowPovertyLevelInThePast12Months_WhiteAlone
+typeOf: dcs:StatisticalVariable
+populationType: schema:Person
+measuredProperty: dcs:unknownMProp
+statType: dcs:measuredValue
+race: dcs:WhiteAlone
+povertyStatus: dcs:BelowPovertyLevelInThePast12Months
+constraintProperties: dcs:race, dcs:povertyStatus
+
+Node: dcid:Count_Person_WhiteAlone
+typeOf: dcs:StatisticalVariable
+populationType: schema:Person
+measuredProperty: dcs:count
+statType: dcs:measuredValue
+race: dcs:WhiteAlone
+constraintProperties: dcs:race
+
+Node: dcid:Count_Person_BelowPovertyLevelInThePast12Months_WhiteAlone
+typeOf: dcs:StatisticalVariable
+populationType: schema:Person
+measuredProperty: dcs:count
+statType: dcs:measuredValue
+race: dcs:WhiteAlone
+povertyStatus: dcs:BelowPovertyLevelInThePast12Months
+constraintProperties: dcs:race, dcs:povertyStatus
+description: "Population of white people living below poverty line"
+
+Node: dcid:Count_Person_AbovePovertyLevelInThePast12Months_WhiteAlone
+typeOf: dcs:StatisticalVariable
+populationType: schema:Person
+measuredProperty: dcs:count
+statType: dcs:measuredValue
+race: dcs:WhiteAlone
+povertyStatus: dcs:AbovePovertyLevelInThePast12Months
+constraintProperties: dcs:race, dcs:povertyStatus


### PR DESCRIPTION
* Added test for [main.in.mcf](https://source.corp.google.com/piper///depot/google3/datacommons/prophet/flume_generator/test_data/svg/main.in.mcf) from G3 and can add tests for more over time.
* Fixed a bug where if there were multiple SVs in the same leaf, it only added one of them. (Testing `main.in.mcf` surfaced this bug.)
* Changed the SVG output to be sorted by SVG ID - makes it easier to follow the hierarchy visually.
* Also, separating camel case words when generating SVG names now to make the names consistent with main DC generated names.