### PR TITLE
Add support for generating topic cache.

### DIFF
--- a/simple/stats/constants.py
+++ b/simple/stats/constants.py
@@ -24,6 +24,7 @@ CONFIG_JSON_FILE_NAME = "config.json"
 REPORT_JSON_FILE_NAME = "report.json"
 TRIPLES_FILE_NAME = "triples.csv"
 SENTENCES_FILE_NAME = "sentences.csv"
+TOPIC_CACHE_FILE_NAME = "custom_dc_topic_cache.json"
 DB_FILE_NAME = "datacommons.db"
 
 OBSERVATIONS_FILE_NAME_PREFIX = "observations"

--- a/simple/stats/runner.py
+++ b/simple/stats/runner.py
@@ -177,16 +177,17 @@ class Runner:
     # Generate SVG cache.
     self._generate_svg_cache()
 
-    # Generate NL sentences for creating embeddings.
-    self._generate_nl_sentences()
+    # Generate NL artifacts (sentences, embeddings, topic cache).
+    self._generate_nl_artifacts()
 
     # Write import info to DB.
     self.db.insert_import_info(status=ImportStatus.SUCCESS)
 
-  def _generate_nl_sentences(self):
+  def _generate_nl_artifacts(self):
     triples: list[Triple] = []
     # Get topic triples if generating topics else get SV triples.
-    if self.config.generate_topics():
+    generate_topics = self.config.generate_topics()
+    if generate_topics:
       triples = self.db.select_triples_by_subject_type(sc.TYPE_TOPIC)
     else:
       triples = self.db.select_triples_by_subject_type(
@@ -194,6 +195,10 @@ class Runner:
 
     # Generate sentences.
     nl.generate_nl_sentences(triples, self.nl_dir_fh)
+
+    # If generating topics, generate topic cache
+    if generate_topics:
+      nl.generate_topic_cache(triples, self.nl_dir_fh)
 
   def _generate_svg_hierarchy(self):
     if self.mode == RunMode.MAIN_DC:

--- a/simple/stats/schema_constants.py
+++ b/simple/stats/schema_constants.py
@@ -38,6 +38,9 @@ PREDICATE_UNIT = "unit"
 PREDICATE_SCALING_FACTOR = "scalingFactor"
 PREDICATE_MEASUREMENT_METHOD = "measurementMethod"
 PREDICATE_OBSERVATION_PERIOD = "observationPeriod"
+PREDICATE_RELEVANT_VARIABLE = "relevantVariable"
+PREDICATE_RELEVANT_VARIABLE_LIST = "relevantVariableList"
+PREDICATE_MEMBER_LIST = "memberList"
 
 # The set of standard observation properties with first class support in our APIs and FE.
 STANDARD_OBSERVATION_PROPERTIES: set[str] = {

--- a/simple/tests/stats/runner_test.py
+++ b/simple/tests/stats/runner_test.py
@@ -85,6 +85,10 @@ def _test_runner(test: unittest.TestCase,
     expected_nl_sentences_path = os.path.join(expected_dir,
                                               constants.NL_DIR_NAME,
                                               constants.SENTENCES_FILE_NAME)
+    output_topic_cache_json_path = os.path.join(temp_dir, constants.NL_DIR_NAME,
+                                                constants.TOPIC_CACHE_FILE_NAME)
+    expected_topic_cache_json_path = os.path.join(
+        expected_dir, constants.NL_DIR_NAME, constants.TOPIC_CACHE_FILE_NAME)
 
     dc_client.get_property_of_entities = MagicMock(return_value={})
     if remote_entity_types_path and os.path.exists(remote_entity_types_path):
@@ -105,7 +109,11 @@ def _test_runner(test: unittest.TestCase,
       shutil.copy(output_triples_path, expected_triples_path)
       shutil.copy(output_observations_path, expected_observations_path)
       shutil.copy(output_key_value_store_path, expected_key_value_store_path)
-      shutil.copy(output_nl_sentences_path, expected_nl_sentences_path)
+      if os.path.exists(output_nl_sentences_path):
+        shutil.copy(output_nl_sentences_path, expected_nl_sentences_path)
+      if os.path.exists(output_topic_cache_json_path):
+        shutil.copy(output_topic_cache_json_path,
+                    expected_topic_cache_json_path)
       return
 
     compare_files(test, output_triples_path, expected_triples_path,
@@ -115,8 +123,12 @@ def _test_runner(test: unittest.TestCase,
     compare_files(test, output_key_value_store_path,
                   expected_key_value_store_path,
                   f"{test_name}: key_value_store")
-    compare_files(test, output_nl_sentences_path, expected_nl_sentences_path,
-                  f"{test_name}: triples")
+    if os.path.exists(expected_nl_sentences_path):
+      compare_files(test, output_nl_sentences_path, expected_nl_sentences_path,
+                    f"{test_name}: nl sentences")
+    if os.path.exists(expected_topic_cache_json_path):
+      compare_files(test, output_topic_cache_json_path,
+                    expected_topic_cache_json_path, f"{test_name}: topic cache")
 
 
 class TestRunner(unittest.TestCase):

--- a/simple/tests/stats/test_data/nl/expected/topic_triples/custom_dc_topic_cache.json
+++ b/simple/tests/stats/test_data/nl/expected/topic_triples/custom_dc_topic_cache.json
@@ -1,0 +1,48 @@
+{
+ "nodes": [
+  {
+   "dcid": [
+    "topic_with_search_descriptions"
+   ],
+   "typeOf": [
+    "Topic"
+   ],
+   "name": [
+    "Name should NOT be used"
+   ],
+   "relevantVariableList": [
+    "var1",
+    "var2"
+   ]
+  },
+  {
+   "dcid": [
+    "topic_with_name_only"
+   ],
+   "typeOf": [
+    "Topic"
+   ],
+   "name": [
+    "Name should be used"
+   ],
+   "relevantVariableList": [
+    "var3",
+    "var4"
+   ]
+  },
+  {
+   "dcid": [
+    "topic_with_no_sentence_props"
+   ],
+   "typeOf": [
+    "Topic"
+   ],
+   "relevantVariableList": [
+    "var5",
+    "var6",
+    "var7",
+    "var8"
+   ]
+  }
+ ]
+}

--- a/simple/tests/stats/test_data/nl/input/topic_triples.csv
+++ b/simple/tests/stats/test_data/nl/input/topic_triples.csv
@@ -3,7 +3,13 @@ topic_with_search_descriptions,typeOf,Topic,
 topic_with_search_descriptions,name,,Name should NOT be used
 topic_with_search_descriptions,searchDescription,,Topic search description1
 topic_with_search_descriptions,searchDescription,,Topic search description2
+topic_with_search_descriptions,relevantVariable,var1,
+topic_with_search_descriptions,relevantVariable,var2,
 topic_with_name_only,typeOf,Topic,
 topic_with_name_only,name,,Name should be used
+topic_with_name_only,relevantVariableList,,"var3,var4"
 topic_with_no_sentence_props,typeOf,Topic,
 topic_with_no_sentence_props,description,,Descriptions are NOT used for embeddings
+topic_with_no_sentence_props,relevantVariable,var5,
+topic_with_no_sentence_props,relevantVariable,var6,
+topic_with_no_sentence_props,relevantVariableList,,"var7,var8"

--- a/simple/tests/stats/test_data/runner/expected/topic_nl_sentences/nl/custom_dc_topic_cache.json
+++ b/simple/tests/stats/test_data/runner/expected/topic_nl_sentences/nl/custom_dc_topic_cache.json
@@ -1,0 +1,33 @@
+{
+ "nodes": [
+  {
+   "dcid": [
+    "topic1"
+   ],
+   "typeOf": [
+    "Topic"
+   ],
+   "name": [
+    "Topic1 Name"
+   ],
+   "relevantVariableList": [
+    "var1"
+   ]
+  },
+  {
+   "dcid": [
+    "topic2"
+   ],
+   "typeOf": [
+    "Topic"
+   ],
+   "name": [
+    "Topic2 Name"
+   ],
+   "relevantVariableList": [
+    "var1",
+    "var2"
+   ]
+  }
+ ]
+}

--- a/simple/tests/stats/test_data/runner/expected/topic_nl_sentences/triples.db.csv
+++ b/simple/tests/stats/test_data/runner/expected/topic_nl_sentences/triples.db.csv
@@ -9,10 +9,12 @@ var2,searchDescription,,Variable2 Search Description1
 var2,searchDescription,,Variable2 Search Description2
 topic1,typeOf,Topic,
 topic1,name,,Topic1 Name
+topic1,relevantVariable,var1,
 topic2,typeOf,Topic,
 topic2,name,,Topic2 Name
 topic2,searchDescription,,Topic2 Search Description1
 topic2,searchDescription,,Topic2 Search Description2
+topic2,relevantVariableList,,"var1, var2"
 c/s/default,typeOf,Source,
 c/s/default,name,,Custom Data Commons
 c/s/1,typeOf,Source,

--- a/simple/tests/stats/test_data/runner/input/topic_nl_sentences/schema.mcf
+++ b/simple/tests/stats/test_data/runner/input/topic_nl_sentences/schema.mcf
@@ -13,9 +13,11 @@ searchDescription: "Variable2 Search Description2"
 Node: dcid:topic1
 typeOf: dcs:Topic
 name: "Topic1 Name"
+relevantVariable: dcid:var1
 
 Node: dcid:topic2
 typeOf: dcs:Topic
 name: "Topic2 Name"
 searchDescription: "Topic2 Search Description1"
 searchDescription: "Topic2 Search Description2"
+relevantVariableList: "var1, var2"


### PR DESCRIPTION
* For an example topic cache json, refer [this one](https://github.com/datacommonsorg/website/blob/204ee2668d6e800f1a554c60066057d638f424ad/server/tests/lib/test_data/topic_cache/input/merge_with_undata/datacommons/nl/custom_dc_topic_cache.json#L4).
* The generated json does not include the `dc` field, so that it is merged with the main dc cache itself. [reference](https://github.com/datacommonsorg/website/blob/204ee2668d6e800f1a554c60066057d638f424ad/server/lib/topic_cache.py#L238)
* Currently the cache is only generated for topics and not for SV peer groups.
  + @dwnoble - let me know if this is needed and I can add it in a follow-up PR.