### PR TITLE
Added new db indices to improve performance of getStatVarSummaries query

### DIFF
--- a/simple/stats/db.py
+++ b/simple/stats/db.py
@@ -191,8 +191,8 @@ _DB_INDEXES: list[DbIndex] = [
             indexed_columns=["subject_id", "predicate"]),
     # Used by getStatVarSummaries
     DbIndex(table_name="observations",
-            index_name="observations_variable_value",
-            indexed_columns=["variable", "value"]),
+            index_name="observations_variable",
+            indexed_columns=["variable"]),
 ]
 
 

--- a/simple/stats/db.py
+++ b/simple/stats/db.py
@@ -184,7 +184,15 @@ _DB_INDEXES: list[DbIndex] = [
             indexed_columns=["entity", "variable"]),
     DbIndex(table_name="triples",
             index_name="triples_subject_id",
-            indexed_columns=["subject_id"])
+            indexed_columns=["subject_id"]),
+    # Used by getStatVarSummaries
+    DbIndex(table_name="triples",
+            index_name="triples_subject_id_predicate",
+            indexed_columns=["subject_id", "predicate"]),
+    # Used by getStatVarSummaries
+    DbIndex(table_name="observations",
+            index_name="observations_variable_value",
+            indexed_columns=["variable", "value"]),
 ]
 
 

--- a/simple/tests/stats/test_data/db/input/sqlite_current_schema_populated.sql
+++ b/simple/tests/stats/test_data/db/input/sqlite_current_schema_populated.sql
@@ -36,7 +36,7 @@ INSERT INTO "triples" VALUES('sub3','name','','name3');
 INSERT INTO "triples" VALUES('sub2','typeOf','StatisticalVariable','');
 INSERT INTO "triples" VALUES('sub2','name','','name2');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
-CREATE INDEX observations_variable_value on observations (variable, value);
+CREATE INDEX observations_variable on observations (variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
 CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
 COMMIT;

--- a/simple/tests/stats/test_data/db/input/sqlite_current_schema_populated.sql
+++ b/simple/tests/stats/test_data/db/input/sqlite_current_schema_populated.sql
@@ -36,5 +36,7 @@ INSERT INTO "triples" VALUES('sub3','name','','name3');
 INSERT INTO "triples" VALUES('sub2','typeOf','StatisticalVariable','');
 INSERT INTO "triples" VALUES('sub2','name','','name2');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
+CREATE INDEX observations_variable_value on observations (variable, value);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
 COMMIT;

--- a/simple/tests/stats/test_data/db/input/sqlite_old_schema_populated.sql
+++ b/simple/tests/stats/test_data/db/input/sqlite_old_schema_populated.sql
@@ -32,7 +32,7 @@ INSERT INTO "triples" VALUES('sub1','name','','name1');
 INSERT INTO "triples" VALUES('sub2','typeOf','StatisticalVariable','');
 INSERT INTO "triples" VALUES('sub2','name','','name2');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
-CREATE INDEX observations_variable_value on observations (variable, value);
+CREATE INDEX observations_variable on observations (variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
 CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
 COMMIT;

--- a/simple/tests/stats/test_data/db/input/sqlite_old_schema_populated.sql
+++ b/simple/tests/stats/test_data/db/input/sqlite_old_schema_populated.sql
@@ -32,5 +32,7 @@ INSERT INTO "triples" VALUES('sub1','name','','name1');
 INSERT INTO "triples" VALUES('sub2','typeOf','StatisticalVariable','');
 INSERT INTO "triples" VALUES('sub2','name','','name2');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
+CREATE INDEX observations_variable_value on observations (variable, value);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/input/input_dir_driven_with_existing_old_schema_data/sqlite_old_schema_populated.sql
+++ b/simple/tests/stats/test_data/runner/input/input_dir_driven_with_existing_old_schema_data/sqlite_old_schema_populated.sql
@@ -32,7 +32,7 @@ INSERT INTO "triples" VALUES('sub1','name','','name1');
 INSERT INTO "triples" VALUES('sub2','typeOf','StatisticalVariable','');
 INSERT INTO "triples" VALUES('sub2','name','','name2');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
-CREATE INDEX observations_variable_value on observations (variable, value);
+CREATE INDEX observations_variable on observations (variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
 CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/input/input_dir_driven_with_existing_old_schema_data/sqlite_old_schema_populated.sql
+++ b/simple/tests/stats/test_data/runner/input/input_dir_driven_with_existing_old_schema_data/sqlite_old_schema_populated.sql
@@ -32,5 +32,7 @@ INSERT INTO "triples" VALUES('sub1','name','','name1');
 INSERT INTO "triples" VALUES('sub2','typeOf','StatisticalVariable','');
 INSERT INTO "triples" VALUES('sub2','name','','name2');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
+CREATE INDEX observations_variable_value on observations (variable, value);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/input/schema_update_only/sqlite_old_schema_populated.sql
+++ b/simple/tests/stats/test_data/runner/input/schema_update_only/sqlite_old_schema_populated.sql
@@ -32,7 +32,7 @@ INSERT INTO "triples" VALUES('sub1','name','','name1');
 INSERT INTO "triples" VALUES('sub2','typeOf','StatisticalVariable','');
 INSERT INTO "triples" VALUES('sub2','name','','name2');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
-CREATE INDEX observations_variable_value on observations (variable, value);
+CREATE INDEX observations_variable on observations (variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
 CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/input/schema_update_only/sqlite_old_schema_populated.sql
+++ b/simple/tests/stats/test_data/runner/input/schema_update_only/sqlite_old_schema_populated.sql
@@ -32,5 +32,7 @@ INSERT INTO "triples" VALUES('sub1','name','','name1');
 INSERT INTO "triples" VALUES('sub2','typeOf','StatisticalVariable','');
 INSERT INTO "triples" VALUES('sub2','name','','name2');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
+CREATE INDEX observations_variable_value on observations (variable, value);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
 COMMIT;


### PR DESCRIPTION
- Improves performance from 30s+ to <200ms
- @keyurva it turns out no SQL query changes are necessary. The query we were experimenting with the other day ended up not being exactly right, but it looks like these indices solve the performance issue
- Tested locally against undata-staging instance

Before:
```
2025/02/28 13:41:49 util.go:474: SQL: GetSVSummaries: 34.594636042s
```

After:
```
2025/02/28 13:43:55 util.go:474: SQL: GetSVSummaries: 141.155ms
```