### PR TITLE
Create db indexes programmatically.

### DIFF
--- a/simple/tests/stats/db_test.py
+++ b/simple/tests/stats/db_test.py
@@ -96,6 +96,13 @@ class TestDb(unittest.TestCase):
           import_tuple,
           ("2023-01-01 00:00:00", "SUCCESS", '{"numVars": 1, "numObs": 2}'))
 
+      index_tuples = sqldb.execute(
+          "select name, tbl_name from sqlite_master where type = 'index'"
+      ).fetchall()
+      self.assertListEqual(index_tuples,
+                           [('observations_entity_variable', 'observations'),
+                            ('triples_subject_id', 'triples')])
+
   @freeze_time("2023-01-01")
   def test_main_dc_db(self):
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
* This PR creates DB indexes for better performance as part of loading data itself.
  + Without this, partners would need to create the indexes themselves and we'd have to document it.
* As an optimization, at start of load data, we first drop any existing indexes so that insertions are faster. And we add the indexes only as the final step (after all data has been loaded) before committing the transaction.