### PR TITLE
Remove namespace prefixes from dcids when inserting into the observations table.

### DIFF
--- a/simple/stats/db.py
+++ b/simple/stats/db.py
@@ -239,8 +239,9 @@ def to_triple_tuple(triple: Triple):
 
 
 def to_observation_tuple(observation: Observation):
-  return (observation.entity, observation.variable, observation.date,
-          observation.value, observation.provenance)
+  return (_strip_namespace(observation.entity),
+          _strip_namespace(observation.variable), observation.date,
+          observation.value, _strip_namespace(observation.provenance))
 
 
 def _strip_namespace(v: str) -> str:

--- a/simple/tests/stats/test_data/variable_per_row_importer/expected/namespace_prefixes.db.csv
+++ b/simple/tests/stats/test_data/variable_per_row_importer/expected/namespace_prefixes.db.csv
@@ -1,0 +1,7 @@
+entity,variable,date,value,provenance
+country/BRA,var1,2023,0.19,c/p/default
+country/BRA,var2,2023,6,c/p/default
+country/JPN,var1,2023,0.21,c/p/default
+country/JPN,var2,2023,56,c/p/default
+country/USA,var2,2023,66,c/p/default
+country/CHN,var1,2022,-123.456,c/p/default

--- a/simple/tests/stats/test_data/variable_per_row_importer/input/namespace_prefixes.csv
+++ b/simple/tests/stats/test_data/variable_per_row_importer/input/namespace_prefixes.csv
@@ -1,0 +1,7 @@
+variable,entity,date,value
+dcs:var1,dcid:country/BRA,2023,0.19
+dcs:var2,dcid:country/BRA,2023,6
+var1,dcid:country/JPN,2023,0.21
+var2,dcid:country/JPN,2023,56
+var2,country/USA,2023,66
+var1,country/CHN,2022,-123.456

--- a/simple/tests/stats/variable_per_row_importer_test.py
+++ b/simple/tests/stats/variable_per_row_importer_test.py
@@ -104,3 +104,6 @@ class TestVariablePerRowImporter(unittest.TestCase):
                      "variable": "Observed Variable",
                      "entity": "Observed Location"
                  })
+
+  def test_namespace_prefixes(self):
+    _test_import(self, "namespace_prefixes")


### PR DESCRIPTION
* Ran into this issue when import UN WHO files.
* Namespaces are already removed when inserting into the triples table.