### PR TITLE
Populate entity with type by calling base DC.

### DIFF
--- a/simple/stats/nodes.py
+++ b/simple/stats/nodes.py
@@ -264,7 +264,7 @@ class Nodes:
 
   def entities_with_types(self, dcid2type: dict[str, str]):
     """
-    Adds each dcid2type mapping to the list of entity with their types.
+    Adds each dcid2type mapping to the list of entities with their types.
     The full list will be inserted into the DB in the final stages of the import.
     """
     for entity_dcid, entity_type in dcid2type.items():

--- a/simple/stats/nodes.py
+++ b/simple/stats/nodes.py
@@ -262,6 +262,10 @@ class Nodes:
     for entity_dcid in entity_dcids:
       self.entity_with_type(entity_dcid, entity_type)
 
+  def entities_with_types(self, dcid2type: dict[str, str]):
+    for entity_dcid, entity_type in dcid2type.items():
+      self.entity_with_type(entity_dcid, entity_type)
+
   def triples(self, triples_fh: FileHandler | None = None) -> list[Triple]:
     triples: list[Triple] = []
     for source in self.sources.values():

--- a/simple/stats/nodes.py
+++ b/simple/stats/nodes.py
@@ -263,6 +263,10 @@ class Nodes:
       self.entity_with_type(entity_dcid, entity_type)
 
   def entities_with_types(self, dcid2type: dict[str, str]):
+    """
+    Adds each dcid2type mapping to the list of entity with their types.
+    The full list will be inserted into the DB in the final stages of the import.
+    """
     for entity_dcid, entity_type in dcid2type.items():
       self.entity_with_type(entity_dcid, entity_type)
 

--- a/simple/tests/stats/observations_importer_test.py
+++ b/simple/tests/stats/observations_importer_test.py
@@ -14,13 +14,12 @@
 
 import os
 import shutil
-import sqlite3
 import tempfile
 import unittest
+from unittest.mock import MagicMock
 
 import pandas as pd
 from stats.config import Config
-from stats.data import Observation
 from stats.db import create_db
 from stats.db import create_sqlite_config
 from stats.nodes import Nodes
@@ -31,6 +30,8 @@ from tests.stats.test_util import compare_files
 from tests.stats.test_util import is_write_mode
 from tests.stats.test_util import write_observations
 from util.filehandler import LocalFileHandler
+
+from util import dc_client
 
 _TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                               "test_data", "observations_importer")
@@ -67,6 +68,8 @@ def _test_import(test: unittest.TestCase,
                 }
             }
         }))
+
+    dc_client.get_property_of_entities = MagicMock(return_value={})
 
     ObservationsImporter(input_fh=input_fh,
                          db=db,

--- a/simple/tests/stats/runner_test.py
+++ b/simple/tests/stats/runner_test.py
@@ -51,12 +51,12 @@ def _test_runner(test: unittest.TestCase,
     if is_config_driven:
       config_path = os.path.join(_CONFIG_DIR, f"{test_name}.json")
       input_dir = None
-      remote_schema_names_path = None
+      remote_entity_types_path = None
     else:
       config_path = None
       input_dir = os.path.join(_INPUT_DIR, test_name)
-      remote_schema_names_path = os.path.join(input_dir,
-                                              "remote_schema_names.json")
+      remote_entity_types_path = os.path.join(input_dir,
+                                              "remote_entity_types.json")
 
     db_path = os.path.join(temp_dir, "datacommons.db")
 
@@ -80,9 +80,10 @@ def _test_runner(test: unittest.TestCase,
                                               constants.SENTENCES_FILE_NAME)
 
     dc_client.get_property_of_entities = MagicMock(return_value={})
-    if remote_schema_names_path and os.path.exists(remote_schema_names_path):
-      with os.open(remote_schema_names_path, "r") as f:
-        dc_client.get_property_of_entities = json.load(f)
+    if remote_entity_types_path and os.path.exists(remote_entity_types_path):
+      with open(remote_entity_types_path, "r") as f:
+        dc_client.get_property_of_entities = MagicMock(
+            return_value=json.load(f))
 
     Runner(config_file=config_path, input_dir=input_dir,
            output_dir=temp_dir).run()
@@ -132,3 +133,6 @@ class TestRunner(unittest.TestCase):
 
   def test_topic_nl_sentences(self):
     _test_runner(self, "topic_nl_sentences", is_config_driven=False)
+
+  def test_remote_entity_types(self):
+    _test_runner(self, "remote_entity_types", is_config_driven=False)

--- a/simple/tests/stats/test_data/runner/expected/remote_entity_types/key_value_store.db.csv
+++ b/simple/tests/stats/test_data/runner/expected/remote_entity_types/key_value_store.db.csv
@@ -1,0 +1,2 @@
+lookup_key,value
+StatVarGroups,H4sIAAAAAAAC/+OS5OJMSdZP1w/Kzy8R4pHi4uKA8bjcEGwhKy4B59LikvxchbDEoszEpJzUYiEhLpayxCJDKTCpBCahYkZgMSOwmBEAlEss8mMAAAA=

--- a/simple/tests/stats/test_data/runner/expected/remote_entity_types/nl/sentences.csv
+++ b/simple/tests/stats/test_data/runner/expected/remote_entity_types/nl/sentences.csv
@@ -1,0 +1,3 @@
+dcid,sentence
+var1,var1
+var2,var2

--- a/simple/tests/stats/test_data/runner/expected/remote_entity_types/observations.db.csv
+++ b/simple/tests/stats/test_data/runner/expected/remote_entity_types/observations.db.csv
@@ -1,0 +1,9 @@
+entity,variable,date,value,provenance
+country/FAKE1,var1,2024,1,c/p/1
+country/FAKE2,var1,2024,3,c/p/1
+country/FAKE1,var2,2024,2,c/p/1
+country/FAKE2,var2,2024,4,c/p/1
+country/FAKE3,var1,2024,5,c/p/default
+country/FAKE3,var2,2024,6,c/p/default
+country/FAKE4,var1,2024,7,c/p/default
+country/FAKE4,var2,2024,8,c/p/default

--- a/simple/tests/stats/test_data/runner/expected/remote_entity_types/triples.db.csv
+++ b/simple/tests/stats/test_data/runner/expected/remote_entity_types/triples.db.csv
@@ -1,0 +1,38 @@
+subject_id,predicate,object_id,object_value
+c/s/default,typeOf,Source,
+c/s/default,name,,Custom Data Commons
+c/s/1,typeOf,Source,
+c/s/1,name,,Source1 Name
+c/s/1,url,,http://source1.com
+c/s/1,domain,,source1.com
+c/p/default,typeOf,Provenance,
+c/p/default,name,,Custom Import
+c/p/default,source,c/s/default,
+c/p/default,url,,custom-import
+c/p/1,typeOf,Provenance,
+c/p/1,name,,Provenance1 Name
+c/p/1,source,c/s/1,
+c/p/1,url,,http://source1.com/provenance1
+c/g/Root,typeOf,StatVarGroup,
+c/g/Root,name,,Custom Variables
+c/g/Root,specializationOf,dc/g/Root,
+var1,typeOf,StatisticalVariable,
+var1,name,,var1
+var1,memberOf,c/g/Root,
+var1,includedIn,c/p/1,
+var1,includedIn,c/s/1,
+var1,populationType,Thing,
+var1,statType,measuredValue,
+var1,measuredProperty,var1,
+var2,typeOf,StatisticalVariable,
+var2,name,,var2
+var2,memberOf,c/g/Root,
+var2,includedIn,c/p/1,
+var2,includedIn,c/s/1,
+var2,populationType,Thing,
+var2,statType,measuredValue,
+var2,measuredProperty,var2,
+country/FAKE1,typeOf,FakeType1,
+country/FAKE2,typeOf,FakeType2,
+country/FAKE3,typeOf,FakeType2,
+country/FAKE4,typeOf,FakeType1,

--- a/simple/tests/stats/test_data/runner/input/remote_entity_types/config.json
+++ b/simple/tests/stats/test_data/runner/input/remote_entity_types/config.json
@@ -1,0 +1,23 @@
+{
+  "inputFiles": {
+    "variable_per_column.csv": {
+      "importType": "observations",
+      "format": "variablePerColumn",
+      "entityType": "Country",
+      "provenance": "Provenance1 Name"
+    },
+    "variable_per_row.csv": {
+      "importType": "observations",
+      "format": "variablePerRow",
+      "provenance": "Provenance1"
+    }
+  },
+  "sources": {
+    "Source1 Name": {
+      "url": "http://source1.com",
+      "provenances": {
+        "Provenance1 Name": "http://source1.com/provenance1"
+      }
+    }
+  }
+}

--- a/simple/tests/stats/test_data/runner/input/remote_entity_types/remote_entity_types.json
+++ b/simple/tests/stats/test_data/runner/input/remote_entity_types/remote_entity_types.json
@@ -1,0 +1,6 @@
+{
+  "country/FAKE1": "FakeType1",
+  "country/FAKE2": "FakeType2",
+  "country/FAKE3": "FakeType2",
+  "country/FAKE4": "FakeType1"
+}

--- a/simple/tests/stats/test_data/runner/input/remote_entity_types/variable_per_column.csv
+++ b/simple/tests/stats/test_data/runner/input/remote_entity_types/variable_per_column.csv
@@ -1,0 +1,3 @@
+dcid,year,var1,var2
+country/FAKE1,2024,1,2
+country/FAKE2,2024,3,4

--- a/simple/tests/stats/test_data/runner/input/remote_entity_types/variable_per_row.csv
+++ b/simple/tests/stats/test_data/runner/input/remote_entity_types/variable_per_row.csv
@@ -1,0 +1,5 @@
+entity,variable,date,value
+country/FAKE3,var1,2024,5
+country/FAKE3,var2,2024,6
+country/FAKE4,var1,2024,7
+country/FAKE4,var2,2024,8

--- a/simple/tests/stats/variable_per_row_importer_test.py
+++ b/simple/tests/stats/variable_per_row_importer_test.py
@@ -14,9 +14,9 @@
 
 import os
 import shutil
-import sqlite3
 import tempfile
 import unittest
+from unittest.mock import MagicMock
 
 import pandas as pd
 from stats.config import Config
@@ -30,6 +30,7 @@ from stats.variable_per_row_importer import VariablePerRowImporter
 from tests.stats.test_util import compare_files
 from tests.stats.test_util import is_write_mode
 from tests.stats.test_util import write_observations
+from util.dc_client import get_property_of_entities
 from util.filehandler import LocalFileHandler
 
 _TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -63,6 +64,8 @@ def _test_import(test: unittest.TestCase,
                     "columnMappings": column_mappings
                 }
             }}))
+
+    get_property_of_entities = MagicMock(return_value={})
 
     VariablePerRowImporter(input_fh=input_fh,
                            db=db,


### PR DESCRIPTION
* SV summary in CDC currently does not work if the data is provided in variable per row (aka svobs) format.
* This was because we were not populating entities from those files in the sql db.
* With this fix, we fetch entity types for all unique entities from base dc and record them in sql.
* The fix applies this approach to variable per column files as well for consistency.