### PR TITLE
Strip namespaces from entity dcids before fetching their types.

### DIFF
--- a/simple/stats/data.py
+++ b/simple/stats/data.py
@@ -69,8 +69,8 @@ class Triple:
   object_value: str = ""
 
   def db_tuple(self):
-    return (_strip_namespace(self.subject_id), self.predicate,
-            _strip_namespace(self.object_id), self.object_value)
+    return (strip_namespace(self.subject_id), self.predicate,
+            strip_namespace(self.object_id), self.object_value)
 
 
 @dataclass
@@ -275,12 +275,12 @@ class Observation:
       default_factory=ObservationProperties.new)
 
   def db_tuple(self):
-    return (_strip_namespace(self.entity), _strip_namespace(self.variable),
-            self.date, self.value, _strip_namespace(self.provenance),
-            _strip_namespace(self.properties.unit),
+    return (strip_namespace(self.entity), strip_namespace(self.variable),
+            self.date, self.value, strip_namespace(self.provenance),
+            strip_namespace(self.properties.unit),
             self.properties.scaling_factor,
-            _strip_namespace(self.properties.measurement_method),
-            _strip_namespace(self.properties.observation_period),
+            strip_namespace(self.properties.measurement_method),
+            strip_namespace(self.properties.observation_period),
             json.dumps(self.properties.properties)
             if self.properties.properties else "")
 
@@ -527,5 +527,9 @@ class StatVarHierarchyResult:
   svg_specialized_names: ParentSVG2ChildSpecializedNames
 
 
-def _strip_namespace(v: str) -> str:
+def strip_namespace(v: str) -> str:
+  """
+    Strips namespaces from dcids.
+    e.g. 'dcid:country/USA' -> 'country/USA'
+  """
   return v[v.find(_NAMESPACE_DELIMITER) + 1:]

--- a/simple/stats/logger.py
+++ b/simple/stats/logger.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 import logging
+import os
 import sys
+
+# Get the log level from the environment variable, defaulting to INFO if not set
+log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=log_level)
 
 
 def initialize_logger():
@@ -22,7 +27,7 @@ def initialize_logger():
 
     The logger is configured to:
     - Log to stdout
-    - Use INFO level
+    - Use log_level as the logging level
     - Format messages with timestamp, level, filename, line number and message
     - Remove any existing handlers first
 
@@ -33,7 +38,7 @@ def initialize_logger():
 
   # Initialize logging
   logger = logging.getLogger()
-  logger.setLevel(logging.INFO)
+  logger.setLevel(log_level)
   handler = logging.StreamHandler(sys.stdout)
   formatter = logging.Formatter(
       "[%(asctime)s %(levelname)s %(filename)s:%(lineno)d] %(message)s")

--- a/simple/stats/main.py
+++ b/simple/stats/main.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from absl import app
 from absl import flags
 from freezegun import freeze_time

--- a/simple/stats/observations_importer.py
+++ b/simple/stats/observations_importer.py
@@ -19,6 +19,7 @@ from stats import constants
 from stats import schema_constants as sc
 from stats.data import Observation
 from stats.data import ObservationProperties
+from stats.data import strip_namespace
 from stats.db import Db
 from stats.importer import Importer
 from stats.nodes import Nodes
@@ -133,7 +134,7 @@ class ObservationsImporter(Importer):
     # Convert entity dcids to dict.
     # Using dict instead of set to maintain insertion order which keeps results consistent for tests.
     entity_dcids: dict[str, bool] = {
-        dcid: True for dcid in self.df.iloc[:, 0].tolist()
+        strip_namespace(dcid): True for dcid in self.df.iloc[:, 0].tolist()
     }
 
     # Get entity nodes that are not already recorded.

--- a/simple/stats/variable_per_row_importer.py
+++ b/simple/stats/variable_per_row_importer.py
@@ -19,6 +19,7 @@ from stats import constants
 from stats import schema_constants as sc
 from stats.data import Observation
 from stats.data import ObservationProperties
+from stats.data import strip_namespace
 from stats.db import Db
 from stats.importer import Importer
 from stats.nodes import Nodes
@@ -136,7 +137,8 @@ class VariablePerRowImporter(Importer):
   def _add_entity_nodes(self) -> None:
     # Get entity nodes that are not already recorded.
     new_entity_dcids = [
-        dcid for dcid in self.entity_dcids
+        strip_namespace(dcid)
+        for dcid in self.entity_dcids
         if dcid not in self.nodes.entities.keys()
     ]
 

--- a/simple/tests/stats/runner_test.py
+++ b/simple/tests/stats/runner_test.py
@@ -183,3 +183,6 @@ class TestRunner(unittest.TestCase):
                  config_path=os.path.join(_CONFIG_DIR,
                                           "config_include_subdirs.json"),
                  output_dir_name="with_subdirs_included")
+
+  def test_namespace_prefixes(self):
+    _test_runner(self, "namespace_prefixes")

--- a/simple/tests/stats/test_data/runner/expected/namespace_prefixes/key_value_store.db.csv
+++ b/simple/tests/stats/test_data/runner/expected/namespace_prefixes/key_value_store.db.csv
@@ -1,0 +1,2 @@
+lookup_key,value
+StatVarGroups,H4sIAAAAAAAC/wMAAAAAAAAAAAA=

--- a/simple/tests/stats/test_data/runner/expected/namespace_prefixes/nl/sentences.csv
+++ b/simple/tests/stats/test_data/runner/expected/namespace_prefixes/nl/sentences.csv
@@ -1,0 +1,4 @@
+dcid,sentence
+sv,SV
+sv_female,SV Female
+sv_male,SV Male

--- a/simple/tests/stats/test_data/runner/expected/namespace_prefixes/observations.db.csv
+++ b/simple/tests/stats/test_data/runner/expected/namespace_prefixes/observations.db.csv
@@ -1,0 +1,8 @@
+entity,variable,date,value,provenance,unit,scaling_factor,measurement_method,observation_period,properties
+country/FAKE1,sv_female,2019,1.2,c/p/default,,,,,
+country/FAKE1,sv_male,2019,13.4,c/p/default,,,,,
+country/FAKE1,sv,2019,7.5,c/p/default,,,,,
+country/FAKE2,sv_female,2016,1.8,c/p/default,,,,,
+country/FAKE2,sv_male,2016,14.3,c/p/default,,,,,
+country/FAKE3,sv_female,2018,4.5,c/p/default,,,,,
+country/FAKE3,sv_male,2018,35.7,c/p/default,,,,,

--- a/simple/tests/stats/test_data/runner/expected/namespace_prefixes/triples.db.csv
+++ b/simple/tests/stats/test_data/runner/expected/namespace_prefixes/triples.db.csv
@@ -1,0 +1,25 @@
+subject_id,predicate,object_id,object_value
+sv,typeOf,StatisticalVariable,
+sv,measuredProperty,value,
+sv,name,,SV
+sv,populationType,sv,
+sv,statType,measuredValue,
+sv_female,typeOf,StatisticalVariable,
+sv_female,measuredProperty,value,
+sv_female,name,,SV Female
+sv_female,populationType,sv,
+sv_female,statType,measuredValue,
+sv_male,typeOf,StatisticalVariable,
+sv_male,measuredProperty,value,
+sv_male,name,,SV Male
+sv_male,populationType,sv,
+sv_male,statType,measuredValue,
+c/s/default,typeOf,Source,
+c/s/default,name,,Custom Data Commons
+c/p/default,typeOf,Provenance,
+c/p/default,name,,Custom Import
+c/p/default,source,c/s/default,
+c/p/default,url,,custom-import
+country/FAKE1,typeOf,FakeType1,
+country/FAKE2,typeOf,FakeType2,
+country/FAKE3,typeOf,FakeType2,

--- a/simple/tests/stats/test_data/runner/input/namespace_prefixes/config.json
+++ b/simple/tests/stats/test_data/runner/input/namespace_prefixes/config.json
@@ -1,0 +1,7 @@
+{
+  "inputFiles": {
+    "*.csv": {
+      "format": "variablePerRow"
+    }
+  }
+}

--- a/simple/tests/stats/test_data/runner/input/namespace_prefixes/observations.csv
+++ b/simple/tests/stats/test_data/runner/input/namespace_prefixes/observations.csv
@@ -1,0 +1,8 @@
+variable,entity,date,value
+dcs:sv_female,dcid:country/FAKE1,2019,1.2
+dcs:sv_male,dcid:country/FAKE1,2019,13.4
+dcs:sv,dcid:country/FAKE1,2019,7.5
+dcs:sv_female,dcid:country/FAKE2,2016,1.8
+dcs:sv_male,dcid:country/FAKE2,2016,14.3
+dcs:sv_female,dcid:country/FAKE3,2018,4.5
+dcs:sv_male,dcid:country/FAKE3,2018,35.7

--- a/simple/tests/stats/test_data/runner/input/namespace_prefixes/remote_entity_types.json
+++ b/simple/tests/stats/test_data/runner/input/namespace_prefixes/remote_entity_types.json
@@ -1,0 +1,5 @@
+{
+  "country/FAKE1": "FakeType1",
+  "country/FAKE2": "FakeType2",
+  "country/FAKE3": "FakeType2"
+}

--- a/simple/tests/stats/test_data/runner/input/namespace_prefixes/schema.mcf
+++ b/simple/tests/stats/test_data/runner/input/namespace_prefixes/schema.mcf
@@ -1,0 +1,21 @@
+Node: dcid:sv
+typeOf: dcs:StatisticalVariable
+measuredProperty: dcs:value
+name: "SV"
+populationType: dcs:sv
+statType: dcs:measuredValue
+
+Node: dcid:sv_female
+typeOf: dcs:StatisticalVariable
+measuredProperty: dcs:value
+name: "SV Female"
+populationType: dcs:sv
+statType: dcs:measuredValue
+
+
+Node: dcid:sv_male
+typeOf: dcs:StatisticalVariable
+measuredProperty: dcs:value
+name: "SV Male"
+populationType: dcs:sv
+statType: dcs:measuredValue


### PR DESCRIPTION
* Without this fix, the entity types for entities with dcids were not returned by the DC API.
* This resulted in "no data available" messages on the stat var summary pages.
   + See: https://issuetracker.google.com/issues/383559947
* Unrelated, this PR also makes the log level configurable via an env variable which is helpful for debugging.