### PR TITLE
Make spanner table names configurable.

### DIFF
--- a/pipeline/ingestion/src/main/java/org/datacommons/Entity.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/Entity.java
@@ -14,10 +14,14 @@ public class Entity {
   String subjectId;
   String predicate;
   String objectId;
-  @Nullable String objectValue;
-  @Nullable String provenance;
-  @Nullable String name;
-  @Nullable List<String> types;
+  @Nullable
+  String objectValue;
+  @Nullable
+  String provenance;
+  @Nullable
+  String name;
+  @Nullable
+  List<String> types;
 
   public Entity(
       String id,
@@ -55,39 +59,58 @@ public class Entity {
 
   @Override
   public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
     Entity other = (Entity) obj;
     if (id == null) {
-      if (other.id != null) return false;
-    } else if (!id.equals(other.id)) return false;
+      if (other.id != null)
+        return false;
+    } else if (!id.equals(other.id))
+      return false;
     if (subjectId == null) {
-      if (other.subjectId != null) return false;
-    } else if (!subjectId.equals(other.subjectId)) return false;
+      if (other.subjectId != null)
+        return false;
+    } else if (!subjectId.equals(other.subjectId))
+      return false;
     if (predicate == null) {
-      if (other.predicate != null) return false;
-    } else if (!predicate.equals(other.predicate)) return false;
+      if (other.predicate != null)
+        return false;
+    } else if (!predicate.equals(other.predicate))
+      return false;
     if (objectId == null) {
-      if (other.objectId != null) return false;
-    } else if (!objectId.equals(other.objectId)) return false;
+      if (other.objectId != null)
+        return false;
+    } else if (!objectId.equals(other.objectId))
+      return false;
     if (objectValue == null) {
-      if (other.objectValue != null) return false;
-    } else if (!objectValue.equals(other.objectValue)) return false;
+      if (other.objectValue != null)
+        return false;
+    } else if (!objectValue.equals(other.objectValue))
+      return false;
     if (provenance == null) {
-      if (other.provenance != null) return false;
-    } else if (!provenance.equals(other.provenance)) return false;
+      if (other.provenance != null)
+        return false;
+    } else if (!provenance.equals(other.provenance))
+      return false;
     if (name == null) {
-      if (other.name != null) return false;
-    } else if (!name.equals(other.name)) return false;
+      if (other.name != null)
+        return false;
+    } else if (!name.equals(other.name))
+      return false;
     if (types == null) {
-      if (other.types != null) return false;
-    } else if (!types.equals(other.types)) return false;
+      if (other.types != null)
+        return false;
+    } else if (!types.equals(other.types))
+      return false;
     return true;
   }
 
-  public Mutation toNode() {
-    return Mutation.newInsertOrUpdateBuilder("Node")
+  public Mutation toNode(String nodeTableName) {
+    return Mutation.newInsertOrUpdateBuilder(nodeTableName)
         .set("subject_id")
         .to(subjectId)
         .set("name")
@@ -97,8 +120,8 @@ public class Entity {
         .build();
   }
 
-  public Mutation toEdge() {
-    return Mutation.newInsertOrUpdateBuilder("Edge")
+  public Mutation toEdge(String edgeTableName) {
+    return Mutation.newInsertOrUpdateBuilder(edgeTableName)
         .set("id")
         .to(id)
         .set("subject_id")
@@ -114,5 +137,6 @@ public class Entity {
         .build();
   }
 
-  Entity() {}
+  Entity() {
   }
+}

--- a/pipeline/ingestion/src/main/java/org/datacommons/IngestionOptions.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/IngestionOptions.java
@@ -3,36 +3,55 @@ package org.datacommons;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
+
 public interface IngestionOptions extends PipelineOptions {
 
-@Description("GCP project id")
-String getProjectId();
+    @Description("GCP project id")
+    String getProjectId();
 
-void setProjectId(String projectId);
+    void setProjectId(String projectId);
 
-@Description("Spanner Instance Id for output")
-String getSpannerInstanceId();
+    @Description("Spanner Instance Id for output")
+    String getSpannerInstanceId();
 
-void setSpannerInstanceId(String instanceId);
+    void setSpannerInstanceId(String instanceId);
 
-@Description("Spanner Database Id for output")
-String getSpannerDatabaseId();
+    @Description("Spanner Database Id for output")
+    String getSpannerDatabaseId();
 
-void setSpannerDatabaseId(String databaseId);
+    void setSpannerDatabaseId(String databaseId);
 
-@Description("GCS bucket Id for input data")
-String getStorageBucketId();
+    @Description("GCS bucket Id for input data")
+    String getStorageBucketId();
 
-void setStorageBucketId(String bucketId);
+    void setStorageBucketId(String bucketId);
 
-@Description("Import group list in CSV format")
-String getImportGroupList();
+    @Description("Import group list in CSV format")
+    String getImportGroupList();
 
-void setImportGroupList(String importGroupList);
+    void setImportGroupList(String importGroupList);
 
-@Description("Cache type for import (observation/graph)")
-@Default.String("graph")
-String getCacheType();
+    @Description("Cache type for import (observation/graph)")
+    @Default.String("graph")
+    String getCacheType();
 
-void setCacheType(String cacheType);
+    void setCacheType(String cacheType);
+
+    @Description("Spanner Observation table name")
+    @Default.String("Observation")
+    String getSpannerObservationTableName();
+
+    void setSpannerObservationTableName(String tableName);
+
+    @Description("Spanner Node table name")
+    @Default.String("Node")
+    String getSpannerNodeTableName();
+
+    void setSpannerNodeTableName(String tableName);
+
+    @Description("Spanner Edge table name")
+    @Default.String("Edge")
+    String getSpannerEdgeTableName();
+
+    void setSpannerEdgeTableName(String tableName);
 }

--- a/pipeline/ingestion/src/main/java/org/datacommons/Observation.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/Observation.java
@@ -100,8 +100,9 @@ public class Observation {
     return true;
   }
 
-  public Mutation toMutation() {
-    return Mutation.newInsertOrUpdateBuilder("Observation")
+  public Mutation toMutation(String observationTableName) {
+    return Mutation.newInsertOrUpdateBuilder(
+        observationTableName)
         .set("variable_measured")
         .to(variableMeasured)
         .set("observation_about")


### PR DESCRIPTION
Making the table names configurable allows loading into tables with different names without requiring code changes.

Example:

```
mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.datacommons.IngestionPipeline \
-Dexec.args="... --spannerNodeTableName=Nodex --spannerEdgeTableName=Edgex --spannerObservationTableName=Observationx"
```

Note that the formatting changes were applied by the standard vscode formatter. We should choose a formatter and go with it moving forward.