### PR TITLE
Spanner ingestion fixes

### DIFF
--- a/pipeline/ingestion/src/main/java/org/datacommons/CacheReader.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/CacheReader.java
@@ -6,6 +6,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -70,6 +71,7 @@ public class CacheReader {
           try {
             String dcid = keys[0];
             String predicate = keys[1];
+            String typeOf = keys[2];
             PagedEntities elist =
                 PagedEntities.parseFrom(
                     new GZIPInputStream(
@@ -92,6 +94,10 @@ public class CacheReader {
                   nodeId = entity.getDcid();
                 }
               }
+              List<String> types = entity.getTypesList();
+              if (types.isEmpty() && !typeOf.isEmpty()) {
+                types = Arrays.asList(typeOf);
+              }
               // TODO: fix id column.
               Entity e =
                   new Entity(
@@ -103,7 +109,7 @@ public class CacheReader {
                       entity.getProvenanceId(),
                       nodeId,
                       entity.getName(),
-                      entity.getTypesList());
+                      types);
               entities.add(e);
             }
           } catch (IOException e) {

--- a/pipeline/ingestion/src/main/java/org/datacommons/CacheReader.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/CacheReader.java
@@ -75,29 +75,33 @@ public class CacheReader {
                     new GZIPInputStream(
                         new ByteArrayInputStream(Base64.getDecoder().decode(value))));
             for (EntityInfo entity : elist.getEntitiesList()) {
-              String subjectId, objectId;
+              String subjectId, objectId, nodeId = "";
               // Add a self edge if value is populated.
-              if (entity.getValue().isEmpty()) {
+              if (!entity.getValue().isEmpty()) {
                 subjectId = dcid;
                 objectId = dcid;
+                // Terminal edges won't produce any object nodes.
               } else {
                 if (row.startsWith("d/m/")) {
                   subjectId = dcid;
                   objectId = entity.getDcid();
+                  nodeId = entity.getDcid();
                 } else { // "d/l/"
                   subjectId = entity.getDcid();
                   objectId = dcid;
+                  nodeId = entity.getDcid();
                 }
               }
               // TODO: fix id column.
               Entity e =
                   new Entity(
-                      dcid,
+                      subjectId,
                       subjectId,
                       predicate,
                       objectId,
                       entity.getValue(),
                       entity.getProvenanceId(),
+                      nodeId,
                       entity.getName(),
                       entity.getTypesList());
               entities.add(e);

--- a/pipeline/ingestion/src/main/java/org/datacommons/Entity.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/Entity.java
@@ -113,7 +113,7 @@ public class Entity {
     if (types == null) {
       if (other.types != null)
         return false;
-    } else if (!types.equals(other.types)) 
+    } else if (!types.equals(other.types))
       return false;
     return true;
   }

--- a/pipeline/ingestion/src/main/java/org/datacommons/Entity.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/Entity.java
@@ -113,7 +113,7 @@ public class Entity {
     if (types == null) {
       if (other.types != null)
         return false;
-    } else if (!types.equals(other.types))
+    } else if (!types.equals(other.types)) 
       return false;
     return true;
   }
@@ -130,7 +130,7 @@ public class Entity {
           "\n\tnodeId: %s" +
           "\n\tname: %s" +
           "\n\ttypes: %s" +
-          "\n}", id, subjectId, predicate, objectId, objectValue, nodeId, provenance, name, String.join(", ", types));
+          "\n}", id, subjectId, predicate, objectId, objectValue, provenance, nodeId, name, String.join(", ", types));
   }
 
   public Mutation toNode(String nodeTableName) {

--- a/pipeline/ingestion/src/main/java/org/datacommons/Entity.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/Entity.java
@@ -20,6 +20,7 @@ public class Entity {
   String provenance;
   @Nullable
   String name;
+  String nodeId;
   @Nullable
   List<String> types;
 
@@ -30,6 +31,7 @@ public class Entity {
       String objectId,
       String objectValue,
       String provenance,
+      String nodeId,
       String name,
       List<String> types) {
     this.id = id;
@@ -38,6 +40,7 @@ public class Entity {
     this.objectId = objectId;
     this.objectValue = objectValue;
     this.provenance = provenance;
+    this.nodeId = nodeId;
     this.name = name;
     this.types = types;
   }
@@ -52,6 +55,7 @@ public class Entity {
     result = prime * result + ((objectId == null) ? 0 : objectId.hashCode());
     result = prime * result + ((objectValue == null) ? 0 : objectValue.hashCode());
     result = prime * result + ((provenance == null) ? 0 : provenance.hashCode());
+    result = prime * result + ((nodeId == null) ? 0 : nodeId.hashCode());
     result = prime * result + ((name == null) ? 0 : name.hashCode());
     result = prime * result + ((types == null) ? 0 : types.hashCode());
     return result;
@@ -96,6 +100,11 @@ public class Entity {
         return false;
     } else if (!provenance.equals(other.provenance))
       return false;
+    if (nodeId == null) {
+      if (other.nodeId != null)
+        return false;
+    } else if (!nodeId.equals(other.nodeId))
+      return false;
     if (name == null) {
       if (other.name != null)
         return false;
@@ -109,10 +118,25 @@ public class Entity {
     return true;
   }
 
+  @Override
+  public String toString() {
+        return String.format("{" +
+          "\n\tid: %s" +
+          "\n\tsubjectId: %s" +
+          "\n\tpredicate: %s" + 
+          "\n\tobjectId: %s" +
+          "\n\tobjectValue: %s" +
+          "\n\tprovenance: %s" +
+          "\n\tnodeId: %s" +
+          "\n\tname: %s" +
+          "\n\ttypes: %s" +
+          "\n}", id, subjectId, predicate, objectId, objectValue, nodeId, provenance, name, String.join(", ", types));
+  }
+
   public Mutation toNode(String nodeTableName) {
     return Mutation.newInsertOrUpdateBuilder(nodeTableName)
         .set("subject_id")
-        .to(subjectId)
+        .to(nodeId)
         .set("name")
         .to(name)
         .set("types")

--- a/pipeline/ingestion/src/main/java/org/datacommons/Entity.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/Entity.java
@@ -10,17 +10,26 @@ import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 /** Models a graph entity (node/edge). */
 @DefaultCoder(AvroCoder.class)
 public class Entity {
+  // Id of the generated Edge.
   String id;
+  // SubjectId of the generated Edge.
   String subjectId;
+  // Predicate of the generated Edge.
   String predicate;
+  // ObjectId of the generated Edge.
   String objectId;
+  // ObjectValue of the generatedEdge.
   @Nullable
   String objectValue;
+  // Provenance of the generated Edge.
   @Nullable
   String provenance;
+  // SubjectId of the generated Node.
+  String nodeId;
+  // Name of the generated Node.
   @Nullable
   String name;
-  String nodeId;
+  // Types of the generated Node.
   @Nullable
   List<String> types;
 

--- a/pipeline/ingestion/src/main/java/org/datacommons/SpannerClient.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/SpannerClient.java
@@ -50,8 +50,11 @@ public class SpannerClient {
                 new DoFn<Entity, Mutation>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
-                    IngestionOptions options = c.getPipelineOptions().as(IngestionOptions.class);
-                    c.output(c.element().toNode(options.getSpannerNodeTableName()));
+                    // Only emit if node can be created.
+                    if (!c.element().nodeId.isEmpty()) {
+                      IngestionOptions options = c.getPipelineOptions().as(IngestionOptions.class);
+                      c.output(c.element().toNode(options.getSpannerNodeTableName()));
+                    }
                   }
                 }))
         .apply(

--- a/pipeline/ingestion/src/test/java/org/datacommons/IngestionTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/IngestionTest.java
@@ -1,5 +1,7 @@
 package org.datacommons;
 
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Value;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -7,6 +9,7 @@ import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -62,9 +65,13 @@ public class IngestionTest {
     List<String> cache = new ArrayList<>();
     cache.add(
         "d/m/Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person^measuredProperty^Property^0,H4sIAAAAAAAAAOPS5WJNzi/NK5GCUEqyKcn6SYnFqfoepbmJeUGpiSmJSTmpwSWJJWGJRcWCDGDwwR4AejAnwDgAAAA=");
+    cache.add(
+        "d/m/Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person^name^^0,H4sIAAAAAAAAAONqYFSSTUnWT0osTtX3KM1NzAtKTUxJTMpJDS5JLAlLLCrWig9ILUpOzStJTE9VCM8vylYISs1JLElNUQjIqCzOTE7MUXBMLsksyyyp1FHwzU9JLQJKwoUU/IsUPFITyyoRIo65+XnpCgH5BaVAYzLz8wQZwOCDPQA1JajOjAAAAA==");
+    cache.add(
+        "d/l/dc/d/UnitedNationsUn_SdgIndicatorsDatabase^isPartOf^Provenance^0,H4sIAAAAAAAAAOPS4GIL9YsPdnGX4ktJ1k9KLE7Vh/CV0PiCDGDwwR4AhMbiaDMAAAA=");
     PCollection<String> entries = p.apply(Create.of(cache));
     PCollection<Entity> result = CacheReader.getEntities(entries);
-    Entity expected =
+    List<Entity> expected =  Arrays.asList(
         new Entity(
             "Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person",
             "Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person",
@@ -73,8 +80,52 @@ public class IngestionTest {
             "",
             "dc/base/HumanReadableStatVars",
             "count",
-            new ArrayList<>());
+            "count",
+            new ArrayList<>()),
+        new Entity(
+            "Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person",
+            "Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person",
+            "name",
+            "Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person",
+            "Percentage Work Related Physical Activity, Moderate Activity Or Heavy Activity Among Population",
+            "dc/base/HumanReadableStatVars",
+            "",
+            "",
+            new ArrayList<>()),
+        new Entity(
+            "dc/base/UN_SDG",
+            "dc/base/UN_SDG",
+            "isPartOf",
+            "dc/d/UnitedNationsUn_SdgIndicatorsDatabase",
+            "",
+            "dc/base/UN_SDG",
+            "dc/base/UN_SDG",
+            "UN_SDG",
+            new ArrayList<>()));
     PAssert.that(result).containsInAnyOrder(expected);
     p.run();
+  }
+
+  @Test
+  public void testToNode() {
+    Entity out = new Entity(
+        "Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person",
+        "Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person",
+        "measuredProperty",
+        "count",
+        "",
+        "dc/base/HumanReadableStatVars",
+        "count",
+        "count",
+        new ArrayList<>());
+    Mutation outExpected = Mutation.newInsertOrUpdateBuilder("Node")
+        .set("subject_id")
+        .to("count")
+        .set("name")
+        .to("count")
+        .set("types")
+        .to(Value.stringArray(new ArrayList<String>()))
+        .build();
+    Assert.assertTrue(out.toNode("Node").equals(outExpected));
   }
 }

--- a/pipeline/ingestion/src/test/java/org/datacommons/IngestionTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/IngestionTest.java
@@ -81,7 +81,7 @@ public class IngestionTest {
             "dc/base/HumanReadableStatVars",
             "count",
             "count",
-            new ArrayList<>()),
+            List.of("Property")),
         new Entity(
             "Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person",
             "Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person",
@@ -91,7 +91,7 @@ public class IngestionTest {
             "dc/base/HumanReadableStatVars",
             "",
             "",
-            new ArrayList<>()),
+            new ArrayList<String>()),
         new Entity(
             "dc/base/UN_SDG",
             "dc/base/UN_SDG",
@@ -101,7 +101,7 @@ public class IngestionTest {
             "dc/base/UN_SDG",
             "dc/base/UN_SDG",
             "UN_SDG",
-            new ArrayList<>()));
+            List.of("Provenance")));
     PAssert.that(result).containsInAnyOrder(expected);
     p.run();
   }
@@ -117,14 +117,14 @@ public class IngestionTest {
         "dc/base/HumanReadableStatVars",
         "count",
         "count",
-        new ArrayList<>());
+        List.of("Property"));
     Mutation outExpected = Mutation.newInsertOrUpdateBuilder("Node")
         .set("subject_id")
         .to("count")
         .set("name")
         .to("count")
         .set("types")
-        .to(Value.stringArray(new ArrayList<String>()))
+        .to(Value.stringArray(List.of("Property")))
         .build();
     Assert.assertTrue(out.toNode("Node").equals(outExpected));
   }


### PR DESCRIPTION
* Only create self edge when value is /not/ empty 
* Add a new field "nodeId" for creating nodes. This is because the node is always about the EntityInfo, but this sometimes corresponds to subjectId and sometimes the objectId. (This was more of a temporary fix to unblock, but maybe as a follow up we can handle the in/out edges separately, since they differ in a few ways)
* Don't create nodes for terminal edges since there's no object 
* Add type from cache key if not specified in EntityInfo (it looks like it might only be specified for multiple types)
* Add some more unit tests