### PR TITLE
Put SVGs under a hierarchy root.

### DIFF
--- a/simple/stats/nodes.py
+++ b/simple/stats/nodes.py
@@ -86,6 +86,9 @@ class Nodes:
     self._event_type_generated_id_count = 0
     # Used to generate entity type IDs
     self._entity_type_generated_id_count = 0
+    # If generating SV hierarchy, create default custom dc group at the outset.
+    if config.generate_hierarchy():
+      self.group("")
 
   def _load_provenances_and_sources(self):
     # Load default source and provenance.

--- a/simple/stats/nodes.py
+++ b/simple/stats/nodes.py
@@ -27,6 +27,7 @@ from stats.data import Source
 from stats.data import StatVar
 from stats.data import StatVarGroup
 from stats.data import Triple
+import stats.schema_constants as sc
 from util.filehandler import FileHandler
 
 _CUSTOM_SV_ID_PREFIX = "custom/statvar_"
@@ -36,15 +37,15 @@ _CUSTOM_SOURCE_ID_PREFIX = "c/s/"
 _CUSTOM_PROPERTY_ID_PREFIX = "c/prop/"
 _CUSTOM_EVENT_TYPE_ID_PREFIX = "c/e/"
 _CUSTOM_ENTITY_TYPE_ID_PREFIX = "c/n/"
-_ROOT_GROUP_ID = "dc/g/Root"
 # Pattern to check if a string conforms to that of a valid DCID.
 # Note that slashes ("/") are intentionally not considered here
 # since it can be confusing for custom DCs.
 _DCID_PATTERN = r"^[A-Za-z0-9_]+$"
 # If group path for a variable is empty, we'll put it under a default custom group.
 _DEFAULT_CUSTOM_GROUP_PATH = "__DEFAULT__"
-_DEFAULT_CUSTOM_GROUP = StatVarGroup("custom/g/Root", "Custom Variables",
-                                     _ROOT_GROUP_ID)
+_DEFAULT_CUSTOM_GROUP = StatVarGroup(sc.DEFAULT_CUSTOM_ROOT_SVG_ID,
+                                     sc.DEFAULT_CUSTOM_ROOT_SVG_NAME,
+                                     sc.ROOT_SVG_ID)
 
 _DEFAULT_SOURCE = Source(f"{_CUSTOM_SOURCE_ID_PREFIX}default",
                          "Custom Data Commons")
@@ -127,7 +128,7 @@ class Nodes:
     if not sv_column_name in self.variables:
       var_cfg = self.config.variable(sv_column_name)
       group = self.group(var_cfg.group_path)
-      group_id = group.id if group else _ROOT_GROUP_ID
+      group_id = group.id if group else sc.ROOT_SVG_ID
       self.variables[sv_column_name] = StatVar(
           self._sv_id(sv_column_name),
           var_cfg.name,
@@ -237,7 +238,7 @@ class Nodes:
       if path not in self.groups:
         parent_path = "" if "/" not in path else path[:path.rindex("/")]
         parent_id = (self.groups[parent_path].id
-                     if parent_path in self.groups else _ROOT_GROUP_ID)
+                     if parent_path in self.groups else sc.ROOT_SVG_ID)
         svg = StatVarGroup(f"{_CUSTOM_GROUP_ID_PREFIX}{len(self.groups) + 1}",
                            tokens[index], parent_id)
         self.groups[path] = svg

--- a/simple/stats/runner.py
+++ b/simple/stats/runner.py
@@ -184,6 +184,10 @@ class Runner:
     svg_triples = stat_var_hierarchy_generator.generate(sv_triples)
     logging.info("Inserting %s SVG triples into DB.", len(svg_triples))
     self.db.insert_triples(svg_triples)
+    # SVG triples are put under the default custom dc root group.
+    # Ensure that the default group is always created in that case.
+    if svg_triples:
+      self.nodes.group("")
 
   def _run_imports(self):
     input_fhs: list[FileHandler] = []

--- a/simple/stats/runner.py
+++ b/simple/stats/runner.py
@@ -184,10 +184,6 @@ class Runner:
     svg_triples = stat_var_hierarchy_generator.generate(sv_triples)
     logging.info("Inserting %s SVG triples into DB.", len(svg_triples))
     self.db.insert_triples(svg_triples)
-    # SVG triples are put under the default custom dc root group.
-    # Ensure that the default group is always created in that case.
-    if svg_triples:
-      self.nodes.group("")
 
   def _run_imports(self):
     input_fhs: list[FileHandler] = []

--- a/simple/stats/schema_constants.py
+++ b/simple/stats/schema_constants.py
@@ -41,3 +41,7 @@ DEFAULT_POPULATION_TYPE = "Thing"
 
 CUSTOM_SVG_PREFIX = "c/g/"
 ROOT_SVG_ID = "dc/g/Root"
+
+# SV hierarchy groups will be put under this root.
+HIERARCHY_ROOT_SVG_ID = f"{CUSTOM_SVG_PREFIX}hierarchy"
+HIERARCHY_ROOT_SVG_NAME = "Hierarchy"

--- a/simple/stats/schema_constants.py
+++ b/simple/stats/schema_constants.py
@@ -42,6 +42,5 @@ DEFAULT_POPULATION_TYPE = "Thing"
 CUSTOM_SVG_PREFIX = "c/g/"
 ROOT_SVG_ID = "dc/g/Root"
 
-# SV hierarchy groups will be put under this root.
-HIERARCHY_ROOT_SVG_ID = f"{CUSTOM_SVG_PREFIX}hierarchy"
-HIERARCHY_ROOT_SVG_NAME = "Hierarchy"
+DEFAULT_CUSTOM_ROOT_SVG_ID = f"{CUSTOM_SVG_PREFIX}Root"
+DEFAULT_CUSTOM_ROOT_SVG_NAME = "Custom Variables"

--- a/simple/stats/stat_var_hierarchy_generator.py
+++ b/simple/stats/stat_var_hierarchy_generator.py
@@ -47,18 +47,14 @@ representing the hierarchy.
   svgs = _create_all_svgs(svs)
   # Sort by SVG ID so it's easier to follow the hierarchy.
   svgs = dict(sorted(svgs.items()))
-  # Create hierarchy root SVG.
-  root_svg = _create_hierarchy_root_svg()
 
   # Get pop type svgs (they don't have a parent set at this stage).
   pop_type_svgs = _get_svgs_with_no_parent(svgs)
   # Attach verticals to pop type svgs.
-  _attach_verticals(pop_type_svgs, root_svg)
+  _attach_verticals(pop_type_svgs)
 
-  # Combine all SVGs - root, verticals (TODO) and hierarchy.
+  # Combine all SVGs - verticals (TODO) and hierarchy.
   final_svgs: dict[str, SVG] = {}
-  # Add root.
-  final_svgs[root_svg.svg_id] = root_svg
   # TODO: add verticals.
   # Add hierarchy.
   final_svgs.update(svgs)
@@ -178,16 +174,15 @@ class StatVarHierarchy:
   svg_triples: list[Triple]
 
 
-def _attach_verticals(pop_type_svgs: list[SVG], root_svg: SVG):
+def _attach_verticals(pop_type_svgs: list[SVG]):
   # For now, we put all pop type svgs under the root svg.
   # TODO: pass vertical specs to this function and implement vertical tagging here.
   for svg in pop_type_svgs:
-    svg.parent_svg_ids[sc.HIERARCHY_ROOT_SVG_ID] = True
-    root_svg.child_svg_ids[svg.svg_id] = True
+    svg.parent_svg_ids[sc.DEFAULT_CUSTOM_ROOT_SVG_ID] = True
 
 
 def _create_hierarchy_root_svg() -> SVG:
-  svg = SVG(sc.HIERARCHY_ROOT_SVG_ID, sc.HIERARCHY_ROOT_SVG_NAME)
+  svg = SVG(sc.DEFAULT_CUSTOM_ROOT_SVG_ID, sc.DEFAULT_CUSTOM_ROOT_SVG_NAME)
   svg.parent_svg_ids[sc.ROOT_SVG_ID] = True
   return svg
 

--- a/simple/stats/stat_var_hierarchy_generator.py
+++ b/simple/stats/stat_var_hierarchy_generator.py
@@ -47,9 +47,25 @@ representing the hierarchy.
   svgs = _create_all_svgs(svs)
   # Sort by SVG ID so it's easier to follow the hierarchy.
   svgs = dict(sorted(svgs.items()))
+  # Create hierarchy root SVG.
+  root_svg = _create_hierarchy_root_svg()
+
+  # Get pop type svgs (they don't have a parent set at this stage).
+  pop_type_svgs = _get_svgs_with_no_parent(svgs)
+  # Attach verticals to pop type svgs.
+  _attach_verticals(pop_type_svgs, root_svg)
+
+  # Combine all SVGs - root, verticals (TODO) and hierarchy.
+  final_svgs: dict[str, SVG] = {}
+  # Add root.
+  final_svgs[root_svg.svg_id] = root_svg
+  # TODO: add verticals.
+  # Add hierarchy.
+  final_svgs.update(svgs)
+
   # Generate SVG triples.
-  svg_triples = _create_all_svg_triples(svgs)
-  return StatVarHierarchy(svgs=svgs, svg_triples=svg_triples)
+  svg_triples = _create_all_svg_triples(final_svgs)
+  return StatVarHierarchy(svgs=final_svgs, svg_triples=svg_triples)
 
 
 @dataclass(eq=True, frozen=True)
@@ -162,6 +178,24 @@ class StatVarHierarchy:
   svg_triples: list[Triple]
 
 
+def _attach_verticals(pop_type_svgs: list[SVG], root_svg: SVG):
+  # For now, we put all pop type svgs under the root svg.
+  # TODO: pass vertical specs to this function and implement vertical tagging here.
+  for svg in pop_type_svgs:
+    svg.parent_svg_ids[sc.HIERARCHY_ROOT_SVG_ID] = True
+    root_svg.child_svg_ids[svg.svg_id] = True
+
+
+def _create_hierarchy_root_svg() -> SVG:
+  svg = SVG(sc.HIERARCHY_ROOT_SVG_ID, sc.HIERARCHY_ROOT_SVG_NAME)
+  svg.parent_svg_ids[sc.ROOT_SVG_ID] = True
+  return svg
+
+
+def _get_svgs_with_no_parent(svgs: dict[str, SVG]) -> list[SVG]:
+  return list(filter(lambda svg: not svg.parent_svg_ids, svgs.values()))
+
+
 def _get_or_create_svg(svgs: dict[str, SVG], sv: SVPropVals) -> SVG:
   svg_id = sv.gen_svg_id()
   svg = svgs.get(svg_id)
@@ -213,10 +247,9 @@ def _create_parent_svgs(svg_id: str, svgs: dict[str, SVG]):
   svg = svgs[svg_id]
   sv = svg.sample_sv
 
-  # If no PVs left, we've reached the top of the population type hierarchy.
-  # Attach it to the DC root and return.
+  # If no PVs left, we've reached the top of the population type hierarchy and we simply return.
+  # We'll attach it to verticals or the root upstream.
   if not sv.pvs:
-    svg.parent_svg_ids[sc.ROOT_SVG_ID] = True
     return
 
   # Process SVGs without a val

--- a/simple/tests/stats/nodes_test.py
+++ b/simple/tests/stats/nodes_test.py
@@ -157,7 +157,7 @@ class TestNodes(unittest.TestCase):
         StatVar(
             "Variable_with_no_config",
             "Variable with no config",
-            group_id="custom/g/Root",
+            group_id="c/g/Root",
             provenance_ids=["c/p/1"],
             source_ids=["c/s/1"],
         ),

--- a/simple/tests/stats/test_data/events_importer/expected/countryalpha3codes.triples.db.csv
+++ b/simple/tests/stats/test_data/events_importer/expected/countryalpha3codes.triples.db.csv
@@ -69,12 +69,12 @@ c/p/1,typeOf,Provenance,
 c/p/1,name,,Test Provenance
 c/p/1,source,c/s/1,
 c/p/1,url,,http://source.com/provenance
-custom/g/Root,typeOf,StatVarGroup,
-custom/g/Root,name,,Custom Variables
-custom/g/Root,specializationOf,dc/g/Root,
+c/g/Root,typeOf,StatVarGroup,
+c/g/Root,name,,Custom Variables
+c/g/Root,specializationOf,dc/g/Root,
 Count_CrimeEvent,typeOf,StatisticalVariable,
 Count_CrimeEvent,name,,Count_CrimeEvent
-Count_CrimeEvent,memberOf,custom/g/Root,
+Count_CrimeEvent,memberOf,c/g/Root,
 Count_CrimeEvent,includedIn,c/p/1,
 Count_CrimeEvent,includedIn,c/s/1,
 Count_CrimeEvent,populationType,Thing,

--- a/simple/tests/stats/test_data/events_importer/expected/idcolumns.triples.db.csv
+++ b/simple/tests/stats/test_data/events_importer/expected/idcolumns.triples.db.csv
@@ -69,12 +69,12 @@ c/p/1,typeOf,Provenance,
 c/p/1,name,,Test Provenance
 c/p/1,source,c/s/1,
 c/p/1,url,,http://source.com/provenance
-custom/g/Root,typeOf,StatVarGroup,
-custom/g/Root,name,,Custom Variables
-custom/g/Root,specializationOf,dc/g/Root,
+c/g/Root,typeOf,StatVarGroup,
+c/g/Root,name,,Custom Variables
+c/g/Root,specializationOf,dc/g/Root,
 Crime_Event2_Count,typeOf,StatisticalVariable,
 Crime_Event2_Count,name,,Number of Crime2 Events
-Crime_Event2_Count,memberOf,custom/g/Root,
+Crime_Event2_Count,memberOf,c/g/Root,
 Crime_Event2_Count,includedIn,c/p/1,
 Crime_Event2_Count,includedIn,c/s/1,
 Crime_Event2_Count,populationType,Thing,

--- a/simple/tests/stats/test_data/nodes/expected/triples.csv
+++ b/simple/tests/stats/test_data/nodes/expected/triples.csv
@@ -30,9 +30,9 @@ custom/g/group_3,name,,Child Group 2
 custom/g/group_3,specializationOf,custom/g/group_1,
 custom/g/group_3,includedIn,c/p/default,
 custom/g/group_3,includedIn,c/s/default,
-custom/g/Root,typeOf,StatVarGroup,
-custom/g/Root,name,,Custom Variables
-custom/g/Root,specializationOf,dc/g/Root,
+c/g/Root,typeOf,StatVarGroup,
+c/g/Root,name,,Custom Variables
+c/g/Root,specializationOf,dc/g/Root,
 Variable_1,typeOf,StatisticalVariable,
 Variable_1,name,,Variable 1
 Variable_1,memberOf,custom/g/group_2,
@@ -62,7 +62,7 @@ var3,statType,dcs:measuredValue,
 var3,measuredProperty,dcs:var3,
 Variable_with_no_config,typeOf,StatisticalVariable,
 Variable_with_no_config,name,,Variable with no config
-Variable_with_no_config,memberOf,custom/g/Root,
+Variable_with_no_config,memberOf,c/g/Root,
 Variable_with_no_config,includedIn,c/p/default,
 Variable_with_no_config,includedIn,c/s/default,
 Variable_with_no_config,populationType,schema:Thing,

--- a/simple/tests/stats/test_data/runner/expected/config_driven/triples.db.csv
+++ b/simple/tests/stats/test_data/runner/expected/config_driven/triples.db.csv
@@ -45,12 +45,12 @@ c/p/1,typeOf,Provenance,
 c/p/1,name,,Provenance1 Name
 c/p/1,source,c/s/1,
 c/p/1,url,,http://source1.com/provenance1
-custom/g/Root,typeOf,StatVarGroup,
-custom/g/Root,name,,Custom Variables
-custom/g/Root,specializationOf,dc/g/Root,
+c/g/Root,typeOf,StatVarGroup,
+c/g/Root,name,,Custom Variables
+c/g/Root,specializationOf,dc/g/Root,
 var1,typeOf,StatisticalVariable,
 var1,name,,var1
-var1,memberOf,custom/g/Root,
+var1,memberOf,c/g/Root,
 var1,includedIn,c/p/1,
 var1,includedIn,c/s/1,
 var1,populationType,Thing,
@@ -58,7 +58,7 @@ var1,statType,measuredValue,
 var1,measuredProperty,var1,
 var2,typeOf,StatisticalVariable,
 var2,name,,var2
-var2,memberOf,custom/g/Root,
+var2,memberOf,c/g/Root,
 var2,includedIn,c/p/1,
 var2,includedIn,c/s/1,
 var2,populationType,Thing,

--- a/simple/tests/stats/test_data/runner/expected/config_with_wildcards/triples.db.csv
+++ b/simple/tests/stats/test_data/runner/expected/config_with_wildcards/triples.db.csv
@@ -13,12 +13,12 @@ c/p/1,typeOf,Provenance,
 c/p/1,name,,Provenance1 Name
 c/p/1,source,c/s/1,
 c/p/1,url,,http://source1.com/provenance1
-custom/g/Root,typeOf,StatVarGroup,
-custom/g/Root,name,,Custom Variables
-custom/g/Root,specializationOf,dc/g/Root,
+c/g/Root,typeOf,StatVarGroup,
+c/g/Root,name,,Custom Variables
+c/g/Root,specializationOf,dc/g/Root,
 var1,typeOf,StatisticalVariable,
 var1,name,,var1
-var1,memberOf,custom/g/Root,
+var1,memberOf,c/g/Root,
 var1,includedIn,c/p/1,
 var1,includedIn,c/s/1,
 var1,populationType,Thing,
@@ -26,7 +26,7 @@ var1,statType,measuredValue,
 var1,measuredProperty,var1,
 var2,typeOf,StatisticalVariable,
 var2,name,,var2
-var2,memberOf,custom/g/Root,
+var2,memberOf,c/g/Root,
 var2,includedIn,c/p/1,
 var2,includedIn,c/s/1,
 var2,populationType,Thing,

--- a/simple/tests/stats/test_data/runner/expected/generate_svg_hierarchy/triples.db.csv
+++ b/simple/tests/stats/test_data/runner/expected/generate_svg_hierarchy/triples.db.csv
@@ -25,9 +25,12 @@ c/p/1,typeOf,Provenance,
 c/p/1,name,,Provenance1
 c/p/1,source,c/s/1,
 c/p/1,url,,http://source1.com/provenance1
+c/g/hierarchy,typeOf,StatVarGroup,
+c/g/hierarchy,name,,Hierarchy
+c/g/hierarchy,specializationOf,dc/g/Root,
 c/g/Person,typeOf,StatVarGroup,
 c/g/Person,name,,Person
-c/g/Person,specializationOf,dc/g/Root,
+c/g/Person,specializationOf,c/g/hierarchy,
 c/g/Person_Gender,typeOf,StatVarGroup,
 c/g/Person_Gender,name,,Person With Gender
 c/g/Person_Gender,specializationOf,c/g/Person,

--- a/simple/tests/stats/test_data/runner/expected/generate_svg_hierarchy/triples.db.csv
+++ b/simple/tests/stats/test_data/runner/expected/generate_svg_hierarchy/triples.db.csv
@@ -25,6 +25,9 @@ c/p/1,typeOf,Provenance,
 c/p/1,name,,Provenance1
 c/p/1,source,c/s/1,
 c/p/1,url,,http://source1.com/provenance1
+c/g/Root,typeOf,StatVarGroup,
+c/g/Root,name,,Custom Variables
+c/g/Root,specializationOf,dc/g/Root,
 c/g/Person,typeOf,StatVarGroup,
 c/g/Person,name,,Person
 c/g/Person,specializationOf,c/g/Root,

--- a/simple/tests/stats/test_data/runner/expected/generate_svg_hierarchy/triples.db.csv
+++ b/simple/tests/stats/test_data/runner/expected/generate_svg_hierarchy/triples.db.csv
@@ -25,12 +25,9 @@ c/p/1,typeOf,Provenance,
 c/p/1,name,,Provenance1
 c/p/1,source,c/s/1,
 c/p/1,url,,http://source1.com/provenance1
-c/g/hierarchy,typeOf,StatVarGroup,
-c/g/hierarchy,name,,Hierarchy
-c/g/hierarchy,specializationOf,dc/g/Root,
 c/g/Person,typeOf,StatVarGroup,
 c/g/Person,name,,Person
-c/g/Person,specializationOf,c/g/hierarchy,
+c/g/Person,specializationOf,c/g/Root,
 c/g/Person_Gender,typeOf,StatVarGroup,
 c/g/Person_Gender,name,,Person With Gender
 c/g/Person_Gender,specializationOf,c/g/Person,

--- a/simple/tests/stats/test_data/runner/expected/input_dir_driven/triples.db.csv
+++ b/simple/tests/stats/test_data/runner/expected/input_dir_driven/triples.db.csv
@@ -53,12 +53,12 @@ c/p/1,typeOf,Provenance,
 c/p/1,name,,Provenance1 Name
 c/p/1,source,c/s/1,
 c/p/1,url,,http://source1.com/provenance1
-custom/g/Root,typeOf,StatVarGroup,
-custom/g/Root,name,,Custom Variables
-custom/g/Root,specializationOf,dc/g/Root,
+c/g/Root,typeOf,StatVarGroup,
+c/g/Root,name,,Custom Variables
+c/g/Root,specializationOf,dc/g/Root,
 var1,typeOf,StatisticalVariable,
 var1,name,,var1
-var1,memberOf,custom/g/Root,
+var1,memberOf,c/g/Root,
 var1,includedIn,c/p/1,
 var1,includedIn,c/s/1,
 var1,populationType,Thing,
@@ -66,7 +66,7 @@ var1,statType,measuredValue,
 var1,measuredProperty,var1,
 var2,typeOf,StatisticalVariable,
 var2,name,,var2
-var2,memberOf,custom/g/Root,
+var2,memberOf,c/g/Root,
 var2,includedIn,c/p/1,
 var2,includedIn,c/s/1,
 var2,populationType,Thing,

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/basic_svgs.json
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/basic_svgs.json
@@ -1,21 +1,10 @@
 [
  {
-  "svg_id": "c/g/hierarchy",
-  "svg_name": "Hierarchy",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "dc/g/Root"
-  ],
-  "child_svg_ids": [
-   "c/g/Person"
-  ]
- },
- {
   "svg_id": "c/g/Person",
   "svg_name": "Person",
   "sv_ids": [],
   "parent_svg_ids": [
-   "c/g/hierarchy"
+   "c/g/Root"
   ],
   "child_svg_ids": [
    "c/g/Person_Race",

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/basic_svgs.json
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/basic_svgs.json
@@ -1,10 +1,21 @@
 [
  {
+  "svg_id": "c/g/hierarchy",
+  "svg_name": "Hierarchy",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "dc/g/Root"
+  ],
+  "child_svg_ids": [
+   "c/g/Person"
+  ]
+ },
+ {
   "svg_id": "c/g/Person",
   "svg_name": "Person",
   "sv_ids": [],
   "parent_svg_ids": [
-   "dc/g/Root"
+   "c/g/hierarchy"
   ],
   "child_svg_ids": [
    "c/g/Person_Race",

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/basic_triples.csv
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/basic_triples.csv
@@ -1,7 +1,10 @@
 subject_id,predicate,object_id,object_value
+c/g/hierarchy,typeOf,StatVarGroup,
+c/g/hierarchy,name,,Hierarchy
+c/g/hierarchy,specializationOf,dc/g/Root,
 c/g/Person,typeOf,StatVarGroup,
 c/g/Person,name,,Person
-c/g/Person,specializationOf,dc/g/Root,
+c/g/Person,specializationOf,c/g/hierarchy,
 c/g/Person_Gender,typeOf,StatVarGroup,
 c/g/Person_Gender,name,,Person With Gender
 c/g/Person_Gender,specializationOf,c/g/Person,

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/basic_triples.csv
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/basic_triples.csv
@@ -1,10 +1,7 @@
 subject_id,predicate,object_id,object_value
-c/g/hierarchy,typeOf,StatVarGroup,
-c/g/hierarchy,name,,Hierarchy
-c/g/hierarchy,specializationOf,dc/g/Root,
 c/g/Person,typeOf,StatVarGroup,
 c/g/Person,name,,Person
-c/g/Person,specializationOf,c/g/hierarchy,
+c/g/Person,specializationOf,c/g/Root,
 c/g/Person_Gender,typeOf,StatVarGroup,
 c/g/Person_Gender,name,,Person With Gender
 c/g/Person_Gender,specializationOf,c/g/Person,

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/main_svgs.json
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/main_svgs.json
@@ -1,5 +1,16 @@
 [
  {
+  "svg_id": "c/g/hierarchy",
+  "svg_name": "Hierarchy",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "dc/g/Root"
+  ],
+  "child_svg_ids": [
+   "c/g/Person"
+  ]
+ },
+ {
   "svg_id": "c/g/Person",
   "svg_name": "Person",
   "sv_ids": [
@@ -7,7 +18,7 @@
    "dc/population"
   ],
   "parent_svg_ids": [
-   "dc/g/Root"
+   "c/g/hierarchy"
   ],
   "child_svg_ids": [
    "c/g/Person_Race",

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/main_svgs.json
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/main_svgs.json
@@ -1,16 +1,5 @@
 [
  {
-  "svg_id": "c/g/hierarchy",
-  "svg_name": "Hierarchy",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "dc/g/Root"
-  ],
-  "child_svg_ids": [
-   "c/g/Person"
-  ]
- },
- {
   "svg_id": "c/g/Person",
   "svg_name": "Person",
   "sv_ids": [
@@ -18,7 +7,7 @@
    "dc/population"
   ],
   "parent_svg_ids": [
-   "c/g/hierarchy"
+   "c/g/Root"
   ],
   "child_svg_ids": [
    "c/g/Person_Race",

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/main_triples.csv
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/main_triples.csv
@@ -1,7 +1,10 @@
 subject_id,predicate,object_id,object_value
+c/g/hierarchy,typeOf,StatVarGroup,
+c/g/hierarchy,name,,Hierarchy
+c/g/hierarchy,specializationOf,dc/g/Root,
 c/g/Person,typeOf,StatVarGroup,
 c/g/Person,name,,Person
-c/g/Person,specializationOf,dc/g/Root,
+c/g/Person,specializationOf,c/g/hierarchy,
 Count_Person,memberOf,c/g/Person,
 dc/population,memberOf,c/g/Person,
 c/g/Person_PovertyStatus,typeOf,StatVarGroup,

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/main_triples.csv
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/main_triples.csv
@@ -1,10 +1,7 @@
 subject_id,predicate,object_id,object_value
-c/g/hierarchy,typeOf,StatVarGroup,
-c/g/hierarchy,name,,Hierarchy
-c/g/hierarchy,specializationOf,dc/g/Root,
 c/g/Person,typeOf,StatVarGroup,
 c/g/Person,name,,Person
-c/g/Person,specializationOf,c/g/hierarchy,
+c/g/Person,specializationOf,c/g/Root,
 Count_Person,memberOf,c/g/Person,
 dc/population,memberOf,c/g/Person,
 c/g/Person_PovertyStatus,typeOf,StatVarGroup,

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/three_unrelated_svs_svgs.json
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/three_unrelated_svs_svgs.json
@@ -1,23 +1,10 @@
 [
  {
-  "svg_id": "c/g/hierarchy",
-  "svg_name": "Hierarchy",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "dc/g/Root"
-  ],
-  "child_svg_ids": [
-   "c/g/Coal",
-   "c/g/Person",
-   "c/g/Thing"
-  ]
- },
- {
   "svg_id": "c/g/Coal",
   "svg_name": "Coal",
   "sv_ids": [],
   "parent_svg_ids": [
-   "c/g/hierarchy"
+   "c/g/Root"
   ],
   "child_svg_ids": [
    "c/g/Coal_EnergySource"
@@ -50,7 +37,7 @@
   "svg_name": "Person",
   "sv_ids": [],
   "parent_svg_ids": [
-   "c/g/hierarchy"
+   "c/g/Root"
   ],
   "child_svg_ids": [
    "c/g/Person_Race",
@@ -142,7 +129,7 @@
    "sv3"
   ],
   "parent_svg_ids": [
-   "c/g/hierarchy"
+   "c/g/Root"
   ],
   "child_svg_ids": []
  }

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/three_unrelated_svs_svgs.json
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/three_unrelated_svs_svgs.json
@@ -1,10 +1,23 @@
 [
  {
+  "svg_id": "c/g/hierarchy",
+  "svg_name": "Hierarchy",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "dc/g/Root"
+  ],
+  "child_svg_ids": [
+   "c/g/Coal",
+   "c/g/Person",
+   "c/g/Thing"
+  ]
+ },
+ {
   "svg_id": "c/g/Coal",
   "svg_name": "Coal",
   "sv_ids": [],
   "parent_svg_ids": [
-   "dc/g/Root"
+   "c/g/hierarchy"
   ],
   "child_svg_ids": [
    "c/g/Coal_EnergySource"
@@ -37,7 +50,7 @@
   "svg_name": "Person",
   "sv_ids": [],
   "parent_svg_ids": [
-   "dc/g/Root"
+   "c/g/hierarchy"
   ],
   "child_svg_ids": [
    "c/g/Person_Race",
@@ -129,7 +142,7 @@
    "sv3"
   ],
   "parent_svg_ids": [
-   "dc/g/Root"
+   "c/g/hierarchy"
   ],
   "child_svg_ids": []
  }

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/three_unrelated_svs_triples.csv
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/three_unrelated_svs_triples.csv
@@ -1,7 +1,10 @@
 subject_id,predicate,object_id,object_value
+c/g/hierarchy,typeOf,StatVarGroup,
+c/g/hierarchy,name,,Hierarchy
+c/g/hierarchy,specializationOf,dc/g/Root,
 c/g/Coal,typeOf,StatVarGroup,
 c/g/Coal,name,,Coal
-c/g/Coal,specializationOf,dc/g/Root,
+c/g/Coal,specializationOf,c/g/hierarchy,
 c/g/Coal_EnergySource,typeOf,StatVarGroup,
 c/g/Coal_EnergySource,name,,Coal With Energy Source
 c/g/Coal_EnergySource,specializationOf,c/g/Coal,
@@ -11,7 +14,7 @@ c/g/Coal_EnergySource-CokeCoal,specializationOf,c/g/Coal_EnergySource,
 sv2,memberOf,c/g/Coal_EnergySource-CokeCoal,
 c/g/Person,typeOf,StatVarGroup,
 c/g/Person,name,,Person
-c/g/Person,specializationOf,dc/g/Root,
+c/g/Person,specializationOf,c/g/hierarchy,
 c/g/Person_Gender,typeOf,StatVarGroup,
 c/g/Person_Gender,name,,Person With Gender
 c/g/Person_Gender,specializationOf,c/g/Person,
@@ -37,5 +40,5 @@ c/g/Person_Race-Asian,name,,Person With Race = Asian
 c/g/Person_Race-Asian,specializationOf,c/g/Person_Race,
 c/g/Thing,typeOf,StatVarGroup,
 c/g/Thing,name,,Thing
-c/g/Thing,specializationOf,dc/g/Root,
+c/g/Thing,specializationOf,c/g/hierarchy,
 sv3,memberOf,c/g/Thing,

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/three_unrelated_svs_triples.csv
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/three_unrelated_svs_triples.csv
@@ -1,10 +1,7 @@
 subject_id,predicate,object_id,object_value
-c/g/hierarchy,typeOf,StatVarGroup,
-c/g/hierarchy,name,,Hierarchy
-c/g/hierarchy,specializationOf,dc/g/Root,
 c/g/Coal,typeOf,StatVarGroup,
 c/g/Coal,name,,Coal
-c/g/Coal,specializationOf,c/g/hierarchy,
+c/g/Coal,specializationOf,c/g/Root,
 c/g/Coal_EnergySource,typeOf,StatVarGroup,
 c/g/Coal_EnergySource,name,,Coal With Energy Source
 c/g/Coal_EnergySource,specializationOf,c/g/Coal,
@@ -14,7 +11,7 @@ c/g/Coal_EnergySource-CokeCoal,specializationOf,c/g/Coal_EnergySource,
 sv2,memberOf,c/g/Coal_EnergySource-CokeCoal,
 c/g/Person,typeOf,StatVarGroup,
 c/g/Person,name,,Person
-c/g/Person,specializationOf,c/g/hierarchy,
+c/g/Person,specializationOf,c/g/Root,
 c/g/Person_Gender,typeOf,StatVarGroup,
 c/g/Person_Gender,name,,Person With Gender
 c/g/Person_Gender,specializationOf,c/g/Person,
@@ -40,5 +37,5 @@ c/g/Person_Race-Asian,name,,Person With Race = Asian
 c/g/Person_Race-Asian,specializationOf,c/g/Person_Race,
 c/g/Thing,typeOf,StatVarGroup,
 c/g/Thing,name,,Thing
-c/g/Thing,specializationOf,c/g/hierarchy,
+c/g/Thing,specializationOf,c/g/Root,
 sv3,memberOf,c/g/Thing,

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/two_related_svs_svgs.json
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/two_related_svs_svgs.json
@@ -1,21 +1,10 @@
 [
  {
-  "svg_id": "c/g/hierarchy",
-  "svg_name": "Hierarchy",
-  "sv_ids": [],
-  "parent_svg_ids": [
-   "dc/g/Root"
-  ],
-  "child_svg_ids": [
-   "c/g/Person"
-  ]
- },
- {
   "svg_id": "c/g/Person",
   "svg_name": "Person",
   "sv_ids": [],
   "parent_svg_ids": [
-   "c/g/hierarchy"
+   "c/g/Root"
   ],
   "child_svg_ids": [
    "c/g/Person_Race",

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/two_related_svs_svgs.json
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/two_related_svs_svgs.json
@@ -1,10 +1,21 @@
 [
  {
+  "svg_id": "c/g/hierarchy",
+  "svg_name": "Hierarchy",
+  "sv_ids": [],
+  "parent_svg_ids": [
+   "dc/g/Root"
+  ],
+  "child_svg_ids": [
+   "c/g/Person"
+  ]
+ },
+ {
   "svg_id": "c/g/Person",
   "svg_name": "Person",
   "sv_ids": [],
   "parent_svg_ids": [
-   "dc/g/Root"
+   "c/g/hierarchy"
   ],
   "child_svg_ids": [
    "c/g/Person_Race",

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/two_related_svs_triples.csv
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/two_related_svs_triples.csv
@@ -1,7 +1,10 @@
 subject_id,predicate,object_id,object_value
+c/g/hierarchy,typeOf,StatVarGroup,
+c/g/hierarchy,name,,Hierarchy
+c/g/hierarchy,specializationOf,dc/g/Root,
 c/g/Person,typeOf,StatVarGroup,
 c/g/Person,name,,Person
-c/g/Person,specializationOf,dc/g/Root,
+c/g/Person,specializationOf,c/g/hierarchy,
 c/g/Person_Gender,typeOf,StatVarGroup,
 c/g/Person_Gender,name,,Person With Gender
 c/g/Person_Gender,specializationOf,c/g/Person,

--- a/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/two_related_svs_triples.csv
+++ b/simple/tests/stats/test_data/stat_var_hierarchy_generator/expected/two_related_svs_triples.csv
@@ -1,10 +1,7 @@
 subject_id,predicate,object_id,object_value
-c/g/hierarchy,typeOf,StatVarGroup,
-c/g/hierarchy,name,,Hierarchy
-c/g/hierarchy,specializationOf,dc/g/Root,
 c/g/Person,typeOf,StatVarGroup,
 c/g/Person,name,,Person
-c/g/Person,specializationOf,c/g/hierarchy,
+c/g/Person,specializationOf,c/g/Root,
 c/g/Person_Gender,typeOf,StatVarGroup,
 c/g/Person_Gender,name,,Person With Gender
 c/g/Person_Gender,specializationOf,c/g/Person,


### PR DESCRIPTION
* This PR puts all hierarchy SVGs under a custom DC root so the custom hierarchy is cleanly separated from any main dc hierarchies.
* It also sets us up to do vertical tagging in the next PR.