### PR TITLE
Wire schema names into sv hierarchy generator.

### DIFF
--- a/simple/stats/data.py
+++ b/simple/stats/data.py
@@ -439,8 +439,14 @@ class VerticalSpec:
                         verticals=set(json.get("verticals", [])))
 
 
+# dict[svg id, svg specialized name]
+SVGSpecializedNames = dict[str, str]
+
+# dict[parent svg id, child SVGSpecializedNames]
+ParentSVG2ChildSpecializedNames = dict[str, SVGSpecializedNames]
+
+
 @dataclass
 class StatVarHierarchyResult:
   svg_triples: list[Triple]
-  # dict[parent svg id, dict[child svg id, child specialized name]]
-  svg_specialized_names: dict[str, dict[str, str]]
+  svg_specialized_names: ParentSVG2ChildSpecializedNames

--- a/simple/stats/data.py
+++ b/simple/stats/data.py
@@ -437,3 +437,10 @@ class VerticalSpec:
                         measured_properties=set(
                             json.get("measuredProperties", [])),
                         verticals=set(json.get("verticals", [])))
+
+
+@dataclass
+class StatVarHierarchyResult:
+  svg_triples: list[Triple]
+  # dict[parent svg id, dict[child svg id, child specialized name]]
+  svg_specialized_names: dict[str, dict[str, str]]

--- a/simple/stats/runner.py
+++ b/simple/stats/runner.py
@@ -22,6 +22,7 @@ from stats import stat_var_hierarchy_generator
 from stats.config import Config
 from stats.data import ImportType
 from stats.data import InputFileFormat
+from stats.data import ParentSVG2ChildSpecializedNames
 from stats.data import Triple
 from stats.data import VerticalSpec
 from stats.db import create_db
@@ -66,8 +67,7 @@ class Runner:
     # "Special" file handlers.
     # i.e. if files of these types are present, they are handled in specific ways.
     self.special_handlers: dict[str, FileHandler] = {}
-    # dict[parent svg id, dict[child svg id, child specialized name]]
-    self.svg_specialized_names: dict[str, dict[str, str]] = {}
+    self.svg_specialized_names: ParentSVG2ChildSpecializedNames = {}
 
     # Config file driven.
     if config_file:

--- a/simple/stats/stat_var_hierarchy_generator.py
+++ b/simple/stats/stat_var_hierarchy_generator.py
@@ -20,17 +20,17 @@ import re
 from typing import Self
 
 from stats import schema_constants as sc
+from stats.data import StatVarHierarchyResult
 from stats.data import Triple
 from stats.data import VerticalSpec
 
 
 def generate(triples: list[Triple], vertical_specs: list[VerticalSpec],
-             dcid2name: dict[str, str]) -> list[Triple]:
+             dcid2name: dict[str, str]) -> StatVarHierarchyResult:
   """Given a list of input triples (including stat vars), 
-generates a SV hierarchy and returns a list of output triples
-representing the hierarchy.
+generates a SV hierarchy and returns a StatVarHierarchyResult object.
 """
-  return _generate_internal(triples, vertical_specs, dcid2name).svg_triples
+  return _generate_internal(triples, vertical_specs, dcid2name).to_result()
 
 
 def load_vertical_specs(data: str) -> list[VerticalSpec]:
@@ -215,6 +215,16 @@ class StatVarHierarchy:
   # Dict from SVG dcid to SVG.
   svgs: dict[str, SVG]
   svg_triples: list[Triple]
+
+  def to_result(self) -> StatVarHierarchyResult:
+    return StatVarHierarchyResult(self.svg_triples,
+                                  self._get_svg_specialized_names())
+
+  def _get_svg_specialized_names(self) -> dict[str, dict[str, str]]:
+    specialized_names: dict[str, dict[str, str]] = {}
+    for svg_id, svg in self.svgs.items():
+      specialized_names[svg_id] = svg.child_svg_id_2_specialized_name
+    return specialized_names
 
 
 # Attaches matching pop type svgs to vertical svgs, creates those vertical svgs and returns them.

--- a/simple/stats/stat_var_hierarchy_generator.py
+++ b/simple/stats/stat_var_hierarchy_generator.py
@@ -20,6 +20,7 @@ import re
 from typing import Self
 
 from stats import schema_constants as sc
+from stats.data import ParentSVG2ChildSpecializedNames
 from stats.data import StatVarHierarchyResult
 from stats.data import Triple
 from stats.data import VerticalSpec
@@ -220,8 +221,8 @@ class StatVarHierarchy:
     return StatVarHierarchyResult(self.svg_triples,
                                   self._get_svg_specialized_names())
 
-  def _get_svg_specialized_names(self) -> dict[str, dict[str, str]]:
-    specialized_names: dict[str, dict[str, str]] = {}
+  def _get_svg_specialized_names(self) -> ParentSVG2ChildSpecializedNames:
+    specialized_names: ParentSVG2ChildSpecializedNames = {}
     for svg_id, svg in self.svgs.items():
       specialized_names[svg_id] = svg.child_svg_id_2_specialized_name
     return specialized_names

--- a/simple/tests/stats/test_data/runner/expected/generate_svg_hierarchy/triples.db.csv
+++ b/simple/tests/stats/test_data/runner/expected/generate_svg_hierarchy/triples.db.csv
@@ -11,6 +11,10 @@ some_var2,name,,Some Variable 2 Name
 some_var2,description,,Some Variable 2 Description
 some_var2,populationType,Person,
 some_var2,gender,Male,
+PersonCountVertical,typeOf,Thing,
+PersonCountVertical,name,,Number of people
+PersonAgeVertical,typeOf,Thing,
+PersonAgeVertical,name,,Age of people
 c/s/default,typeOf,Source,
 c/s/default,name,,Custom Data Commons
 c/s/1,typeOf,Source,
@@ -29,10 +33,10 @@ c/g/Root,typeOf,StatVarGroup,
 c/g/Root,name,,Custom Variables
 c/g/Root,specializationOf,dc/g/Root,
 c/g/PersonAgeVertical,typeOf,StatVarGroup,
-c/g/PersonAgeVertical,name,,Person Age Vertical
+c/g/PersonAgeVertical,name,,Age of people
 c/g/PersonAgeVertical,specializationOf,c/g/Root,
 c/g/PersonCountVertical,typeOf,StatVarGroup,
-c/g/PersonCountVertical,name,,Person Count Vertical
+c/g/PersonCountVertical,name,,Number of people
 c/g/PersonCountVertical,specializationOf,c/g/Root,
 c/g/Person,typeOf,StatVarGroup,
 c/g/Person,name,,Person

--- a/simple/tests/stats/test_data/runner/input/generate_svg_hierarchy/nodes.mcf
+++ b/simple/tests/stats/test_data/runner/input/generate_svg_hierarchy/nodes.mcf
@@ -14,3 +14,11 @@ name: "Some Variable 2 Name"
 description: "Some Variable 2 Description"
 populationType: schema:Person
 gender: dcs:Male
+
+Node: dcid:PersonCountVertical
+typeOf: dcs:Thing
+name: "Number of people"
+
+Node: dcid:PersonAgeVertical
+typeOf: dcs:Thing
+name: "Age of people"


### PR DESCRIPTION
* Also updated the generator to return svg specialized names to the runner. This will be used in a follow up PR to generate json equivalent of the [StatVarGroups](https://source.corp.google.com/piper///depot/google3/datacommons/proto/prophet/cache_data.proto;l=338?q=StatVarGroups) cache.