### PR TITLE
Deprecate ResolveResponse.Entity.resolved_ids from import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
                 <!-- For google-java-format check. Order this after generate-sources since they are in the same phase. -->
                 <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.19</version>
+                <version>2.25</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/util/src/main/java/org/datacommons/proto/Debug.java
+++ b/util/src/main/java/org/datacommons/proto/Debug.java
@@ -27,6 +27,7 @@ public final class Debug {
      * <code>map&lt;string, .org.datacommons.proto.Log.CounterSet&gt; level_summary = 1;</code>
      */
     int getLevelSummaryCount();
+
     /**
      *
      *
@@ -37,9 +38,11 @@ public final class Debug {
      * <code>map&lt;string, .org.datacommons.proto.Log.CounterSet&gt; level_summary = 1;</code>
      */
     boolean containsLevelSummary(java.lang.String key);
+
     /** Use {@link #getLevelSummaryMap()} instead. */
     @java.lang.Deprecated
     java.util.Map<java.lang.String, org.datacommons.proto.Debug.Log.CounterSet> getLevelSummary();
+
     /**
      *
      *
@@ -51,6 +54,7 @@ public final class Debug {
      */
     java.util.Map<java.lang.String, org.datacommons.proto.Debug.Log.CounterSet>
         getLevelSummaryMap();
+
     /**
      *
      *
@@ -62,6 +66,7 @@ public final class Debug {
      */
     org.datacommons.proto.Debug.Log.CounterSet getLevelSummaryOrDefault(
         java.lang.String key, org.datacommons.proto.Debug.Log.CounterSet defaultValue);
+
     /**
      *
      *
@@ -75,13 +80,17 @@ public final class Debug {
 
     /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
     java.util.List<org.datacommons.proto.Debug.Log.Entry> getEntriesList();
+
     /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
     org.datacommons.proto.Debug.Log.Entry getEntries(int index);
+
     /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
     int getEntriesCount();
+
     /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
     java.util.List<? extends org.datacommons.proto.Debug.Log.EntryOrBuilder>
         getEntriesOrBuilderList();
+
     /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
     org.datacommons.proto.Debug.Log.EntryOrBuilder getEntriesOrBuilder(int index);
 
@@ -89,19 +98,23 @@ public final class Debug {
      * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
      */
     java.util.List<org.datacommons.proto.Debug.StatValidationResult> getStatsCheckSummaryList();
+
     /**
      * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
      */
     org.datacommons.proto.Debug.StatValidationResult getStatsCheckSummary(int index);
+
     /**
      * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
      */
     int getStatsCheckSummaryCount();
+
     /**
      * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
      */
     java.util.List<? extends org.datacommons.proto.Debug.StatValidationResultOrBuilder>
         getStatsCheckSummaryOrBuilderList();
+
     /**
      * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
      */
@@ -114,15 +127,18 @@ public final class Debug {
      * @return Whether the commandArgs field is set.
      */
     boolean hasCommandArgs();
+
     /**
      * <code>optional .org.datacommons.proto.CommandArgs command_args = 5;</code>
      *
      * @return The commandArgs.
      */
     org.datacommons.proto.Debug.CommandArgs getCommandArgs();
+
     /** <code>optional .org.datacommons.proto.CommandArgs command_args = 5;</code> */
     org.datacommons.proto.Debug.CommandArgsOrBuilder getCommandArgsOrBuilder();
   }
+
   /**
    *
    *
@@ -137,6 +153,7 @@ public final class Debug {
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.Log)
       LogOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use Log.newBuilder() to construct.
     private Log(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -309,12 +326,16 @@ public final class Debug {
 
       /** <code>LEVEL_UNSPECIFIED = 0;</code> */
       public static final int LEVEL_UNSPECIFIED_VALUE = 0;
+
       /** <code>LEVEL_INFO = 1;</code> */
       public static final int LEVEL_INFO_VALUE = 1;
+
       /** <code>LEVEL_WARNING = 2;</code> */
       public static final int LEVEL_WARNING_VALUE = 2;
+
       /** <code>LEVEL_ERROR = 3;</code> */
       public static final int LEVEL_ERROR_VALUE = 3;
+
       /** <code>LEVEL_FATAL = 4;</code> */
       public static final int LEVEL_FATAL_VALUE = 4;
 
@@ -409,6 +430,7 @@ public final class Debug {
        * <code>map&lt;string, int64&gt; counters = 1;</code>
        */
       int getCountersCount();
+
       /**
        *
        *
@@ -419,9 +441,11 @@ public final class Debug {
        * <code>map&lt;string, int64&gt; counters = 1;</code>
        */
       boolean containsCounters(java.lang.String key);
+
       /** Use {@link #getCountersMap()} instead. */
       @java.lang.Deprecated
       java.util.Map<java.lang.String, java.lang.Long> getCounters();
+
       /**
        *
        *
@@ -432,6 +456,7 @@ public final class Debug {
        * <code>map&lt;string, int64&gt; counters = 1;</code>
        */
       java.util.Map<java.lang.String, java.lang.Long> getCountersMap();
+
       /**
        *
        *
@@ -442,6 +467,7 @@ public final class Debug {
        * <code>map&lt;string, int64&gt; counters = 1;</code>
        */
       long getCountersOrDefault(java.lang.String key, long defaultValue);
+
       /**
        *
        *
@@ -453,12 +479,14 @@ public final class Debug {
        */
       long getCountersOrThrow(java.lang.String key);
     }
+
     /** Protobuf type {@code org.datacommons.proto.Log.CounterSet} */
     public static final class CounterSet extends com.google.protobuf.GeneratedMessageV3
         implements
         // @@protoc_insertion_point(message_implements:org.datacommons.proto.Log.CounterSet)
         CounterSetOrBuilder {
       private static final long serialVersionUID = 0L;
+
       // Use CounterSet.newBuilder() to construct.
       private CounterSet(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
@@ -583,6 +611,7 @@ public final class Debug {
       public int getCountersCount() {
         return internalGetCounters().getMap().size();
       }
+
       /**
        *
        *
@@ -599,12 +628,14 @@ public final class Debug {
         }
         return internalGetCounters().getMap().containsKey(key);
       }
+
       /** Use {@link #getCountersMap()} instead. */
       @java.lang.Override
       @java.lang.Deprecated
       public java.util.Map<java.lang.String, java.lang.Long> getCounters() {
         return getCountersMap();
       }
+
       /**
        *
        *
@@ -618,6 +649,7 @@ public final class Debug {
       public java.util.Map<java.lang.String, java.lang.Long> getCountersMap() {
         return internalGetCounters().getMap();
       }
+
       /**
        *
        *
@@ -635,6 +667,7 @@ public final class Debug {
         java.util.Map<java.lang.String, java.lang.Long> map = internalGetCounters().getMap();
         return map.containsKey(key) ? map.get(key) : defaultValue;
       }
+
       /**
        *
        *
@@ -824,6 +857,7 @@ public final class Debug {
         Builder builder = new Builder(parent);
         return builder;
       }
+
       /** Protobuf type {@code org.datacommons.proto.Log.CounterSet} */
       public static final class Builder
           extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -1024,6 +1058,7 @@ public final class Debug {
         public int getCountersCount() {
           return internalGetCounters().getMap().size();
         }
+
         /**
          *
          *
@@ -1040,12 +1075,14 @@ public final class Debug {
           }
           return internalGetCounters().getMap().containsKey(key);
         }
+
         /** Use {@link #getCountersMap()} instead. */
         @java.lang.Override
         @java.lang.Deprecated
         public java.util.Map<java.lang.String, java.lang.Long> getCounters() {
           return getCountersMap();
         }
+
         /**
          *
          *
@@ -1059,6 +1096,7 @@ public final class Debug {
         public java.util.Map<java.lang.String, java.lang.Long> getCountersMap() {
           return internalGetCounters().getMap();
         }
+
         /**
          *
          *
@@ -1076,6 +1114,7 @@ public final class Debug {
           java.util.Map<java.lang.String, java.lang.Long> map = internalGetCounters().getMap();
           return map.containsKey(key) ? map.get(key) : defaultValue;
         }
+
         /**
          *
          *
@@ -1101,6 +1140,7 @@ public final class Debug {
           internalGetMutableCounters().getMutableMap().clear();
           return this;
         }
+
         /**
          *
          *
@@ -1117,11 +1157,13 @@ public final class Debug {
           internalGetMutableCounters().getMutableMap().remove(key);
           return this;
         }
+
         /** Use alternate mutation accessors instead. */
         @java.lang.Deprecated
         public java.util.Map<java.lang.String, java.lang.Long> getMutableCounters() {
           return internalGetMutableCounters().getMutableMap();
         }
+
         /**
          *
          *
@@ -1139,6 +1181,7 @@ public final class Debug {
           internalGetMutableCounters().getMutableMap().put(key, value);
           return this;
         }
+
         /**
          *
          *
@@ -1217,6 +1260,7 @@ public final class Debug {
        * @return Whether the level field is set.
        */
       boolean hasLevel();
+
       /**
        * <code>optional .org.datacommons.proto.Log.Level level = 1;</code>
        *
@@ -1230,12 +1274,14 @@ public final class Debug {
        * @return Whether the location field is set.
        */
       boolean hasLocation();
+
       /**
        * <code>optional .org.datacommons.proto.Location location = 2;</code>
        *
        * @return The location.
        */
       org.datacommons.proto.LogLocation.Location getLocation();
+
       /** <code>optional .org.datacommons.proto.Location location = 2;</code> */
       org.datacommons.proto.LogLocation.LocationOrBuilder getLocationOrBuilder();
 
@@ -1251,6 +1297,7 @@ public final class Debug {
        * @return Whether the userMessage field is set.
        */
       boolean hasUserMessage();
+
       /**
        *
        *
@@ -1263,6 +1310,7 @@ public final class Debug {
        * @return The userMessage.
        */
       java.lang.String getUserMessage();
+
       /**
        *
        *
@@ -1288,6 +1336,7 @@ public final class Debug {
        * @return Whether the counterKey field is set.
        */
       boolean hasCounterKey();
+
       /**
        *
        *
@@ -1300,6 +1349,7 @@ public final class Debug {
        * @return The counterKey.
        */
       java.lang.String getCounterKey();
+
       /**
        *
        *
@@ -1327,6 +1377,7 @@ public final class Debug {
        * @return A list containing the columnName.
        */
       java.util.List<java.lang.String> getColumnNameList();
+
       /**
        *
        *
@@ -1341,6 +1392,7 @@ public final class Debug {
        * @return The count of columnName.
        */
       int getColumnNameCount();
+
       /**
        *
        *
@@ -1356,6 +1408,7 @@ public final class Debug {
        * @return The columnName at the given index.
        */
       java.lang.String getColumnName(int index);
+
       /**
        *
        *
@@ -1372,6 +1425,7 @@ public final class Debug {
        */
       com.google.protobuf.ByteString getColumnNameBytes(int index);
     }
+
     /**
      *
      *
@@ -1387,6 +1441,7 @@ public final class Debug {
         // @@protoc_insertion_point(message_implements:org.datacommons.proto.Log.Entry)
         EntryOrBuilder {
       private static final long serialVersionUID = 0L;
+
       // Use Entry.newBuilder() to construct.
       private Entry(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
@@ -1524,6 +1579,7 @@ public final class Debug {
       private int bitField0_;
       public static final int LEVEL_FIELD_NUMBER = 1;
       private int level_;
+
       /**
        * <code>optional .org.datacommons.proto.Log.Level level = 1;</code>
        *
@@ -1533,6 +1589,7 @@ public final class Debug {
       public boolean hasLevel() {
         return ((bitField0_ & 0x00000001) != 0);
       }
+
       /**
        * <code>optional .org.datacommons.proto.Log.Level level = 1;</code>
        *
@@ -1548,6 +1605,7 @@ public final class Debug {
 
       public static final int LOCATION_FIELD_NUMBER = 2;
       private org.datacommons.proto.LogLocation.Location location_;
+
       /**
        * <code>optional .org.datacommons.proto.Location location = 2;</code>
        *
@@ -1557,6 +1615,7 @@ public final class Debug {
       public boolean hasLocation() {
         return ((bitField0_ & 0x00000002) != 0);
       }
+
       /**
        * <code>optional .org.datacommons.proto.Location location = 2;</code>
        *
@@ -1568,6 +1627,7 @@ public final class Debug {
             ? org.datacommons.proto.LogLocation.Location.getDefaultInstance()
             : location_;
       }
+
       /** <code>optional .org.datacommons.proto.Location location = 2;</code> */
       @java.lang.Override
       public org.datacommons.proto.LogLocation.LocationOrBuilder getLocationOrBuilder() {
@@ -1578,6 +1638,7 @@ public final class Debug {
 
       public static final int USER_MESSAGE_FIELD_NUMBER = 3;
       private volatile java.lang.Object userMessage_;
+
       /**
        *
        *
@@ -1593,6 +1654,7 @@ public final class Debug {
       public boolean hasUserMessage() {
         return ((bitField0_ & 0x00000004) != 0);
       }
+
       /**
        *
        *
@@ -1618,6 +1680,7 @@ public final class Debug {
           return s;
         }
       }
+
       /**
        *
        *
@@ -1644,6 +1707,7 @@ public final class Debug {
 
       public static final int COUNTER_KEY_FIELD_NUMBER = 4;
       private volatile java.lang.Object counterKey_;
+
       /**
        *
        *
@@ -1659,6 +1723,7 @@ public final class Debug {
       public boolean hasCounterKey() {
         return ((bitField0_ & 0x00000008) != 0);
       }
+
       /**
        *
        *
@@ -1684,6 +1749,7 @@ public final class Debug {
           return s;
         }
       }
+
       /**
        *
        *
@@ -1710,6 +1776,7 @@ public final class Debug {
 
       public static final int COLUMN_NAME_FIELD_NUMBER = 5;
       private com.google.protobuf.LazyStringList columnName_;
+
       /**
        *
        *
@@ -1726,6 +1793,7 @@ public final class Debug {
       public com.google.protobuf.ProtocolStringList getColumnNameList() {
         return columnName_;
       }
+
       /**
        *
        *
@@ -1742,6 +1810,7 @@ public final class Debug {
       public int getColumnNameCount() {
         return columnName_.size();
       }
+
       /**
        *
        *
@@ -1759,6 +1828,7 @@ public final class Debug {
       public java.lang.String getColumnName(int index) {
         return columnName_.get(index);
       }
+
       /**
        *
        *
@@ -1999,6 +2069,7 @@ public final class Debug {
         Builder builder = new Builder(parent);
         return builder;
       }
+
       /**
        *
        *
@@ -2226,6 +2297,7 @@ public final class Debug {
         private int bitField0_;
 
         private int level_ = 0;
+
         /**
          * <code>optional .org.datacommons.proto.Log.Level level = 1;</code>
          *
@@ -2235,6 +2307,7 @@ public final class Debug {
         public boolean hasLevel() {
           return ((bitField0_ & 0x00000001) != 0);
         }
+
         /**
          * <code>optional .org.datacommons.proto.Log.Level level = 1;</code>
          *
@@ -2247,6 +2320,7 @@ public final class Debug {
               org.datacommons.proto.Debug.Log.Level.valueOf(level_);
           return result == null ? org.datacommons.proto.Debug.Log.Level.LEVEL_UNSPECIFIED : result;
         }
+
         /**
          * <code>optional .org.datacommons.proto.Log.Level level = 1;</code>
          *
@@ -2262,6 +2336,7 @@ public final class Debug {
           onChanged();
           return this;
         }
+
         /**
          * <code>optional .org.datacommons.proto.Log.Level level = 1;</code>
          *
@@ -2280,6 +2355,7 @@ public final class Debug {
                 org.datacommons.proto.LogLocation.Location.Builder,
                 org.datacommons.proto.LogLocation.LocationOrBuilder>
             locationBuilder_;
+
         /**
          * <code>optional .org.datacommons.proto.Location location = 2;</code>
          *
@@ -2288,6 +2364,7 @@ public final class Debug {
         public boolean hasLocation() {
           return ((bitField0_ & 0x00000002) != 0);
         }
+
         /**
          * <code>optional .org.datacommons.proto.Location location = 2;</code>
          *
@@ -2302,6 +2379,7 @@ public final class Debug {
             return locationBuilder_.getMessage();
           }
         }
+
         /** <code>optional .org.datacommons.proto.Location location = 2;</code> */
         public Builder setLocation(org.datacommons.proto.LogLocation.Location value) {
           if (locationBuilder_ == null) {
@@ -2316,6 +2394,7 @@ public final class Debug {
           bitField0_ |= 0x00000002;
           return this;
         }
+
         /** <code>optional .org.datacommons.proto.Location location = 2;</code> */
         public Builder setLocation(
             org.datacommons.proto.LogLocation.Location.Builder builderForValue) {
@@ -2328,6 +2407,7 @@ public final class Debug {
           bitField0_ |= 0x00000002;
           return this;
         }
+
         /** <code>optional .org.datacommons.proto.Location location = 2;</code> */
         public Builder mergeLocation(org.datacommons.proto.LogLocation.Location value) {
           if (locationBuilder_ == null) {
@@ -2348,6 +2428,7 @@ public final class Debug {
           bitField0_ |= 0x00000002;
           return this;
         }
+
         /** <code>optional .org.datacommons.proto.Location location = 2;</code> */
         public Builder clearLocation() {
           if (locationBuilder_ == null) {
@@ -2359,12 +2440,14 @@ public final class Debug {
           bitField0_ = (bitField0_ & ~0x00000002);
           return this;
         }
+
         /** <code>optional .org.datacommons.proto.Location location = 2;</code> */
         public org.datacommons.proto.LogLocation.Location.Builder getLocationBuilder() {
           bitField0_ |= 0x00000002;
           onChanged();
           return getLocationFieldBuilder().getBuilder();
         }
+
         /** <code>optional .org.datacommons.proto.Location location = 2;</code> */
         public org.datacommons.proto.LogLocation.LocationOrBuilder getLocationOrBuilder() {
           if (locationBuilder_ != null) {
@@ -2375,6 +2458,7 @@ public final class Debug {
                 : location_;
           }
         }
+
         /** <code>optional .org.datacommons.proto.Location location = 2;</code> */
         private com.google.protobuf.SingleFieldBuilderV3<
                 org.datacommons.proto.LogLocation.Location,
@@ -2394,6 +2478,7 @@ public final class Debug {
         }
 
         private java.lang.Object userMessage_ = "";
+
         /**
          *
          *
@@ -2408,6 +2493,7 @@ public final class Debug {
         public boolean hasUserMessage() {
           return ((bitField0_ & 0x00000004) != 0);
         }
+
         /**
          *
          *
@@ -2432,6 +2518,7 @@ public final class Debug {
             return (java.lang.String) ref;
           }
         }
+
         /**
          *
          *
@@ -2454,6 +2541,7 @@ public final class Debug {
             return (com.google.protobuf.ByteString) ref;
           }
         }
+
         /**
          *
          *
@@ -2475,6 +2563,7 @@ public final class Debug {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -2492,6 +2581,7 @@ public final class Debug {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -2515,6 +2605,7 @@ public final class Debug {
         }
 
         private java.lang.Object counterKey_ = "";
+
         /**
          *
          *
@@ -2529,6 +2620,7 @@ public final class Debug {
         public boolean hasCounterKey() {
           return ((bitField0_ & 0x00000008) != 0);
         }
+
         /**
          *
          *
@@ -2553,6 +2645,7 @@ public final class Debug {
             return (java.lang.String) ref;
           }
         }
+
         /**
          *
          *
@@ -2575,6 +2668,7 @@ public final class Debug {
             return (com.google.protobuf.ByteString) ref;
           }
         }
+
         /**
          *
          *
@@ -2596,6 +2690,7 @@ public final class Debug {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -2613,6 +2708,7 @@ public final class Debug {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -2644,6 +2740,7 @@ public final class Debug {
             bitField0_ |= 0x00000010;
           }
         }
+
         /**
          *
          *
@@ -2660,6 +2757,7 @@ public final class Debug {
         public com.google.protobuf.ProtocolStringList getColumnNameList() {
           return columnName_.getUnmodifiableView();
         }
+
         /**
          *
          *
@@ -2676,6 +2774,7 @@ public final class Debug {
         public int getColumnNameCount() {
           return columnName_.size();
         }
+
         /**
          *
          *
@@ -2693,6 +2792,7 @@ public final class Debug {
         public java.lang.String getColumnName(int index) {
           return columnName_.get(index);
         }
+
         /**
          *
          *
@@ -2710,6 +2810,7 @@ public final class Debug {
         public com.google.protobuf.ByteString getColumnNameBytes(int index) {
           return columnName_.getByteString(index);
         }
+
         /**
          *
          *
@@ -2734,6 +2835,7 @@ public final class Debug {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -2757,6 +2859,7 @@ public final class Debug {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -2777,6 +2880,7 @@ public final class Debug {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -2796,6 +2900,7 @@ public final class Debug {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -2907,6 +3012,7 @@ public final class Debug {
     public int getLevelSummaryCount() {
       return internalGetLevelSummary().getMap().size();
     }
+
     /**
      *
      *
@@ -2923,6 +3029,7 @@ public final class Debug {
       }
       return internalGetLevelSummary().getMap().containsKey(key);
     }
+
     /** Use {@link #getLevelSummaryMap()} instead. */
     @java.lang.Override
     @java.lang.Deprecated
@@ -2930,6 +3037,7 @@ public final class Debug {
         getLevelSummary() {
       return getLevelSummaryMap();
     }
+
     /**
      *
      *
@@ -2944,6 +3052,7 @@ public final class Debug {
         getLevelSummaryMap() {
       return internalGetLevelSummary().getMap();
     }
+
     /**
      *
      *
@@ -2963,6 +3072,7 @@ public final class Debug {
           internalGetLevelSummary().getMap();
       return map.containsKey(key) ? map.get(key) : defaultValue;
     }
+
     /**
      *
      *
@@ -2987,27 +3097,32 @@ public final class Debug {
 
     public static final int ENTRIES_FIELD_NUMBER = 3;
     private java.util.List<org.datacommons.proto.Debug.Log.Entry> entries_;
+
     /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
     @java.lang.Override
     public java.util.List<org.datacommons.proto.Debug.Log.Entry> getEntriesList() {
       return entries_;
     }
+
     /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
     @java.lang.Override
     public java.util.List<? extends org.datacommons.proto.Debug.Log.EntryOrBuilder>
         getEntriesOrBuilderList() {
       return entries_;
     }
+
     /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
     @java.lang.Override
     public int getEntriesCount() {
       return entries_.size();
     }
+
     /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
     @java.lang.Override
     public org.datacommons.proto.Debug.Log.Entry getEntries(int index) {
       return entries_.get(index);
     }
+
     /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
     @java.lang.Override
     public org.datacommons.proto.Debug.Log.EntryOrBuilder getEntriesOrBuilder(int index) {
@@ -3016,6 +3131,7 @@ public final class Debug {
 
     public static final int STATS_CHECK_SUMMARY_FIELD_NUMBER = 4;
     private java.util.List<org.datacommons.proto.Debug.StatValidationResult> statsCheckSummary_;
+
     /**
      * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
      */
@@ -3024,6 +3140,7 @@ public final class Debug {
         getStatsCheckSummaryList() {
       return statsCheckSummary_;
     }
+
     /**
      * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
      */
@@ -3032,6 +3149,7 @@ public final class Debug {
         getStatsCheckSummaryOrBuilderList() {
       return statsCheckSummary_;
     }
+
     /**
      * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
      */
@@ -3039,6 +3157,7 @@ public final class Debug {
     public int getStatsCheckSummaryCount() {
       return statsCheckSummary_.size();
     }
+
     /**
      * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
      */
@@ -3046,6 +3165,7 @@ public final class Debug {
     public org.datacommons.proto.Debug.StatValidationResult getStatsCheckSummary(int index) {
       return statsCheckSummary_.get(index);
     }
+
     /**
      * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
      */
@@ -3057,6 +3177,7 @@ public final class Debug {
 
     public static final int COMMAND_ARGS_FIELD_NUMBER = 5;
     private org.datacommons.proto.Debug.CommandArgs commandArgs_;
+
     /**
      * <code>optional .org.datacommons.proto.CommandArgs command_args = 5;</code>
      *
@@ -3066,6 +3187,7 @@ public final class Debug {
     public boolean hasCommandArgs() {
       return ((bitField0_ & 0x00000001) != 0);
     }
+
     /**
      * <code>optional .org.datacommons.proto.CommandArgs command_args = 5;</code>
      *
@@ -3077,6 +3199,7 @@ public final class Debug {
           ? org.datacommons.proto.Debug.CommandArgs.getDefaultInstance()
           : commandArgs_;
     }
+
     /** <code>optional .org.datacommons.proto.CommandArgs command_args = 5;</code> */
     @java.lang.Override
     public org.datacommons.proto.Debug.CommandArgsOrBuilder getCommandArgsOrBuilder() {
@@ -3289,6 +3412,7 @@ public final class Debug {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /**
      *
      *
@@ -3605,6 +3729,7 @@ public final class Debug {
       public int getLevelSummaryCount() {
         return internalGetLevelSummary().getMap().size();
       }
+
       /**
        *
        *
@@ -3621,6 +3746,7 @@ public final class Debug {
         }
         return internalGetLevelSummary().getMap().containsKey(key);
       }
+
       /** Use {@link #getLevelSummaryMap()} instead. */
       @java.lang.Override
       @java.lang.Deprecated
@@ -3628,6 +3754,7 @@ public final class Debug {
           getLevelSummary() {
         return getLevelSummaryMap();
       }
+
       /**
        *
        *
@@ -3642,6 +3769,7 @@ public final class Debug {
           getLevelSummaryMap() {
         return internalGetLevelSummary().getMap();
       }
+
       /**
        *
        *
@@ -3661,6 +3789,7 @@ public final class Debug {
             internalGetLevelSummary().getMap();
         return map.containsKey(key) ? map.get(key) : defaultValue;
       }
+
       /**
        *
        *
@@ -3688,6 +3817,7 @@ public final class Debug {
         internalGetMutableLevelSummary().getMutableMap().clear();
         return this;
       }
+
       /**
        *
        *
@@ -3704,12 +3834,14 @@ public final class Debug {
         internalGetMutableLevelSummary().getMutableMap().remove(key);
         return this;
       }
+
       /** Use alternate mutation accessors instead. */
       @java.lang.Deprecated
       public java.util.Map<java.lang.String, org.datacommons.proto.Debug.Log.CounterSet>
           getMutableLevelSummary() {
         return internalGetMutableLevelSummary().getMutableMap();
       }
+
       /**
        *
        *
@@ -3730,6 +3862,7 @@ public final class Debug {
         internalGetMutableLevelSummary().getMutableMap().put(key, value);
         return this;
       }
+
       /**
        *
        *
@@ -3769,6 +3902,7 @@ public final class Debug {
           return entriesBuilder_.getMessageList();
         }
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public int getEntriesCount() {
         if (entriesBuilder_ == null) {
@@ -3777,6 +3911,7 @@ public final class Debug {
           return entriesBuilder_.getCount();
         }
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public org.datacommons.proto.Debug.Log.Entry getEntries(int index) {
         if (entriesBuilder_ == null) {
@@ -3785,6 +3920,7 @@ public final class Debug {
           return entriesBuilder_.getMessage(index);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public Builder setEntries(int index, org.datacommons.proto.Debug.Log.Entry value) {
         if (entriesBuilder_ == null) {
@@ -3799,6 +3935,7 @@ public final class Debug {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public Builder setEntries(
           int index, org.datacommons.proto.Debug.Log.Entry.Builder builderForValue) {
@@ -3811,6 +3948,7 @@ public final class Debug {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public Builder addEntries(org.datacommons.proto.Debug.Log.Entry value) {
         if (entriesBuilder_ == null) {
@@ -3825,6 +3963,7 @@ public final class Debug {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public Builder addEntries(int index, org.datacommons.proto.Debug.Log.Entry value) {
         if (entriesBuilder_ == null) {
@@ -3839,6 +3978,7 @@ public final class Debug {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public Builder addEntries(org.datacommons.proto.Debug.Log.Entry.Builder builderForValue) {
         if (entriesBuilder_ == null) {
@@ -3850,6 +3990,7 @@ public final class Debug {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public Builder addEntries(
           int index, org.datacommons.proto.Debug.Log.Entry.Builder builderForValue) {
@@ -3862,6 +4003,7 @@ public final class Debug {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public Builder addAllEntries(
           java.lang.Iterable<? extends org.datacommons.proto.Debug.Log.Entry> values) {
@@ -3874,6 +4016,7 @@ public final class Debug {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public Builder clearEntries() {
         if (entriesBuilder_ == null) {
@@ -3885,6 +4028,7 @@ public final class Debug {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public Builder removeEntries(int index) {
         if (entriesBuilder_ == null) {
@@ -3896,10 +4040,12 @@ public final class Debug {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public org.datacommons.proto.Debug.Log.Entry.Builder getEntriesBuilder(int index) {
         return getEntriesFieldBuilder().getBuilder(index);
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public org.datacommons.proto.Debug.Log.EntryOrBuilder getEntriesOrBuilder(int index) {
         if (entriesBuilder_ == null) {
@@ -3908,6 +4054,7 @@ public final class Debug {
           return entriesBuilder_.getMessageOrBuilder(index);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public java.util.List<? extends org.datacommons.proto.Debug.Log.EntryOrBuilder>
           getEntriesOrBuilderList() {
@@ -3917,16 +4064,19 @@ public final class Debug {
           return java.util.Collections.unmodifiableList(entries_);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public org.datacommons.proto.Debug.Log.Entry.Builder addEntriesBuilder() {
         return getEntriesFieldBuilder()
             .addBuilder(org.datacommons.proto.Debug.Log.Entry.getDefaultInstance());
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public org.datacommons.proto.Debug.Log.Entry.Builder addEntriesBuilder(int index) {
         return getEntriesFieldBuilder()
             .addBuilder(index, org.datacommons.proto.Debug.Log.Entry.getDefaultInstance());
       }
+
       /** <code>repeated .org.datacommons.proto.Log.Entry entries = 3;</code> */
       public java.util.List<org.datacommons.proto.Debug.Log.Entry.Builder> getEntriesBuilderList() {
         return getEntriesFieldBuilder().getBuilderList();
@@ -3978,6 +4128,7 @@ public final class Debug {
           return statsCheckSummaryBuilder_.getMessageList();
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -3988,6 +4139,7 @@ public final class Debug {
           return statsCheckSummaryBuilder_.getCount();
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -3998,6 +4150,7 @@ public final class Debug {
           return statsCheckSummaryBuilder_.getMessage(index);
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4015,6 +4168,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4029,6 +4183,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4045,6 +4200,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4062,6 +4218,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4076,6 +4233,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4090,6 +4248,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4104,6 +4263,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4117,6 +4277,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4130,6 +4291,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4137,6 +4299,7 @@ public final class Debug {
           int index) {
         return getStatsCheckSummaryFieldBuilder().getBuilder(index);
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4148,6 +4311,7 @@ public final class Debug {
           return statsCheckSummaryBuilder_.getMessageOrBuilder(index);
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4159,6 +4323,7 @@ public final class Debug {
           return java.util.Collections.unmodifiableList(statsCheckSummary_);
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4167,6 +4332,7 @@ public final class Debug {
         return getStatsCheckSummaryFieldBuilder()
             .addBuilder(org.datacommons.proto.Debug.StatValidationResult.getDefaultInstance());
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4176,6 +4342,7 @@ public final class Debug {
             .addBuilder(
                 index, org.datacommons.proto.Debug.StatValidationResult.getDefaultInstance());
       }
+
       /**
        * <code>repeated .org.datacommons.proto.StatValidationResult stats_check_summary = 4;</code>
        */
@@ -4210,6 +4377,7 @@ public final class Debug {
               org.datacommons.proto.Debug.CommandArgs.Builder,
               org.datacommons.proto.Debug.CommandArgsOrBuilder>
           commandArgsBuilder_;
+
       /**
        * <code>optional .org.datacommons.proto.CommandArgs command_args = 5;</code>
        *
@@ -4218,6 +4386,7 @@ public final class Debug {
       public boolean hasCommandArgs() {
         return ((bitField0_ & 0x00000008) != 0);
       }
+
       /**
        * <code>optional .org.datacommons.proto.CommandArgs command_args = 5;</code>
        *
@@ -4232,6 +4401,7 @@ public final class Debug {
           return commandArgsBuilder_.getMessage();
         }
       }
+
       /** <code>optional .org.datacommons.proto.CommandArgs command_args = 5;</code> */
       public Builder setCommandArgs(org.datacommons.proto.Debug.CommandArgs value) {
         if (commandArgsBuilder_ == null) {
@@ -4246,6 +4416,7 @@ public final class Debug {
         bitField0_ |= 0x00000008;
         return this;
       }
+
       /** <code>optional .org.datacommons.proto.CommandArgs command_args = 5;</code> */
       public Builder setCommandArgs(
           org.datacommons.proto.Debug.CommandArgs.Builder builderForValue) {
@@ -4258,6 +4429,7 @@ public final class Debug {
         bitField0_ |= 0x00000008;
         return this;
       }
+
       /** <code>optional .org.datacommons.proto.CommandArgs command_args = 5;</code> */
       public Builder mergeCommandArgs(org.datacommons.proto.Debug.CommandArgs value) {
         if (commandArgsBuilder_ == null) {
@@ -4278,6 +4450,7 @@ public final class Debug {
         bitField0_ |= 0x00000008;
         return this;
       }
+
       /** <code>optional .org.datacommons.proto.CommandArgs command_args = 5;</code> */
       public Builder clearCommandArgs() {
         if (commandArgsBuilder_ == null) {
@@ -4289,12 +4462,14 @@ public final class Debug {
         bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
+
       /** <code>optional .org.datacommons.proto.CommandArgs command_args = 5;</code> */
       public org.datacommons.proto.Debug.CommandArgs.Builder getCommandArgsBuilder() {
         bitField0_ |= 0x00000008;
         onChanged();
         return getCommandArgsFieldBuilder().getBuilder();
       }
+
       /** <code>optional .org.datacommons.proto.CommandArgs command_args = 5;</code> */
       public org.datacommons.proto.Debug.CommandArgsOrBuilder getCommandArgsOrBuilder() {
         if (commandArgsBuilder_ != null) {
@@ -4305,6 +4480,7 @@ public final class Debug {
               : commandArgs_;
         }
       }
+
       /** <code>optional .org.datacommons.proto.CommandArgs command_args = 5;</code> */
       private com.google.protobuf.SingleFieldBuilderV3<
               org.datacommons.proto.Debug.CommandArgs,
@@ -4387,6 +4563,7 @@ public final class Debug {
      * @return Whether the existenceChecks field is set.
      */
     boolean hasExistenceChecks();
+
     /**
      * <code>optional bool existence_checks = 1;</code>
      *
@@ -4400,6 +4577,7 @@ public final class Debug {
      * @return Whether the resolution field is set.
      */
     boolean hasResolution();
+
     /**
      * <code>optional .org.datacommons.proto.CommandArgs.ResolutionMode resolution = 2;</code>
      *
@@ -4413,6 +4591,7 @@ public final class Debug {
      * @return Whether the numThreads field is set.
      */
     boolean hasNumThreads();
+
     /**
      * <code>optional int32 num_threads = 3;</code>
      *
@@ -4426,6 +4605,7 @@ public final class Debug {
      * @return Whether the statChecks field is set.
      */
     boolean hasStatChecks();
+
     /**
      * <code>optional bool stat_checks = 4;</code>
      *
@@ -4439,12 +4619,14 @@ public final class Debug {
      * @return A list containing the samplePlaces.
      */
     java.util.List<java.lang.String> getSamplePlacesList();
+
     /**
      * <code>repeated string sample_places = 5;</code>
      *
      * @return The count of samplePlaces.
      */
     int getSamplePlacesCount();
+
     /**
      * <code>repeated string sample_places = 5;</code>
      *
@@ -4452,6 +4634,7 @@ public final class Debug {
      * @return The samplePlaces at the given index.
      */
     java.lang.String getSamplePlaces(int index);
+
     /**
      * <code>repeated string sample_places = 5;</code>
      *
@@ -4466,6 +4649,7 @@ public final class Debug {
      * @return Whether the observationAbout field is set.
      */
     boolean hasObservationAbout();
+
     /**
      * <code>optional bool observation_about = 6;</code>
      *
@@ -4485,6 +4669,7 @@ public final class Debug {
      * @return Whether the allowNanSvobs field is set.
      */
     boolean hasAllowNanSvobs();
+
     /**
      *
      *
@@ -4510,6 +4695,7 @@ public final class Debug {
      * @return Whether the checkMeasurementResult field is set.
      */
     boolean hasCheckMeasurementResult();
+
     /**
      *
      *
@@ -4529,6 +4715,7 @@ public final class Debug {
      * @return Whether the coordinatesResolution field is set.
      */
     boolean hasCoordinatesResolution();
+
     /**
      * <code>optional bool coordinates_resolution = 9;</code>
      *
@@ -4536,12 +4723,14 @@ public final class Debug {
      */
     boolean getCoordinatesResolution();
   }
+
   /** Protobuf type {@code org.datacommons.proto.CommandArgs} */
   public static final class CommandArgs extends com.google.protobuf.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.CommandArgs)
       CommandArgsOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use CommandArgs.newBuilder() to construct.
     private CommandArgs(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -4724,6 +4913,7 @@ public final class Debug {
 
       /** <code>RESOLUTION_MODE_UNSPECIFIED = 0;</code> */
       public static final int RESOLUTION_MODE_UNSPECIFIED_VALUE = 0;
+
       /**
        *
        *
@@ -4734,6 +4924,7 @@ public final class Debug {
        * <code>RESOLUTION_MODE_NONE = 1;</code>
        */
       public static final int RESOLUTION_MODE_NONE_VALUE = 1;
+
       /**
        *
        *
@@ -4745,6 +4936,7 @@ public final class Debug {
        * <code>RESOLUTION_MODE_LOCAL = 2;</code>
        */
       public static final int RESOLUTION_MODE_LOCAL_VALUE = 2;
+
       /**
        *
        *
@@ -4835,6 +5027,7 @@ public final class Debug {
     private int bitField0_;
     public static final int EXISTENCE_CHECKS_FIELD_NUMBER = 1;
     private boolean existenceChecks_;
+
     /**
      * <code>optional bool existence_checks = 1;</code>
      *
@@ -4844,6 +5037,7 @@ public final class Debug {
     public boolean hasExistenceChecks() {
       return ((bitField0_ & 0x00000001) != 0);
     }
+
     /**
      * <code>optional bool existence_checks = 1;</code>
      *
@@ -4856,6 +5050,7 @@ public final class Debug {
 
     public static final int RESOLUTION_FIELD_NUMBER = 2;
     private int resolution_;
+
     /**
      * <code>optional .org.datacommons.proto.CommandArgs.ResolutionMode resolution = 2;</code>
      *
@@ -4865,6 +5060,7 @@ public final class Debug {
     public boolean hasResolution() {
       return ((bitField0_ & 0x00000002) != 0);
     }
+
     /**
      * <code>optional .org.datacommons.proto.CommandArgs.ResolutionMode resolution = 2;</code>
      *
@@ -4882,6 +5078,7 @@ public final class Debug {
 
     public static final int NUM_THREADS_FIELD_NUMBER = 3;
     private int numThreads_;
+
     /**
      * <code>optional int32 num_threads = 3;</code>
      *
@@ -4891,6 +5088,7 @@ public final class Debug {
     public boolean hasNumThreads() {
       return ((bitField0_ & 0x00000004) != 0);
     }
+
     /**
      * <code>optional int32 num_threads = 3;</code>
      *
@@ -4903,6 +5101,7 @@ public final class Debug {
 
     public static final int STAT_CHECKS_FIELD_NUMBER = 4;
     private boolean statChecks_;
+
     /**
      * <code>optional bool stat_checks = 4;</code>
      *
@@ -4912,6 +5111,7 @@ public final class Debug {
     public boolean hasStatChecks() {
       return ((bitField0_ & 0x00000008) != 0);
     }
+
     /**
      * <code>optional bool stat_checks = 4;</code>
      *
@@ -4924,6 +5124,7 @@ public final class Debug {
 
     public static final int SAMPLE_PLACES_FIELD_NUMBER = 5;
     private com.google.protobuf.LazyStringList samplePlaces_;
+
     /**
      * <code>repeated string sample_places = 5;</code>
      *
@@ -4932,6 +5133,7 @@ public final class Debug {
     public com.google.protobuf.ProtocolStringList getSamplePlacesList() {
       return samplePlaces_;
     }
+
     /**
      * <code>repeated string sample_places = 5;</code>
      *
@@ -4940,6 +5142,7 @@ public final class Debug {
     public int getSamplePlacesCount() {
       return samplePlaces_.size();
     }
+
     /**
      * <code>repeated string sample_places = 5;</code>
      *
@@ -4949,6 +5152,7 @@ public final class Debug {
     public java.lang.String getSamplePlaces(int index) {
       return samplePlaces_.get(index);
     }
+
     /**
      * <code>repeated string sample_places = 5;</code>
      *
@@ -4961,6 +5165,7 @@ public final class Debug {
 
     public static final int OBSERVATION_ABOUT_FIELD_NUMBER = 6;
     private boolean observationAbout_;
+
     /**
      * <code>optional bool observation_about = 6;</code>
      *
@@ -4970,6 +5175,7 @@ public final class Debug {
     public boolean hasObservationAbout() {
       return ((bitField0_ & 0x00000010) != 0);
     }
+
     /**
      * <code>optional bool observation_about = 6;</code>
      *
@@ -4982,6 +5188,7 @@ public final class Debug {
 
     public static final int ALLOW_NAN_SVOBS_FIELD_NUMBER = 7;
     private boolean allowNanSvobs_;
+
     /**
      *
      *
@@ -4997,6 +5204,7 @@ public final class Debug {
     public boolean hasAllowNanSvobs() {
       return ((bitField0_ & 0x00000020) != 0);
     }
+
     /**
      *
      *
@@ -5015,6 +5223,7 @@ public final class Debug {
 
     public static final int CHECK_MEASUREMENT_RESULT_FIELD_NUMBER = 8;
     private boolean checkMeasurementResult_;
+
     /**
      *
      *
@@ -5030,6 +5239,7 @@ public final class Debug {
     public boolean hasCheckMeasurementResult() {
       return ((bitField0_ & 0x00000040) != 0);
     }
+
     /**
      *
      *
@@ -5048,6 +5258,7 @@ public final class Debug {
 
     public static final int COORDINATES_RESOLUTION_FIELD_NUMBER = 9;
     private boolean coordinatesResolution_;
+
     /**
      * <code>optional bool coordinates_resolution = 9;</code>
      *
@@ -5057,6 +5268,7 @@ public final class Debug {
     public boolean hasCoordinatesResolution() {
       return ((bitField0_ & 0x00000080) != 0);
     }
+
     /**
      * <code>optional bool coordinates_resolution = 9;</code>
      *
@@ -5345,6 +5557,7 @@ public final class Debug {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /** Protobuf type {@code org.datacommons.proto.CommandArgs} */
     public static final class Builder
         extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -5585,6 +5798,7 @@ public final class Debug {
       private int bitField0_;
 
       private boolean existenceChecks_;
+
       /**
        * <code>optional bool existence_checks = 1;</code>
        *
@@ -5594,6 +5808,7 @@ public final class Debug {
       public boolean hasExistenceChecks() {
         return ((bitField0_ & 0x00000001) != 0);
       }
+
       /**
        * <code>optional bool existence_checks = 1;</code>
        *
@@ -5603,6 +5818,7 @@ public final class Debug {
       public boolean getExistenceChecks() {
         return existenceChecks_;
       }
+
       /**
        * <code>optional bool existence_checks = 1;</code>
        *
@@ -5615,6 +5831,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>optional bool existence_checks = 1;</code>
        *
@@ -5628,6 +5845,7 @@ public final class Debug {
       }
 
       private int resolution_ = 0;
+
       /**
        * <code>optional .org.datacommons.proto.CommandArgs.ResolutionMode resolution = 2;</code>
        *
@@ -5637,6 +5855,7 @@ public final class Debug {
       public boolean hasResolution() {
         return ((bitField0_ & 0x00000002) != 0);
       }
+
       /**
        * <code>optional .org.datacommons.proto.CommandArgs.ResolutionMode resolution = 2;</code>
        *
@@ -5651,6 +5870,7 @@ public final class Debug {
             ? org.datacommons.proto.Debug.CommandArgs.ResolutionMode.RESOLUTION_MODE_UNSPECIFIED
             : result;
       }
+
       /**
        * <code>optional .org.datacommons.proto.CommandArgs.ResolutionMode resolution = 2;</code>
        *
@@ -5666,6 +5886,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>optional .org.datacommons.proto.CommandArgs.ResolutionMode resolution = 2;</code>
        *
@@ -5679,6 +5900,7 @@ public final class Debug {
       }
 
       private int numThreads_;
+
       /**
        * <code>optional int32 num_threads = 3;</code>
        *
@@ -5688,6 +5910,7 @@ public final class Debug {
       public boolean hasNumThreads() {
         return ((bitField0_ & 0x00000004) != 0);
       }
+
       /**
        * <code>optional int32 num_threads = 3;</code>
        *
@@ -5697,6 +5920,7 @@ public final class Debug {
       public int getNumThreads() {
         return numThreads_;
       }
+
       /**
        * <code>optional int32 num_threads = 3;</code>
        *
@@ -5709,6 +5933,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>optional int32 num_threads = 3;</code>
        *
@@ -5722,6 +5947,7 @@ public final class Debug {
       }
 
       private boolean statChecks_;
+
       /**
        * <code>optional bool stat_checks = 4;</code>
        *
@@ -5731,6 +5957,7 @@ public final class Debug {
       public boolean hasStatChecks() {
         return ((bitField0_ & 0x00000008) != 0);
       }
+
       /**
        * <code>optional bool stat_checks = 4;</code>
        *
@@ -5740,6 +5967,7 @@ public final class Debug {
       public boolean getStatChecks() {
         return statChecks_;
       }
+
       /**
        * <code>optional bool stat_checks = 4;</code>
        *
@@ -5752,6 +5980,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>optional bool stat_checks = 4;</code>
        *
@@ -5773,6 +6002,7 @@ public final class Debug {
           bitField0_ |= 0x00000010;
         }
       }
+
       /**
        * <code>repeated string sample_places = 5;</code>
        *
@@ -5781,6 +6011,7 @@ public final class Debug {
       public com.google.protobuf.ProtocolStringList getSamplePlacesList() {
         return samplePlaces_.getUnmodifiableView();
       }
+
       /**
        * <code>repeated string sample_places = 5;</code>
        *
@@ -5789,6 +6020,7 @@ public final class Debug {
       public int getSamplePlacesCount() {
         return samplePlaces_.size();
       }
+
       /**
        * <code>repeated string sample_places = 5;</code>
        *
@@ -5798,6 +6030,7 @@ public final class Debug {
       public java.lang.String getSamplePlaces(int index) {
         return samplePlaces_.get(index);
       }
+
       /**
        * <code>repeated string sample_places = 5;</code>
        *
@@ -5807,6 +6040,7 @@ public final class Debug {
       public com.google.protobuf.ByteString getSamplePlacesBytes(int index) {
         return samplePlaces_.getByteString(index);
       }
+
       /**
        * <code>repeated string sample_places = 5;</code>
        *
@@ -5823,6 +6057,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>repeated string sample_places = 5;</code>
        *
@@ -5838,6 +6073,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>repeated string sample_places = 5;</code>
        *
@@ -5850,6 +6086,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>repeated string sample_places = 5;</code>
        *
@@ -5861,6 +6098,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>repeated string sample_places = 5;</code>
        *
@@ -5878,6 +6116,7 @@ public final class Debug {
       }
 
       private boolean observationAbout_;
+
       /**
        * <code>optional bool observation_about = 6;</code>
        *
@@ -5887,6 +6126,7 @@ public final class Debug {
       public boolean hasObservationAbout() {
         return ((bitField0_ & 0x00000020) != 0);
       }
+
       /**
        * <code>optional bool observation_about = 6;</code>
        *
@@ -5896,6 +6136,7 @@ public final class Debug {
       public boolean getObservationAbout() {
         return observationAbout_;
       }
+
       /**
        * <code>optional bool observation_about = 6;</code>
        *
@@ -5908,6 +6149,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>optional bool observation_about = 6;</code>
        *
@@ -5921,6 +6163,7 @@ public final class Debug {
       }
 
       private boolean allowNanSvobs_;
+
       /**
        *
        *
@@ -5936,6 +6179,7 @@ public final class Debug {
       public boolean hasAllowNanSvobs() {
         return ((bitField0_ & 0x00000040) != 0);
       }
+
       /**
        *
        *
@@ -5951,6 +6195,7 @@ public final class Debug {
       public boolean getAllowNanSvobs() {
         return allowNanSvobs_;
       }
+
       /**
        *
        *
@@ -5969,6 +6214,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -5988,6 +6234,7 @@ public final class Debug {
       }
 
       private boolean checkMeasurementResult_;
+
       /**
        *
        *
@@ -6003,6 +6250,7 @@ public final class Debug {
       public boolean hasCheckMeasurementResult() {
         return ((bitField0_ & 0x00000080) != 0);
       }
+
       /**
        *
        *
@@ -6018,6 +6266,7 @@ public final class Debug {
       public boolean getCheckMeasurementResult() {
         return checkMeasurementResult_;
       }
+
       /**
        *
        *
@@ -6036,6 +6285,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -6055,6 +6305,7 @@ public final class Debug {
       }
 
       private boolean coordinatesResolution_;
+
       /**
        * <code>optional bool coordinates_resolution = 9;</code>
        *
@@ -6064,6 +6315,7 @@ public final class Debug {
       public boolean hasCoordinatesResolution() {
         return ((bitField0_ & 0x00000100) != 0);
       }
+
       /**
        * <code>optional bool coordinates_resolution = 9;</code>
        *
@@ -6073,6 +6325,7 @@ public final class Debug {
       public boolean getCoordinatesResolution() {
         return coordinatesResolution_;
       }
+
       /**
        * <code>optional bool coordinates_resolution = 9;</code>
        *
@@ -6085,6 +6338,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>optional bool coordinates_resolution = 9;</code>
        *
@@ -6161,12 +6415,14 @@ public final class Debug {
      * @return Whether the date field is set.
      */
     boolean hasDate();
+
     /**
      * <code>optional string date = 1;</code>
      *
      * @return The date.
      */
     java.lang.String getDate();
+
     /**
      * <code>optional string date = 1;</code>
      *
@@ -6184,6 +6440,7 @@ public final class Debug {
      * <code>repeated .org.datacommons.proto.DataPoint.DataValue values = 2;</code>
      */
     java.util.List<org.datacommons.proto.Debug.DataPoint.DataValue> getValuesList();
+
     /**
      *
      *
@@ -6194,6 +6451,7 @@ public final class Debug {
      * <code>repeated .org.datacommons.proto.DataPoint.DataValue values = 2;</code>
      */
     org.datacommons.proto.Debug.DataPoint.DataValue getValues(int index);
+
     /**
      *
      *
@@ -6204,6 +6462,7 @@ public final class Debug {
      * <code>repeated .org.datacommons.proto.DataPoint.DataValue values = 2;</code>
      */
     int getValuesCount();
+
     /**
      *
      *
@@ -6215,6 +6474,7 @@ public final class Debug {
      */
     java.util.List<? extends org.datacommons.proto.Debug.DataPoint.DataValueOrBuilder>
         getValuesOrBuilderList();
+
     /**
      *
      *
@@ -6226,12 +6486,14 @@ public final class Debug {
      */
     org.datacommons.proto.Debug.DataPoint.DataValueOrBuilder getValuesOrBuilder(int index);
   }
+
   /** Protobuf type {@code org.datacommons.proto.DataPoint} */
   public static final class DataPoint extends com.google.protobuf.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.DataPoint)
       DataPointOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use DataPoint.newBuilder() to construct.
     private DataPoint(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -6338,12 +6600,14 @@ public final class Debug {
        * @return Whether the value field is set.
        */
       boolean hasValue();
+
       /**
        * <code>optional .org.datacommons.proto.McfGraph.TypedValue value = 1;</code>
        *
        * @return The value.
        */
       org.datacommons.proto.Mcf.McfGraph.TypedValue getValue();
+
       /** <code>optional .org.datacommons.proto.McfGraph.TypedValue value = 1;</code> */
       org.datacommons.proto.Mcf.McfGraph.TypedValueOrBuilder getValueOrBuilder();
 
@@ -6357,6 +6621,7 @@ public final class Debug {
        * <code>repeated .org.datacommons.proto.Location locations = 2;</code>
        */
       java.util.List<org.datacommons.proto.LogLocation.Location> getLocationsList();
+
       /**
        *
        *
@@ -6367,6 +6632,7 @@ public final class Debug {
        * <code>repeated .org.datacommons.proto.Location locations = 2;</code>
        */
       org.datacommons.proto.LogLocation.Location getLocations(int index);
+
       /**
        *
        *
@@ -6377,6 +6643,7 @@ public final class Debug {
        * <code>repeated .org.datacommons.proto.Location locations = 2;</code>
        */
       int getLocationsCount();
+
       /**
        *
        *
@@ -6388,6 +6655,7 @@ public final class Debug {
        */
       java.util.List<? extends org.datacommons.proto.LogLocation.LocationOrBuilder>
           getLocationsOrBuilderList();
+
       /**
        *
        *
@@ -6399,12 +6667,14 @@ public final class Debug {
        */
       org.datacommons.proto.LogLocation.LocationOrBuilder getLocationsOrBuilder(int index);
     }
+
     /** Protobuf type {@code org.datacommons.proto.DataPoint.DataValue} */
     public static final class DataValue extends com.google.protobuf.GeneratedMessageV3
         implements
         // @@protoc_insertion_point(message_implements:org.datacommons.proto.DataPoint.DataValue)
         DataValueOrBuilder {
       private static final long serialVersionUID = 0L;
+
       // Use DataValue.newBuilder() to construct.
       private DataValue(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
@@ -6513,6 +6783,7 @@ public final class Debug {
       private int bitField0_;
       public static final int VALUE_FIELD_NUMBER = 1;
       private org.datacommons.proto.Mcf.McfGraph.TypedValue value_;
+
       /**
        * <code>optional .org.datacommons.proto.McfGraph.TypedValue value = 1;</code>
        *
@@ -6522,6 +6793,7 @@ public final class Debug {
       public boolean hasValue() {
         return ((bitField0_ & 0x00000001) != 0);
       }
+
       /**
        * <code>optional .org.datacommons.proto.McfGraph.TypedValue value = 1;</code>
        *
@@ -6533,6 +6805,7 @@ public final class Debug {
             ? org.datacommons.proto.Mcf.McfGraph.TypedValue.getDefaultInstance()
             : value_;
       }
+
       /** <code>optional .org.datacommons.proto.McfGraph.TypedValue value = 1;</code> */
       @java.lang.Override
       public org.datacommons.proto.Mcf.McfGraph.TypedValueOrBuilder getValueOrBuilder() {
@@ -6543,6 +6816,7 @@ public final class Debug {
 
       public static final int LOCATIONS_FIELD_NUMBER = 2;
       private java.util.List<org.datacommons.proto.LogLocation.Location> locations_;
+
       /**
        *
        *
@@ -6556,6 +6830,7 @@ public final class Debug {
       public java.util.List<org.datacommons.proto.LogLocation.Location> getLocationsList() {
         return locations_;
       }
+
       /**
        *
        *
@@ -6570,6 +6845,7 @@ public final class Debug {
           getLocationsOrBuilderList() {
         return locations_;
       }
+
       /**
        *
        *
@@ -6583,6 +6859,7 @@ public final class Debug {
       public int getLocationsCount() {
         return locations_.size();
       }
+
       /**
        *
        *
@@ -6596,6 +6873,7 @@ public final class Debug {
       public org.datacommons.proto.LogLocation.Location getLocations(int index) {
         return locations_.get(index);
       }
+
       /**
        *
        *
@@ -6786,6 +7064,7 @@ public final class Debug {
         Builder builder = new Builder(parent);
         return builder;
       }
+
       /** Protobuf type {@code org.datacommons.proto.DataPoint.DataValue} */
       public static final class Builder
           extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -7006,6 +7285,7 @@ public final class Debug {
                 org.datacommons.proto.Mcf.McfGraph.TypedValue.Builder,
                 org.datacommons.proto.Mcf.McfGraph.TypedValueOrBuilder>
             valueBuilder_;
+
         /**
          * <code>optional .org.datacommons.proto.McfGraph.TypedValue value = 1;</code>
          *
@@ -7014,6 +7294,7 @@ public final class Debug {
         public boolean hasValue() {
           return ((bitField0_ & 0x00000001) != 0);
         }
+
         /**
          * <code>optional .org.datacommons.proto.McfGraph.TypedValue value = 1;</code>
          *
@@ -7028,6 +7309,7 @@ public final class Debug {
             return valueBuilder_.getMessage();
           }
         }
+
         /** <code>optional .org.datacommons.proto.McfGraph.TypedValue value = 1;</code> */
         public Builder setValue(org.datacommons.proto.Mcf.McfGraph.TypedValue value) {
           if (valueBuilder_ == null) {
@@ -7042,6 +7324,7 @@ public final class Debug {
           bitField0_ |= 0x00000001;
           return this;
         }
+
         /** <code>optional .org.datacommons.proto.McfGraph.TypedValue value = 1;</code> */
         public Builder setValue(
             org.datacommons.proto.Mcf.McfGraph.TypedValue.Builder builderForValue) {
@@ -7054,6 +7337,7 @@ public final class Debug {
           bitField0_ |= 0x00000001;
           return this;
         }
+
         /** <code>optional .org.datacommons.proto.McfGraph.TypedValue value = 1;</code> */
         public Builder mergeValue(org.datacommons.proto.Mcf.McfGraph.TypedValue value) {
           if (valueBuilder_ == null) {
@@ -7074,6 +7358,7 @@ public final class Debug {
           bitField0_ |= 0x00000001;
           return this;
         }
+
         /** <code>optional .org.datacommons.proto.McfGraph.TypedValue value = 1;</code> */
         public Builder clearValue() {
           if (valueBuilder_ == null) {
@@ -7085,12 +7370,14 @@ public final class Debug {
           bitField0_ = (bitField0_ & ~0x00000001);
           return this;
         }
+
         /** <code>optional .org.datacommons.proto.McfGraph.TypedValue value = 1;</code> */
         public org.datacommons.proto.Mcf.McfGraph.TypedValue.Builder getValueBuilder() {
           bitField0_ |= 0x00000001;
           onChanged();
           return getValueFieldBuilder().getBuilder();
         }
+
         /** <code>optional .org.datacommons.proto.McfGraph.TypedValue value = 1;</code> */
         public org.datacommons.proto.Mcf.McfGraph.TypedValueOrBuilder getValueOrBuilder() {
           if (valueBuilder_ != null) {
@@ -7101,6 +7388,7 @@ public final class Debug {
                 : value_;
           }
         }
+
         /** <code>optional .org.datacommons.proto.McfGraph.TypedValue value = 1;</code> */
         private com.google.protobuf.SingleFieldBuilderV3<
                 org.datacommons.proto.Mcf.McfGraph.TypedValue,
@@ -7152,6 +7440,7 @@ public final class Debug {
             return locationsBuilder_.getMessageList();
           }
         }
+
         /**
          *
          *
@@ -7168,6 +7457,7 @@ public final class Debug {
             return locationsBuilder_.getCount();
           }
         }
+
         /**
          *
          *
@@ -7184,6 +7474,7 @@ public final class Debug {
             return locationsBuilder_.getMessage(index);
           }
         }
+
         /**
          *
          *
@@ -7206,6 +7497,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -7226,6 +7518,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -7248,6 +7541,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -7270,6 +7564,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -7290,6 +7585,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -7310,6 +7606,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -7330,6 +7627,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -7349,6 +7647,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -7368,6 +7667,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -7380,6 +7680,7 @@ public final class Debug {
         public org.datacommons.proto.LogLocation.Location.Builder getLocationsBuilder(int index) {
           return getLocationsFieldBuilder().getBuilder(index);
         }
+
         /**
          *
          *
@@ -7397,6 +7698,7 @@ public final class Debug {
             return locationsBuilder_.getMessageOrBuilder(index);
           }
         }
+
         /**
          *
          *
@@ -7414,6 +7716,7 @@ public final class Debug {
             return java.util.Collections.unmodifiableList(locations_);
           }
         }
+
         /**
          *
          *
@@ -7427,6 +7730,7 @@ public final class Debug {
           return getLocationsFieldBuilder()
               .addBuilder(org.datacommons.proto.LogLocation.Location.getDefaultInstance());
         }
+
         /**
          *
          *
@@ -7440,6 +7744,7 @@ public final class Debug {
           return getLocationsFieldBuilder()
               .addBuilder(index, org.datacommons.proto.LogLocation.Location.getDefaultInstance());
         }
+
         /**
          *
          *
@@ -7530,6 +7835,7 @@ public final class Debug {
     private int bitField0_;
     public static final int DATE_FIELD_NUMBER = 1;
     private volatile java.lang.Object date_;
+
     /**
      * <code>optional string date = 1;</code>
      *
@@ -7539,6 +7845,7 @@ public final class Debug {
     public boolean hasDate() {
       return ((bitField0_ & 0x00000001) != 0);
     }
+
     /**
      * <code>optional string date = 1;</code>
      *
@@ -7558,6 +7865,7 @@ public final class Debug {
         return s;
       }
     }
+
     /**
      * <code>optional string date = 1;</code>
      *
@@ -7578,6 +7886,7 @@ public final class Debug {
 
     public static final int VALUES_FIELD_NUMBER = 2;
     private java.util.List<org.datacommons.proto.Debug.DataPoint.DataValue> values_;
+
     /**
      *
      *
@@ -7591,6 +7900,7 @@ public final class Debug {
     public java.util.List<org.datacommons.proto.Debug.DataPoint.DataValue> getValuesList() {
       return values_;
     }
+
     /**
      *
      *
@@ -7605,6 +7915,7 @@ public final class Debug {
         getValuesOrBuilderList() {
       return values_;
     }
+
     /**
      *
      *
@@ -7618,6 +7929,7 @@ public final class Debug {
     public int getValuesCount() {
       return values_.size();
     }
+
     /**
      *
      *
@@ -7631,6 +7943,7 @@ public final class Debug {
     public org.datacommons.proto.Debug.DataPoint.DataValue getValues(int index) {
       return values_.get(index);
     }
+
     /**
      *
      *
@@ -7820,6 +8133,7 @@ public final class Debug {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /** Protobuf type {@code org.datacommons.proto.DataPoint} */
     public static final class Builder
         extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -8026,6 +8340,7 @@ public final class Debug {
       private int bitField0_;
 
       private java.lang.Object date_ = "";
+
       /**
        * <code>optional string date = 1;</code>
        *
@@ -8034,6 +8349,7 @@ public final class Debug {
       public boolean hasDate() {
         return ((bitField0_ & 0x00000001) != 0);
       }
+
       /**
        * <code>optional string date = 1;</code>
        *
@@ -8052,6 +8368,7 @@ public final class Debug {
           return (java.lang.String) ref;
         }
       }
+
       /**
        * <code>optional string date = 1;</code>
        *
@@ -8068,6 +8385,7 @@ public final class Debug {
           return (com.google.protobuf.ByteString) ref;
         }
       }
+
       /**
        * <code>optional string date = 1;</code>
        *
@@ -8083,6 +8401,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>optional string date = 1;</code>
        *
@@ -8094,6 +8413,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>optional string date = 1;</code>
        *
@@ -8143,6 +8463,7 @@ public final class Debug {
           return valuesBuilder_.getMessageList();
         }
       }
+
       /**
        *
        *
@@ -8159,6 +8480,7 @@ public final class Debug {
           return valuesBuilder_.getCount();
         }
       }
+
       /**
        *
        *
@@ -8175,6 +8497,7 @@ public final class Debug {
           return valuesBuilder_.getMessage(index);
         }
       }
+
       /**
        *
        *
@@ -8197,6 +8520,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        *
        *
@@ -8217,6 +8541,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        *
        *
@@ -8239,6 +8564,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        *
        *
@@ -8261,6 +8587,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        *
        *
@@ -8281,6 +8608,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        *
        *
@@ -8301,6 +8629,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        *
        *
@@ -8321,6 +8650,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        *
        *
@@ -8340,6 +8670,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        *
        *
@@ -8359,6 +8690,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        *
        *
@@ -8371,6 +8703,7 @@ public final class Debug {
       public org.datacommons.proto.Debug.DataPoint.DataValue.Builder getValuesBuilder(int index) {
         return getValuesFieldBuilder().getBuilder(index);
       }
+
       /**
        *
        *
@@ -8388,6 +8721,7 @@ public final class Debug {
           return valuesBuilder_.getMessageOrBuilder(index);
         }
       }
+
       /**
        *
        *
@@ -8405,6 +8739,7 @@ public final class Debug {
           return java.util.Collections.unmodifiableList(values_);
         }
       }
+
       /**
        *
        *
@@ -8418,6 +8753,7 @@ public final class Debug {
         return getValuesFieldBuilder()
             .addBuilder(org.datacommons.proto.Debug.DataPoint.DataValue.getDefaultInstance());
       }
+
       /**
        *
        *
@@ -8432,6 +8768,7 @@ public final class Debug {
             .addBuilder(
                 index, org.datacommons.proto.Debug.DataPoint.DataValue.getDefaultInstance());
       }
+
       /**
        *
        *
@@ -8533,6 +8870,7 @@ public final class Debug {
      * @return Whether the placeDcid field is set.
      */
     boolean hasPlaceDcid();
+
     /**
      *
      *
@@ -8545,6 +8883,7 @@ public final class Debug {
      * @return The placeDcid.
      */
     java.lang.String getPlaceDcid();
+
     /**
      *
      *
@@ -8570,6 +8909,7 @@ public final class Debug {
      * @return Whether the statVarDcid field is set.
      */
     boolean hasStatVarDcid();
+
     /**
      *
      *
@@ -8582,6 +8922,7 @@ public final class Debug {
      * @return The statVarDcid.
      */
     java.lang.String getStatVarDcid();
+
     /**
      *
      *
@@ -8608,6 +8949,7 @@ public final class Debug {
      * @return Whether the measurementMethod field is set.
      */
     boolean hasMeasurementMethod();
+
     /**
      *
      *
@@ -8621,6 +8963,7 @@ public final class Debug {
      * @return The measurementMethod.
      */
     java.lang.String getMeasurementMethod();
+
     /**
      *
      *
@@ -8641,12 +8984,14 @@ public final class Debug {
      * @return Whether the observationPeriod field is set.
      */
     boolean hasObservationPeriod();
+
     /**
      * <code>optional string observation_period = 4;</code>
      *
      * @return The observationPeriod.
      */
     java.lang.String getObservationPeriod();
+
     /**
      * <code>optional string observation_period = 4;</code>
      *
@@ -8660,12 +9005,14 @@ public final class Debug {
      * @return Whether the scalingFactor field is set.
      */
     boolean hasScalingFactor();
+
     /**
      * <code>optional string scaling_factor = 5;</code>
      *
      * @return The scalingFactor.
      */
     java.lang.String getScalingFactor();
+
     /**
      * <code>optional string scaling_factor = 5;</code>
      *
@@ -8679,12 +9026,14 @@ public final class Debug {
      * @return Whether the unit field is set.
      */
     boolean hasUnit();
+
     /**
      * <code>optional string unit = 6;</code>
      *
      * @return The unit.
      */
     java.lang.String getUnit();
+
     /**
      * <code>optional string unit = 6;</code>
      *
@@ -8699,6 +9048,7 @@ public final class Debug {
      */
     java.util.List<org.datacommons.proto.Debug.StatValidationResult.StatValidationEntry>
         getValidationCountersList();
+
     /**
      * <code>
      * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -8706,12 +9056,14 @@ public final class Debug {
      */
     org.datacommons.proto.Debug.StatValidationResult.StatValidationEntry getValidationCounters(
         int index);
+
     /**
      * <code>
      * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
      * </code>
      */
     int getValidationCountersCount();
+
     /**
      * <code>
      * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -8720,6 +9072,7 @@ public final class Debug {
     java.util.List<
             ? extends org.datacommons.proto.Debug.StatValidationResult.StatValidationEntryOrBuilder>
         getValidationCountersOrBuilderList();
+
     /**
      * <code>
      * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -8728,12 +9081,14 @@ public final class Debug {
     org.datacommons.proto.Debug.StatValidationResult.StatValidationEntryOrBuilder
         getValidationCountersOrBuilder(int index);
   }
+
   /** Protobuf type {@code org.datacommons.proto.StatValidationResult} */
   public static final class StatValidationResult extends com.google.protobuf.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.StatValidationResult)
       StatValidationResultOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use StatValidationResult.newBuilder() to construct.
     private StatValidationResult(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -8889,6 +9244,7 @@ public final class Debug {
        * @return Whether the counterKey field is set.
        */
       boolean hasCounterKey();
+
       /**
        *
        *
@@ -8901,6 +9257,7 @@ public final class Debug {
        * @return The counterKey.
        */
       java.lang.String getCounterKey();
+
       /**
        *
        *
@@ -8924,6 +9281,7 @@ public final class Debug {
        * <code>repeated .org.datacommons.proto.DataPoint problem_points = 2;</code>
        */
       java.util.List<org.datacommons.proto.Debug.DataPoint> getProblemPointsList();
+
       /**
        *
        *
@@ -8934,6 +9292,7 @@ public final class Debug {
        * <code>repeated .org.datacommons.proto.DataPoint problem_points = 2;</code>
        */
       org.datacommons.proto.Debug.DataPoint getProblemPoints(int index);
+
       /**
        *
        *
@@ -8944,6 +9303,7 @@ public final class Debug {
        * <code>repeated .org.datacommons.proto.DataPoint problem_points = 2;</code>
        */
       int getProblemPointsCount();
+
       /**
        *
        *
@@ -8955,6 +9315,7 @@ public final class Debug {
        */
       java.util.List<? extends org.datacommons.proto.Debug.DataPointOrBuilder>
           getProblemPointsOrBuilderList();
+
       /**
        *
        *
@@ -8978,6 +9339,7 @@ public final class Debug {
        * @return Whether the additionalDetails field is set.
        */
       boolean hasAdditionalDetails();
+
       /**
        *
        *
@@ -8990,6 +9352,7 @@ public final class Debug {
        * @return The additionalDetails.
        */
       java.lang.String getAdditionalDetails();
+
       /**
        *
        *
@@ -9015,6 +9378,7 @@ public final class Debug {
        * @return Whether the percentDifference field is set.
        */
       boolean hasPercentDifference();
+
       /**
        *
        *
@@ -9028,6 +9392,7 @@ public final class Debug {
        */
       double getPercentDifference();
     }
+
     /**
      *
      *
@@ -9042,6 +9407,7 @@ public final class Debug {
         // @@protoc_insertion_point(message_implements:org.datacommons.proto.StatValidationResult.StatValidationEntry)
         StatValidationEntryOrBuilder {
       private static final long serialVersionUID = 0L;
+
       // Use StatValidationEntry.newBuilder() to construct.
       private StatValidationEntry(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
@@ -9156,6 +9522,7 @@ public final class Debug {
       private int bitField0_;
       public static final int COUNTER_KEY_FIELD_NUMBER = 1;
       private volatile java.lang.Object counterKey_;
+
       /**
        *
        *
@@ -9171,6 +9538,7 @@ public final class Debug {
       public boolean hasCounterKey() {
         return ((bitField0_ & 0x00000001) != 0);
       }
+
       /**
        *
        *
@@ -9196,6 +9564,7 @@ public final class Debug {
           return s;
         }
       }
+
       /**
        *
        *
@@ -9222,6 +9591,7 @@ public final class Debug {
 
       public static final int PROBLEM_POINTS_FIELD_NUMBER = 2;
       private java.util.List<org.datacommons.proto.Debug.DataPoint> problemPoints_;
+
       /**
        *
        *
@@ -9235,6 +9605,7 @@ public final class Debug {
       public java.util.List<org.datacommons.proto.Debug.DataPoint> getProblemPointsList() {
         return problemPoints_;
       }
+
       /**
        *
        *
@@ -9249,6 +9620,7 @@ public final class Debug {
           getProblemPointsOrBuilderList() {
         return problemPoints_;
       }
+
       /**
        *
        *
@@ -9262,6 +9634,7 @@ public final class Debug {
       public int getProblemPointsCount() {
         return problemPoints_.size();
       }
+
       /**
        *
        *
@@ -9275,6 +9648,7 @@ public final class Debug {
       public org.datacommons.proto.Debug.DataPoint getProblemPoints(int index) {
         return problemPoints_.get(index);
       }
+
       /**
        *
        *
@@ -9291,6 +9665,7 @@ public final class Debug {
 
       public static final int ADDITIONAL_DETAILS_FIELD_NUMBER = 3;
       private volatile java.lang.Object additionalDetails_;
+
       /**
        *
        *
@@ -9306,6 +9681,7 @@ public final class Debug {
       public boolean hasAdditionalDetails() {
         return ((bitField0_ & 0x00000002) != 0);
       }
+
       /**
        *
        *
@@ -9331,6 +9707,7 @@ public final class Debug {
           return s;
         }
       }
+
       /**
        *
        *
@@ -9357,6 +9734,7 @@ public final class Debug {
 
       public static final int PERCENT_DIFFERENCE_FIELD_NUMBER = 4;
       private double percentDifference_;
+
       /**
        *
        *
@@ -9372,6 +9750,7 @@ public final class Debug {
       public boolean hasPercentDifference() {
         return ((bitField0_ & 0x00000004) != 0);
       }
+
       /**
        *
        *
@@ -9601,6 +9980,7 @@ public final class Debug {
         Builder builder = new Builder(parent);
         return builder;
       }
+
       /**
        *
        *
@@ -9847,6 +10227,7 @@ public final class Debug {
         private int bitField0_;
 
         private java.lang.Object counterKey_ = "";
+
         /**
          *
          *
@@ -9861,6 +10242,7 @@ public final class Debug {
         public boolean hasCounterKey() {
           return ((bitField0_ & 0x00000001) != 0);
         }
+
         /**
          *
          *
@@ -9885,6 +10267,7 @@ public final class Debug {
             return (java.lang.String) ref;
           }
         }
+
         /**
          *
          *
@@ -9907,6 +10290,7 @@ public final class Debug {
             return (com.google.protobuf.ByteString) ref;
           }
         }
+
         /**
          *
          *
@@ -9928,6 +10312,7 @@ public final class Debug {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -9945,6 +10330,7 @@ public final class Debug {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -10000,6 +10386,7 @@ public final class Debug {
             return problemPointsBuilder_.getMessageList();
           }
         }
+
         /**
          *
          *
@@ -10016,6 +10403,7 @@ public final class Debug {
             return problemPointsBuilder_.getCount();
           }
         }
+
         /**
          *
          *
@@ -10032,6 +10420,7 @@ public final class Debug {
             return problemPointsBuilder_.getMessage(index);
           }
         }
+
         /**
          *
          *
@@ -10054,6 +10443,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -10074,6 +10464,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -10096,6 +10487,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -10118,6 +10510,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -10138,6 +10531,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -10158,6 +10552,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -10178,6 +10573,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -10197,6 +10593,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -10216,6 +10613,7 @@ public final class Debug {
           }
           return this;
         }
+
         /**
          *
          *
@@ -10228,6 +10626,7 @@ public final class Debug {
         public org.datacommons.proto.Debug.DataPoint.Builder getProblemPointsBuilder(int index) {
           return getProblemPointsFieldBuilder().getBuilder(index);
         }
+
         /**
          *
          *
@@ -10244,6 +10643,7 @@ public final class Debug {
             return problemPointsBuilder_.getMessageOrBuilder(index);
           }
         }
+
         /**
          *
          *
@@ -10261,6 +10661,7 @@ public final class Debug {
             return java.util.Collections.unmodifiableList(problemPoints_);
           }
         }
+
         /**
          *
          *
@@ -10274,6 +10675,7 @@ public final class Debug {
           return getProblemPointsFieldBuilder()
               .addBuilder(org.datacommons.proto.Debug.DataPoint.getDefaultInstance());
         }
+
         /**
          *
          *
@@ -10287,6 +10689,7 @@ public final class Debug {
           return getProblemPointsFieldBuilder()
               .addBuilder(index, org.datacommons.proto.Debug.DataPoint.getDefaultInstance());
         }
+
         /**
          *
          *
@@ -10322,6 +10725,7 @@ public final class Debug {
         }
 
         private java.lang.Object additionalDetails_ = "";
+
         /**
          *
          *
@@ -10336,6 +10740,7 @@ public final class Debug {
         public boolean hasAdditionalDetails() {
           return ((bitField0_ & 0x00000004) != 0);
         }
+
         /**
          *
          *
@@ -10360,6 +10765,7 @@ public final class Debug {
             return (java.lang.String) ref;
           }
         }
+
         /**
          *
          *
@@ -10382,6 +10788,7 @@ public final class Debug {
             return (com.google.protobuf.ByteString) ref;
           }
         }
+
         /**
          *
          *
@@ -10403,6 +10810,7 @@ public final class Debug {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -10420,6 +10828,7 @@ public final class Debug {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -10443,6 +10852,7 @@ public final class Debug {
         }
 
         private double percentDifference_;
+
         /**
          *
          *
@@ -10458,6 +10868,7 @@ public final class Debug {
         public boolean hasPercentDifference() {
           return ((bitField0_ & 0x00000008) != 0);
         }
+
         /**
          *
          *
@@ -10473,6 +10884,7 @@ public final class Debug {
         public double getPercentDifference() {
           return percentDifference_;
         }
+
         /**
          *
          *
@@ -10491,6 +10903,7 @@ public final class Debug {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -10569,6 +10982,7 @@ public final class Debug {
     private int bitField0_;
     public static final int PLACE_DCID_FIELD_NUMBER = 1;
     private volatile java.lang.Object placeDcid_;
+
     /**
      *
      *
@@ -10584,6 +10998,7 @@ public final class Debug {
     public boolean hasPlaceDcid() {
       return ((bitField0_ & 0x00000001) != 0);
     }
+
     /**
      *
      *
@@ -10609,6 +11024,7 @@ public final class Debug {
         return s;
       }
     }
+
     /**
      *
      *
@@ -10635,6 +11051,7 @@ public final class Debug {
 
     public static final int STAT_VAR_DCID_FIELD_NUMBER = 2;
     private volatile java.lang.Object statVarDcid_;
+
     /**
      *
      *
@@ -10650,6 +11067,7 @@ public final class Debug {
     public boolean hasStatVarDcid() {
       return ((bitField0_ & 0x00000002) != 0);
     }
+
     /**
      *
      *
@@ -10675,6 +11093,7 @@ public final class Debug {
         return s;
       }
     }
+
     /**
      *
      *
@@ -10701,6 +11120,7 @@ public final class Debug {
 
     public static final int MEASUREMENT_METHOD_FIELD_NUMBER = 3;
     private volatile java.lang.Object measurementMethod_;
+
     /**
      *
      *
@@ -10717,6 +11137,7 @@ public final class Debug {
     public boolean hasMeasurementMethod() {
       return ((bitField0_ & 0x00000004) != 0);
     }
+
     /**
      *
      *
@@ -10743,6 +11164,7 @@ public final class Debug {
         return s;
       }
     }
+
     /**
      *
      *
@@ -10770,6 +11192,7 @@ public final class Debug {
 
     public static final int OBSERVATION_PERIOD_FIELD_NUMBER = 4;
     private volatile java.lang.Object observationPeriod_;
+
     /**
      * <code>optional string observation_period = 4;</code>
      *
@@ -10779,6 +11202,7 @@ public final class Debug {
     public boolean hasObservationPeriod() {
       return ((bitField0_ & 0x00000008) != 0);
     }
+
     /**
      * <code>optional string observation_period = 4;</code>
      *
@@ -10798,6 +11222,7 @@ public final class Debug {
         return s;
       }
     }
+
     /**
      * <code>optional string observation_period = 4;</code>
      *
@@ -10818,6 +11243,7 @@ public final class Debug {
 
     public static final int SCALING_FACTOR_FIELD_NUMBER = 5;
     private volatile java.lang.Object scalingFactor_;
+
     /**
      * <code>optional string scaling_factor = 5;</code>
      *
@@ -10827,6 +11253,7 @@ public final class Debug {
     public boolean hasScalingFactor() {
       return ((bitField0_ & 0x00000010) != 0);
     }
+
     /**
      * <code>optional string scaling_factor = 5;</code>
      *
@@ -10846,6 +11273,7 @@ public final class Debug {
         return s;
       }
     }
+
     /**
      * <code>optional string scaling_factor = 5;</code>
      *
@@ -10866,6 +11294,7 @@ public final class Debug {
 
     public static final int UNIT_FIELD_NUMBER = 6;
     private volatile java.lang.Object unit_;
+
     /**
      * <code>optional string unit = 6;</code>
      *
@@ -10875,6 +11304,7 @@ public final class Debug {
     public boolean hasUnit() {
       return ((bitField0_ & 0x00000020) != 0);
     }
+
     /**
      * <code>optional string unit = 6;</code>
      *
@@ -10894,6 +11324,7 @@ public final class Debug {
         return s;
       }
     }
+
     /**
      * <code>optional string unit = 6;</code>
      *
@@ -10915,6 +11346,7 @@ public final class Debug {
     public static final int VALIDATION_COUNTERS_FIELD_NUMBER = 7;
     private java.util.List<org.datacommons.proto.Debug.StatValidationResult.StatValidationEntry>
         validationCounters_;
+
     /**
      * <code>
      * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -10925,6 +11357,7 @@ public final class Debug {
         getValidationCountersList() {
       return validationCounters_;
     }
+
     /**
      * <code>
      * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -10936,6 +11369,7 @@ public final class Debug {
         getValidationCountersOrBuilderList() {
       return validationCounters_;
     }
+
     /**
      * <code>
      * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -10945,6 +11379,7 @@ public final class Debug {
     public int getValidationCountersCount() {
       return validationCounters_.size();
     }
+
     /**
      * <code>
      * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -10955,6 +11390,7 @@ public final class Debug {
         getValidationCounters(int index) {
       return validationCounters_.get(index);
     }
+
     /**
      * <code>
      * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -11213,6 +11649,7 @@ public final class Debug {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /** Protobuf type {@code org.datacommons.proto.StatValidationResult} */
     public static final class Builder
         extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -11476,6 +11913,7 @@ public final class Debug {
       private int bitField0_;
 
       private java.lang.Object placeDcid_ = "";
+
       /**
        *
        *
@@ -11490,6 +11928,7 @@ public final class Debug {
       public boolean hasPlaceDcid() {
         return ((bitField0_ & 0x00000001) != 0);
       }
+
       /**
        *
        *
@@ -11514,6 +11953,7 @@ public final class Debug {
           return (java.lang.String) ref;
         }
       }
+
       /**
        *
        *
@@ -11536,6 +11976,7 @@ public final class Debug {
           return (com.google.protobuf.ByteString) ref;
         }
       }
+
       /**
        *
        *
@@ -11557,6 +11998,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -11574,6 +12016,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -11597,6 +12040,7 @@ public final class Debug {
       }
 
       private java.lang.Object statVarDcid_ = "";
+
       /**
        *
        *
@@ -11611,6 +12055,7 @@ public final class Debug {
       public boolean hasStatVarDcid() {
         return ((bitField0_ & 0x00000002) != 0);
       }
+
       /**
        *
        *
@@ -11635,6 +12080,7 @@ public final class Debug {
           return (java.lang.String) ref;
         }
       }
+
       /**
        *
        *
@@ -11657,6 +12103,7 @@ public final class Debug {
           return (com.google.protobuf.ByteString) ref;
         }
       }
+
       /**
        *
        *
@@ -11678,6 +12125,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -11695,6 +12143,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -11718,6 +12167,7 @@ public final class Debug {
       }
 
       private java.lang.Object measurementMethod_ = "";
+
       /**
        *
        *
@@ -11733,6 +12183,7 @@ public final class Debug {
       public boolean hasMeasurementMethod() {
         return ((bitField0_ & 0x00000004) != 0);
       }
+
       /**
        *
        *
@@ -11758,6 +12209,7 @@ public final class Debug {
           return (java.lang.String) ref;
         }
       }
+
       /**
        *
        *
@@ -11781,6 +12233,7 @@ public final class Debug {
           return (com.google.protobuf.ByteString) ref;
         }
       }
+
       /**
        *
        *
@@ -11803,6 +12256,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -11821,6 +12275,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -11845,6 +12300,7 @@ public final class Debug {
       }
 
       private java.lang.Object observationPeriod_ = "";
+
       /**
        * <code>optional string observation_period = 4;</code>
        *
@@ -11853,6 +12309,7 @@ public final class Debug {
       public boolean hasObservationPeriod() {
         return ((bitField0_ & 0x00000008) != 0);
       }
+
       /**
        * <code>optional string observation_period = 4;</code>
        *
@@ -11871,6 +12328,7 @@ public final class Debug {
           return (java.lang.String) ref;
         }
       }
+
       /**
        * <code>optional string observation_period = 4;</code>
        *
@@ -11887,6 +12345,7 @@ public final class Debug {
           return (com.google.protobuf.ByteString) ref;
         }
       }
+
       /**
        * <code>optional string observation_period = 4;</code>
        *
@@ -11902,6 +12361,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>optional string observation_period = 4;</code>
        *
@@ -11913,6 +12373,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>optional string observation_period = 4;</code>
        *
@@ -11930,6 +12391,7 @@ public final class Debug {
       }
 
       private java.lang.Object scalingFactor_ = "";
+
       /**
        * <code>optional string scaling_factor = 5;</code>
        *
@@ -11938,6 +12400,7 @@ public final class Debug {
       public boolean hasScalingFactor() {
         return ((bitField0_ & 0x00000010) != 0);
       }
+
       /**
        * <code>optional string scaling_factor = 5;</code>
        *
@@ -11956,6 +12419,7 @@ public final class Debug {
           return (java.lang.String) ref;
         }
       }
+
       /**
        * <code>optional string scaling_factor = 5;</code>
        *
@@ -11972,6 +12436,7 @@ public final class Debug {
           return (com.google.protobuf.ByteString) ref;
         }
       }
+
       /**
        * <code>optional string scaling_factor = 5;</code>
        *
@@ -11987,6 +12452,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>optional string scaling_factor = 5;</code>
        *
@@ -11998,6 +12464,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>optional string scaling_factor = 5;</code>
        *
@@ -12015,6 +12482,7 @@ public final class Debug {
       }
 
       private java.lang.Object unit_ = "";
+
       /**
        * <code>optional string unit = 6;</code>
        *
@@ -12023,6 +12491,7 @@ public final class Debug {
       public boolean hasUnit() {
         return ((bitField0_ & 0x00000020) != 0);
       }
+
       /**
        * <code>optional string unit = 6;</code>
        *
@@ -12041,6 +12510,7 @@ public final class Debug {
           return (java.lang.String) ref;
         }
       }
+
       /**
        * <code>optional string unit = 6;</code>
        *
@@ -12057,6 +12527,7 @@ public final class Debug {
           return (com.google.protobuf.ByteString) ref;
         }
       }
+
       /**
        * <code>optional string unit = 6;</code>
        *
@@ -12072,6 +12543,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>optional string unit = 6;</code>
        *
@@ -12083,6 +12555,7 @@ public final class Debug {
         onChanged();
         return this;
       }
+
       /**
        * <code>optional string unit = 6;</code>
        *
@@ -12131,6 +12604,7 @@ public final class Debug {
           return validationCountersBuilder_.getMessageList();
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12143,6 +12617,7 @@ public final class Debug {
           return validationCountersBuilder_.getCount();
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12156,6 +12631,7 @@ public final class Debug {
           return validationCountersBuilder_.getMessage(index);
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12175,6 +12651,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12193,6 +12670,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12212,6 +12690,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12231,6 +12710,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12248,6 +12728,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12266,6 +12747,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12284,6 +12766,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12299,6 +12782,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12314,6 +12798,7 @@ public final class Debug {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12323,6 +12808,7 @@ public final class Debug {
           getValidationCountersBuilder(int index) {
         return getValidationCountersFieldBuilder().getBuilder(index);
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12336,6 +12822,7 @@ public final class Debug {
           return validationCountersBuilder_.getMessageOrBuilder(index);
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12351,6 +12838,7 @@ public final class Debug {
           return java.util.Collections.unmodifiableList(validationCounters_);
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12363,6 +12851,7 @@ public final class Debug {
                 org.datacommons.proto.Debug.StatValidationResult.StatValidationEntry
                     .getDefaultInstance());
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;
@@ -12376,6 +12865,7 @@ public final class Debug {
                 org.datacommons.proto.Debug.StatValidationResult.StatValidationEntry
                     .getDefaultInstance());
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.StatValidationResult.StatValidationEntry validation_counters = 7;

--- a/util/src/main/java/org/datacommons/proto/LogLocation.java
+++ b/util/src/main/java/org/datacommons/proto/LogLocation.java
@@ -30,6 +30,7 @@ public final class LogLocation {
      * @return Whether the file field is set.
      */
     boolean hasFile();
+
     /**
      *
      *
@@ -43,6 +44,7 @@ public final class LogLocation {
      * @return The file.
      */
     java.lang.String getFile();
+
     /**
      *
      *
@@ -70,6 +72,7 @@ public final class LogLocation {
      * @return Whether the lineNumber field is set.
      */
     boolean hasLineNumber();
+
     /**
      *
      *
@@ -84,12 +87,14 @@ public final class LogLocation {
      */
     long getLineNumber();
   }
+
   /** Protobuf type {@code org.datacommons.proto.Location} */
   public static final class Location extends com.google.protobuf.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.Location)
       LocationOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use Location.newBuilder() to construct.
     private Location(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -179,6 +184,7 @@ public final class LogLocation {
     private int bitField0_;
     public static final int FILE_FIELD_NUMBER = 1;
     private volatile java.lang.Object file_;
+
     /**
      *
      *
@@ -195,6 +201,7 @@ public final class LogLocation {
     public boolean hasFile() {
       return ((bitField0_ & 0x00000001) != 0);
     }
+
     /**
      *
      *
@@ -221,6 +228,7 @@ public final class LogLocation {
         return s;
       }
     }
+
     /**
      *
      *
@@ -248,6 +256,7 @@ public final class LogLocation {
 
     public static final int LINE_NUMBER_FIELD_NUMBER = 2;
     private long lineNumber_;
+
     /**
      *
      *
@@ -264,6 +273,7 @@ public final class LogLocation {
     public boolean hasLineNumber() {
       return ((bitField0_ & 0x00000002) != 0);
     }
+
     /**
      *
      *
@@ -460,6 +470,7 @@ public final class LogLocation {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /** Protobuf type {@code org.datacommons.proto.Location} */
     public static final class Builder
         extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -631,6 +642,7 @@ public final class LogLocation {
       private int bitField0_;
 
       private java.lang.Object file_ = "";
+
       /**
        *
        *
@@ -646,6 +658,7 @@ public final class LogLocation {
       public boolean hasFile() {
         return ((bitField0_ & 0x00000001) != 0);
       }
+
       /**
        *
        *
@@ -671,6 +684,7 @@ public final class LogLocation {
           return (java.lang.String) ref;
         }
       }
+
       /**
        *
        *
@@ -694,6 +708,7 @@ public final class LogLocation {
           return (com.google.protobuf.ByteString) ref;
         }
       }
+
       /**
        *
        *
@@ -716,6 +731,7 @@ public final class LogLocation {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -734,6 +750,7 @@ public final class LogLocation {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -758,6 +775,7 @@ public final class LogLocation {
       }
 
       private long lineNumber_;
+
       /**
        *
        *
@@ -774,6 +792,7 @@ public final class LogLocation {
       public boolean hasLineNumber() {
         return ((bitField0_ & 0x00000002) != 0);
       }
+
       /**
        *
        *
@@ -790,6 +809,7 @@ public final class LogLocation {
       public long getLineNumber() {
         return lineNumber_;
       }
+
       /**
        *
        *
@@ -809,6 +829,7 @@ public final class LogLocation {
         onChanged();
         return this;
       }
+
       /**
        *
        *

--- a/util/src/main/java/org/datacommons/proto/Mcf.java
+++ b/util/src/main/java/org/datacommons/proto/Mcf.java
@@ -11,6 +11,7 @@ public final class Mcf {
   public static void registerAllExtensions(com.google.protobuf.ExtensionRegistry registry) {
     registerAllExtensions((com.google.protobuf.ExtensionRegistryLite) registry);
   }
+
   /**
    *
    *
@@ -47,6 +48,7 @@ public final class Mcf {
 
     /** <code>UNKNOWN_MCF_TYPE = 0;</code> */
     public static final int UNKNOWN_MCF_TYPE_VALUE = 0;
+
     /**
      *
      *
@@ -57,6 +59,7 @@ public final class Mcf {
      * <code>INSTANCE_MCF = 1;</code>
      */
     public static final int INSTANCE_MCF_VALUE = 1;
+
     /**
      *
      *
@@ -229,6 +232,7 @@ public final class Mcf {
 
     /** <code>UNKNOWN_VALUE_TYPE = 0;</code> */
     public static final int UNKNOWN_VALUE_TYPE_VALUE = 0;
+
     /**
      *
      *
@@ -239,6 +243,7 @@ public final class Mcf {
      * <code>TEXT = 1;</code>
      */
     public static final int TEXT_VALUE = 1;
+
     /**
      *
      *
@@ -250,6 +255,7 @@ public final class Mcf {
      * <code>NUMBER = 2;</code>
      */
     public static final int NUMBER_VALUE = 2;
+
     /**
      *
      *
@@ -262,6 +268,7 @@ public final class Mcf {
      * <code>UNRESOLVED_REF = 3;</code>
      */
     public static final int UNRESOLVED_REF_VALUE = 3;
+
     /**
      *
      *
@@ -272,6 +279,7 @@ public final class Mcf {
      * <code>RESOLVED_REF = 4;</code>
      */
     public static final int RESOLVED_REF_VALUE = 4;
+
     /**
      *
      *
@@ -282,6 +290,7 @@ public final class Mcf {
      * <code>COMPLEX_VALUE = 5;</code>
      */
     public static final int COMPLEX_VALUE_VALUE = 5;
+
     /**
      *
      *
@@ -292,6 +301,7 @@ public final class Mcf {
      * <code>TABLE_COLUMN = 6;</code>
      */
     public static final int TABLE_COLUMN_VALUE = 6;
+
     /**
      *
      *
@@ -402,6 +412,7 @@ public final class Mcf {
      * @return Whether the type field is set.
      */
     boolean hasType();
+
     /**
      *
      *
@@ -425,6 +436,7 @@ public final class Mcf {
      * <code>map&lt;string, .org.datacommons.proto.McfGraph.PropertyValues&gt; nodes = 2;</code>
      */
     int getNodesCount();
+
     /**
      *
      *
@@ -435,9 +447,11 @@ public final class Mcf {
      * <code>map&lt;string, .org.datacommons.proto.McfGraph.PropertyValues&gt; nodes = 2;</code>
      */
     boolean containsNodes(java.lang.String key);
+
     /** Use {@link #getNodesMap()} instead. */
     @java.lang.Deprecated
     java.util.Map<java.lang.String, org.datacommons.proto.Mcf.McfGraph.PropertyValues> getNodes();
+
     /**
      *
      *
@@ -449,6 +463,7 @@ public final class Mcf {
      */
     java.util.Map<java.lang.String, org.datacommons.proto.Mcf.McfGraph.PropertyValues>
         getNodesMap();
+
     /**
      *
      *
@@ -460,6 +475,7 @@ public final class Mcf {
      */
     org.datacommons.proto.Mcf.McfGraph.PropertyValues getNodesOrDefault(
         java.lang.String key, org.datacommons.proto.Mcf.McfGraph.PropertyValues defaultValue);
+
     /**
      *
      *
@@ -471,6 +487,7 @@ public final class Mcf {
      */
     org.datacommons.proto.Mcf.McfGraph.PropertyValues getNodesOrThrow(java.lang.String key);
   }
+
   /**
    *
    *
@@ -486,6 +503,7 @@ public final class Mcf {
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.McfGraph)
       McfGraphOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use McfGraph.newBuilder() to construct.
     private McfGraph(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -611,6 +629,7 @@ public final class Mcf {
        * @return Whether the type field is set.
        */
       boolean hasType();
+
       /**
        * <code>optional .org.datacommons.proto.ValueType type = 1;</code>
        *
@@ -624,12 +643,14 @@ public final class Mcf {
        * @return Whether the value field is set.
        */
       boolean hasValue();
+
       /**
        * <code>optional string value = 2;</code>
        *
        * @return The value.
        */
       java.lang.String getValue();
+
       /**
        * <code>optional string value = 2;</code>
        *
@@ -650,6 +671,7 @@ public final class Mcf {
        * @return Whether the column field is set.
        */
       boolean hasColumn();
+
       /**
        *
        *
@@ -663,6 +685,7 @@ public final class Mcf {
        * @return The column.
        */
       java.lang.String getColumn();
+
       /**
        *
        *
@@ -677,6 +700,7 @@ public final class Mcf {
        */
       com.google.protobuf.ByteString getColumnBytes();
     }
+
     /**
      *
      *
@@ -691,6 +715,7 @@ public final class Mcf {
         // @@protoc_insertion_point(message_implements:org.datacommons.proto.McfGraph.TypedValue)
         TypedValueOrBuilder {
       private static final long serialVersionUID = 0L;
+
       // Use TypedValue.newBuilder() to construct.
       private TypedValue(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
@@ -798,6 +823,7 @@ public final class Mcf {
       private int bitField0_;
       public static final int TYPE_FIELD_NUMBER = 1;
       private int type_;
+
       /**
        * <code>optional .org.datacommons.proto.ValueType type = 1;</code>
        *
@@ -807,6 +833,7 @@ public final class Mcf {
       public boolean hasType() {
         return ((bitField0_ & 0x00000001) != 0);
       }
+
       /**
        * <code>optional .org.datacommons.proto.ValueType type = 1;</code>
        *
@@ -822,6 +849,7 @@ public final class Mcf {
 
       public static final int VALUE_FIELD_NUMBER = 2;
       private volatile java.lang.Object value_;
+
       /**
        * <code>optional string value = 2;</code>
        *
@@ -831,6 +859,7 @@ public final class Mcf {
       public boolean hasValue() {
         return ((bitField0_ & 0x00000002) != 0);
       }
+
       /**
        * <code>optional string value = 2;</code>
        *
@@ -850,6 +879,7 @@ public final class Mcf {
           return s;
         }
       }
+
       /**
        * <code>optional string value = 2;</code>
        *
@@ -870,6 +900,7 @@ public final class Mcf {
 
       public static final int COLUMN_FIELD_NUMBER = 3;
       private volatile java.lang.Object column_;
+
       /**
        *
        *
@@ -886,6 +917,7 @@ public final class Mcf {
       public boolean hasColumn() {
         return ((bitField0_ & 0x00000004) != 0);
       }
+
       /**
        *
        *
@@ -912,6 +944,7 @@ public final class Mcf {
           return s;
         }
       }
+
       /**
        *
        *
@@ -1130,6 +1163,7 @@ public final class Mcf {
         Builder builder = new Builder(parent);
         return builder;
       }
+
       /**
        *
        *
@@ -1322,6 +1356,7 @@ public final class Mcf {
         private int bitField0_;
 
         private int type_ = 0;
+
         /**
          * <code>optional .org.datacommons.proto.ValueType type = 1;</code>
          *
@@ -1331,6 +1366,7 @@ public final class Mcf {
         public boolean hasType() {
           return ((bitField0_ & 0x00000001) != 0);
         }
+
         /**
          * <code>optional .org.datacommons.proto.ValueType type = 1;</code>
          *
@@ -1343,6 +1379,7 @@ public final class Mcf {
               org.datacommons.proto.Mcf.ValueType.valueOf(type_);
           return result == null ? org.datacommons.proto.Mcf.ValueType.UNKNOWN_VALUE_TYPE : result;
         }
+
         /**
          * <code>optional .org.datacommons.proto.ValueType type = 1;</code>
          *
@@ -1358,6 +1395,7 @@ public final class Mcf {
           onChanged();
           return this;
         }
+
         /**
          * <code>optional .org.datacommons.proto.ValueType type = 1;</code>
          *
@@ -1371,6 +1409,7 @@ public final class Mcf {
         }
 
         private java.lang.Object value_ = "";
+
         /**
          * <code>optional string value = 2;</code>
          *
@@ -1379,6 +1418,7 @@ public final class Mcf {
         public boolean hasValue() {
           return ((bitField0_ & 0x00000002) != 0);
         }
+
         /**
          * <code>optional string value = 2;</code>
          *
@@ -1397,6 +1437,7 @@ public final class Mcf {
             return (java.lang.String) ref;
           }
         }
+
         /**
          * <code>optional string value = 2;</code>
          *
@@ -1413,6 +1454,7 @@ public final class Mcf {
             return (com.google.protobuf.ByteString) ref;
           }
         }
+
         /**
          * <code>optional string value = 2;</code>
          *
@@ -1428,6 +1470,7 @@ public final class Mcf {
           onChanged();
           return this;
         }
+
         /**
          * <code>optional string value = 2;</code>
          *
@@ -1439,6 +1482,7 @@ public final class Mcf {
           onChanged();
           return this;
         }
+
         /**
          * <code>optional string value = 2;</code>
          *
@@ -1456,6 +1500,7 @@ public final class Mcf {
         }
 
         private java.lang.Object column_ = "";
+
         /**
          *
          *
@@ -1471,6 +1516,7 @@ public final class Mcf {
         public boolean hasColumn() {
           return ((bitField0_ & 0x00000004) != 0);
         }
+
         /**
          *
          *
@@ -1496,6 +1542,7 @@ public final class Mcf {
             return (java.lang.String) ref;
           }
         }
+
         /**
          *
          *
@@ -1519,6 +1566,7 @@ public final class Mcf {
             return (com.google.protobuf.ByteString) ref;
           }
         }
+
         /**
          *
          *
@@ -1541,6 +1589,7 @@ public final class Mcf {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -1559,6 +1608,7 @@ public final class Mcf {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -1650,6 +1700,7 @@ public final class Mcf {
        * <code>repeated .org.datacommons.proto.McfGraph.TypedValue typed_values = 1;</code>
        */
       java.util.List<org.datacommons.proto.Mcf.McfGraph.TypedValue> getTypedValuesList();
+
       /**
        *
        *
@@ -1660,6 +1711,7 @@ public final class Mcf {
        * <code>repeated .org.datacommons.proto.McfGraph.TypedValue typed_values = 1;</code>
        */
       org.datacommons.proto.Mcf.McfGraph.TypedValue getTypedValues(int index);
+
       /**
        *
        *
@@ -1670,6 +1722,7 @@ public final class Mcf {
        * <code>repeated .org.datacommons.proto.McfGraph.TypedValue typed_values = 1;</code>
        */
       int getTypedValuesCount();
+
       /**
        *
        *
@@ -1681,6 +1734,7 @@ public final class Mcf {
        */
       java.util.List<? extends org.datacommons.proto.Mcf.McfGraph.TypedValueOrBuilder>
           getTypedValuesOrBuilderList();
+
       /**
        *
        *
@@ -1692,6 +1746,7 @@ public final class Mcf {
        */
       org.datacommons.proto.Mcf.McfGraph.TypedValueOrBuilder getTypedValuesOrBuilder(int index);
     }
+
     /**
      *
      *
@@ -1706,6 +1761,7 @@ public final class Mcf {
         // @@protoc_insertion_point(message_implements:org.datacommons.proto.McfGraph.Values)
         ValuesOrBuilder {
       private static final long serialVersionUID = 0L;
+
       // Use Values.newBuilder() to construct.
       private Values(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
@@ -1797,6 +1853,7 @@ public final class Mcf {
 
       public static final int TYPED_VALUES_FIELD_NUMBER = 1;
       private java.util.List<org.datacommons.proto.Mcf.McfGraph.TypedValue> typedValues_;
+
       /**
        *
        *
@@ -1810,6 +1867,7 @@ public final class Mcf {
       public java.util.List<org.datacommons.proto.Mcf.McfGraph.TypedValue> getTypedValuesList() {
         return typedValues_;
       }
+
       /**
        *
        *
@@ -1824,6 +1882,7 @@ public final class Mcf {
           getTypedValuesOrBuilderList() {
         return typedValues_;
       }
+
       /**
        *
        *
@@ -1837,6 +1896,7 @@ public final class Mcf {
       public int getTypedValuesCount() {
         return typedValues_.size();
       }
+
       /**
        *
        *
@@ -1850,6 +1910,7 @@ public final class Mcf {
       public org.datacommons.proto.Mcf.McfGraph.TypedValue getTypedValues(int index) {
         return typedValues_.get(index);
       }
+
       /**
        *
        *
@@ -2027,6 +2088,7 @@ public final class Mcf {
         Builder builder = new Builder(parent);
         return builder;
       }
+
       /**
        *
        *
@@ -2261,6 +2323,7 @@ public final class Mcf {
             return typedValuesBuilder_.getMessageList();
           }
         }
+
         /**
          *
          *
@@ -2277,6 +2340,7 @@ public final class Mcf {
             return typedValuesBuilder_.getCount();
           }
         }
+
         /**
          *
          *
@@ -2293,6 +2357,7 @@ public final class Mcf {
             return typedValuesBuilder_.getMessage(index);
           }
         }
+
         /**
          *
          *
@@ -2316,6 +2381,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -2336,6 +2402,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -2358,6 +2425,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -2381,6 +2449,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -2401,6 +2470,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -2421,6 +2491,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -2441,6 +2512,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -2460,6 +2532,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -2479,6 +2552,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -2492,6 +2566,7 @@ public final class Mcf {
             int index) {
           return getTypedValuesFieldBuilder().getBuilder(index);
         }
+
         /**
          *
          *
@@ -2509,6 +2584,7 @@ public final class Mcf {
             return typedValuesBuilder_.getMessageOrBuilder(index);
           }
         }
+
         /**
          *
          *
@@ -2526,6 +2602,7 @@ public final class Mcf {
             return java.util.Collections.unmodifiableList(typedValues_);
           }
         }
+
         /**
          *
          *
@@ -2539,6 +2616,7 @@ public final class Mcf {
           return getTypedValuesFieldBuilder()
               .addBuilder(org.datacommons.proto.Mcf.McfGraph.TypedValue.getDefaultInstance());
         }
+
         /**
          *
          *
@@ -2554,6 +2632,7 @@ public final class Mcf {
               .addBuilder(
                   index, org.datacommons.proto.Mcf.McfGraph.TypedValue.getDefaultInstance());
         }
+
         /**
          *
          *
@@ -2656,6 +2735,7 @@ public final class Mcf {
        * <code>map&lt;string, .org.datacommons.proto.McfGraph.Values&gt; pvs = 1;</code>
        */
       int getPvsCount();
+
       /**
        *
        *
@@ -2666,9 +2746,11 @@ public final class Mcf {
        * <code>map&lt;string, .org.datacommons.proto.McfGraph.Values&gt; pvs = 1;</code>
        */
       boolean containsPvs(java.lang.String key);
+
       /** Use {@link #getPvsMap()} instead. */
       @java.lang.Deprecated
       java.util.Map<java.lang.String, org.datacommons.proto.Mcf.McfGraph.Values> getPvs();
+
       /**
        *
        *
@@ -2679,6 +2761,7 @@ public final class Mcf {
        * <code>map&lt;string, .org.datacommons.proto.McfGraph.Values&gt; pvs = 1;</code>
        */
       java.util.Map<java.lang.String, org.datacommons.proto.Mcf.McfGraph.Values> getPvsMap();
+
       /**
        *
        *
@@ -2690,6 +2773,7 @@ public final class Mcf {
        */
       org.datacommons.proto.Mcf.McfGraph.Values getPvsOrDefault(
           java.lang.String key, org.datacommons.proto.Mcf.McfGraph.Values defaultValue);
+
       /**
        *
        *
@@ -2712,6 +2796,7 @@ public final class Mcf {
        * <code>repeated .org.datacommons.proto.Location locations = 2;</code>
        */
       java.util.List<org.datacommons.proto.LogLocation.Location> getLocationsList();
+
       /**
        *
        *
@@ -2723,6 +2808,7 @@ public final class Mcf {
        * <code>repeated .org.datacommons.proto.Location locations = 2;</code>
        */
       org.datacommons.proto.LogLocation.Location getLocations(int index);
+
       /**
        *
        *
@@ -2734,6 +2820,7 @@ public final class Mcf {
        * <code>repeated .org.datacommons.proto.Location locations = 2;</code>
        */
       int getLocationsCount();
+
       /**
        *
        *
@@ -2746,6 +2833,7 @@ public final class Mcf {
        */
       java.util.List<? extends org.datacommons.proto.LogLocation.LocationOrBuilder>
           getLocationsOrBuilderList();
+
       /**
        *
        *
@@ -2770,6 +2858,7 @@ public final class Mcf {
        * @return Whether the templateNode field is set.
        */
       boolean hasTemplateNode();
+
       /**
        *
        *
@@ -2782,6 +2871,7 @@ public final class Mcf {
        * @return The templateNode.
        */
       java.lang.String getTemplateNode();
+
       /**
        *
        *
@@ -2807,6 +2897,7 @@ public final class Mcf {
        * @return Whether the errorMessage field is set.
        */
       boolean hasErrorMessage();
+
       /**
        *
        *
@@ -2819,6 +2910,7 @@ public final class Mcf {
        * @return The errorMessage.
        */
       java.lang.String getErrorMessage();
+
       /**
        *
        *
@@ -2832,6 +2924,7 @@ public final class Mcf {
        */
       com.google.protobuf.ByteString getErrorMessageBytes();
     }
+
     /**
      *
      *
@@ -2846,6 +2939,7 @@ public final class Mcf {
         // @@protoc_insertion_point(message_implements:org.datacommons.proto.McfGraph.PropertyValues)
         PropertyValuesOrBuilder {
       private static final long serialVersionUID = 0L;
+
       // Use PropertyValues.newBuilder() to construct.
       private PropertyValues(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
@@ -3013,6 +3107,7 @@ public final class Mcf {
       public int getPvsCount() {
         return internalGetPvs().getMap().size();
       }
+
       /**
        *
        *
@@ -3029,12 +3124,14 @@ public final class Mcf {
         }
         return internalGetPvs().getMap().containsKey(key);
       }
+
       /** Use {@link #getPvsMap()} instead. */
       @java.lang.Override
       @java.lang.Deprecated
       public java.util.Map<java.lang.String, org.datacommons.proto.Mcf.McfGraph.Values> getPvs() {
         return getPvsMap();
       }
+
       /**
        *
        *
@@ -3049,6 +3146,7 @@ public final class Mcf {
           getPvsMap() {
         return internalGetPvs().getMap();
       }
+
       /**
        *
        *
@@ -3068,6 +3166,7 @@ public final class Mcf {
             internalGetPvs().getMap();
         return map.containsKey(key) ? map.get(key) : defaultValue;
       }
+
       /**
        *
        *
@@ -3092,6 +3191,7 @@ public final class Mcf {
 
       public static final int LOCATIONS_FIELD_NUMBER = 2;
       private java.util.List<org.datacommons.proto.LogLocation.Location> locations_;
+
       /**
        *
        *
@@ -3106,6 +3206,7 @@ public final class Mcf {
       public java.util.List<org.datacommons.proto.LogLocation.Location> getLocationsList() {
         return locations_;
       }
+
       /**
        *
        *
@@ -3121,6 +3222,7 @@ public final class Mcf {
           getLocationsOrBuilderList() {
         return locations_;
       }
+
       /**
        *
        *
@@ -3135,6 +3237,7 @@ public final class Mcf {
       public int getLocationsCount() {
         return locations_.size();
       }
+
       /**
        *
        *
@@ -3149,6 +3252,7 @@ public final class Mcf {
       public org.datacommons.proto.LogLocation.Location getLocations(int index) {
         return locations_.get(index);
       }
+
       /**
        *
        *
@@ -3166,6 +3270,7 @@ public final class Mcf {
 
       public static final int TEMPLATE_NODE_FIELD_NUMBER = 3;
       private volatile java.lang.Object templateNode_;
+
       /**
        *
        *
@@ -3181,6 +3286,7 @@ public final class Mcf {
       public boolean hasTemplateNode() {
         return ((bitField0_ & 0x00000001) != 0);
       }
+
       /**
        *
        *
@@ -3206,6 +3312,7 @@ public final class Mcf {
           return s;
         }
       }
+
       /**
        *
        *
@@ -3232,6 +3339,7 @@ public final class Mcf {
 
       public static final int ERROR_MESSAGE_FIELD_NUMBER = 4;
       private volatile java.lang.Object errorMessage_;
+
       /**
        *
        *
@@ -3247,6 +3355,7 @@ public final class Mcf {
       public boolean hasErrorMessage() {
         return ((bitField0_ & 0x00000002) != 0);
       }
+
       /**
        *
        *
@@ -3272,6 +3381,7 @@ public final class Mcf {
           return s;
         }
       }
+
       /**
        *
        *
@@ -3505,6 +3615,7 @@ public final class Mcf {
         Builder builder = new Builder(parent);
         return builder;
       }
+
       /**
        *
        *
@@ -3785,6 +3896,7 @@ public final class Mcf {
         public int getPvsCount() {
           return internalGetPvs().getMap().size();
         }
+
         /**
          *
          *
@@ -3801,12 +3913,14 @@ public final class Mcf {
           }
           return internalGetPvs().getMap().containsKey(key);
         }
+
         /** Use {@link #getPvsMap()} instead. */
         @java.lang.Override
         @java.lang.Deprecated
         public java.util.Map<java.lang.String, org.datacommons.proto.Mcf.McfGraph.Values> getPvs() {
           return getPvsMap();
         }
+
         /**
          *
          *
@@ -3821,6 +3935,7 @@ public final class Mcf {
             getPvsMap() {
           return internalGetPvs().getMap();
         }
+
         /**
          *
          *
@@ -3840,6 +3955,7 @@ public final class Mcf {
               internalGetPvs().getMap();
           return map.containsKey(key) ? map.get(key) : defaultValue;
         }
+
         /**
          *
          *
@@ -3866,6 +3982,7 @@ public final class Mcf {
           internalGetMutablePvs().getMutableMap().clear();
           return this;
         }
+
         /**
          *
          *
@@ -3882,12 +3999,14 @@ public final class Mcf {
           internalGetMutablePvs().getMutableMap().remove(key);
           return this;
         }
+
         /** Use alternate mutation accessors instead. */
         @java.lang.Deprecated
         public java.util.Map<java.lang.String, org.datacommons.proto.Mcf.McfGraph.Values>
             getMutablePvs() {
           return internalGetMutablePvs().getMutableMap();
         }
+
         /**
          *
          *
@@ -3908,6 +4027,7 @@ public final class Mcf {
           internalGetMutablePvs().getMutableMap().put(key, value);
           return this;
         }
+
         /**
          *
          *
@@ -3957,6 +4077,7 @@ public final class Mcf {
             return locationsBuilder_.getMessageList();
           }
         }
+
         /**
          *
          *
@@ -3974,6 +4095,7 @@ public final class Mcf {
             return locationsBuilder_.getCount();
           }
         }
+
         /**
          *
          *
@@ -3991,6 +4113,7 @@ public final class Mcf {
             return locationsBuilder_.getMessage(index);
           }
         }
+
         /**
          *
          *
@@ -4014,6 +4137,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -4035,6 +4159,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -4058,6 +4183,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -4081,6 +4207,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -4102,6 +4229,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -4123,6 +4251,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -4144,6 +4273,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -4164,6 +4294,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -4184,6 +4315,7 @@ public final class Mcf {
           }
           return this;
         }
+
         /**
          *
          *
@@ -4197,6 +4329,7 @@ public final class Mcf {
         public org.datacommons.proto.LogLocation.Location.Builder getLocationsBuilder(int index) {
           return getLocationsFieldBuilder().getBuilder(index);
         }
+
         /**
          *
          *
@@ -4215,6 +4348,7 @@ public final class Mcf {
             return locationsBuilder_.getMessageOrBuilder(index);
           }
         }
+
         /**
          *
          *
@@ -4233,6 +4367,7 @@ public final class Mcf {
             return java.util.Collections.unmodifiableList(locations_);
           }
         }
+
         /**
          *
          *
@@ -4247,6 +4382,7 @@ public final class Mcf {
           return getLocationsFieldBuilder()
               .addBuilder(org.datacommons.proto.LogLocation.Location.getDefaultInstance());
         }
+
         /**
          *
          *
@@ -4261,6 +4397,7 @@ public final class Mcf {
           return getLocationsFieldBuilder()
               .addBuilder(index, org.datacommons.proto.LogLocation.Location.getDefaultInstance());
         }
+
         /**
          *
          *
@@ -4297,6 +4434,7 @@ public final class Mcf {
         }
 
         private java.lang.Object templateNode_ = "";
+
         /**
          *
          *
@@ -4311,6 +4449,7 @@ public final class Mcf {
         public boolean hasTemplateNode() {
           return ((bitField0_ & 0x00000004) != 0);
         }
+
         /**
          *
          *
@@ -4335,6 +4474,7 @@ public final class Mcf {
             return (java.lang.String) ref;
           }
         }
+
         /**
          *
          *
@@ -4357,6 +4497,7 @@ public final class Mcf {
             return (com.google.protobuf.ByteString) ref;
           }
         }
+
         /**
          *
          *
@@ -4378,6 +4519,7 @@ public final class Mcf {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -4395,6 +4537,7 @@ public final class Mcf {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -4418,6 +4561,7 @@ public final class Mcf {
         }
 
         private java.lang.Object errorMessage_ = "";
+
         /**
          *
          *
@@ -4432,6 +4576,7 @@ public final class Mcf {
         public boolean hasErrorMessage() {
           return ((bitField0_ & 0x00000008) != 0);
         }
+
         /**
          *
          *
@@ -4456,6 +4601,7 @@ public final class Mcf {
             return (java.lang.String) ref;
           }
         }
+
         /**
          *
          *
@@ -4478,6 +4624,7 @@ public final class Mcf {
             return (com.google.protobuf.ByteString) ref;
           }
         }
+
         /**
          *
          *
@@ -4499,6 +4646,7 @@ public final class Mcf {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -4516,6 +4664,7 @@ public final class Mcf {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -4594,6 +4743,7 @@ public final class Mcf {
     private int bitField0_;
     public static final int TYPE_FIELD_NUMBER = 1;
     private int type_;
+
     /**
      *
      *
@@ -4609,6 +4759,7 @@ public final class Mcf {
     public boolean hasType() {
       return ((bitField0_ & 0x00000001) != 0);
     }
+
     /**
      *
      *
@@ -4660,6 +4811,7 @@ public final class Mcf {
     public int getNodesCount() {
       return internalGetNodes().getMap().size();
     }
+
     /**
      *
      *
@@ -4676,6 +4828,7 @@ public final class Mcf {
       }
       return internalGetNodes().getMap().containsKey(key);
     }
+
     /** Use {@link #getNodesMap()} instead. */
     @java.lang.Override
     @java.lang.Deprecated
@@ -4683,6 +4836,7 @@ public final class Mcf {
         getNodes() {
       return getNodesMap();
     }
+
     /**
      *
      *
@@ -4697,6 +4851,7 @@ public final class Mcf {
         getNodesMap() {
       return internalGetNodes().getMap();
     }
+
     /**
      *
      *
@@ -4716,6 +4871,7 @@ public final class Mcf {
           internalGetNodes().getMap();
       return map.containsKey(key) ? map.get(key) : defaultValue;
     }
+
     /**
      *
      *
@@ -4920,6 +5076,7 @@ public final class Mcf {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /**
      *
      *
@@ -5110,6 +5267,7 @@ public final class Mcf {
       private int bitField0_;
 
       private int type_ = 1;
+
       /**
        *
        *
@@ -5125,6 +5283,7 @@ public final class Mcf {
       public boolean hasType() {
         return ((bitField0_ & 0x00000001) != 0);
       }
+
       /**
        *
        *
@@ -5142,6 +5301,7 @@ public final class Mcf {
         org.datacommons.proto.Mcf.McfType result = org.datacommons.proto.Mcf.McfType.valueOf(type_);
         return result == null ? org.datacommons.proto.Mcf.McfType.INSTANCE_MCF : result;
       }
+
       /**
        *
        *
@@ -5163,6 +5323,7 @@ public final class Mcf {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -5211,6 +5372,7 @@ public final class Mcf {
       public int getNodesCount() {
         return internalGetNodes().getMap().size();
       }
+
       /**
        *
        *
@@ -5227,6 +5389,7 @@ public final class Mcf {
         }
         return internalGetNodes().getMap().containsKey(key);
       }
+
       /** Use {@link #getNodesMap()} instead. */
       @java.lang.Override
       @java.lang.Deprecated
@@ -5234,6 +5397,7 @@ public final class Mcf {
           getNodes() {
         return getNodesMap();
       }
+
       /**
        *
        *
@@ -5248,6 +5412,7 @@ public final class Mcf {
           getNodesMap() {
         return internalGetNodes().getMap();
       }
+
       /**
        *
        *
@@ -5267,6 +5432,7 @@ public final class Mcf {
             internalGetNodes().getMap();
         return map.containsKey(key) ? map.get(key) : defaultValue;
       }
+
       /**
        *
        *
@@ -5294,6 +5460,7 @@ public final class Mcf {
         internalGetMutableNodes().getMutableMap().clear();
         return this;
       }
+
       /**
        *
        *
@@ -5310,12 +5477,14 @@ public final class Mcf {
         internalGetMutableNodes().getMutableMap().remove(key);
         return this;
       }
+
       /** Use alternate mutation accessors instead. */
       @java.lang.Deprecated
       public java.util.Map<java.lang.String, org.datacommons.proto.Mcf.McfGraph.PropertyValues>
           getMutableNodes() {
         return internalGetMutableNodes().getMutableMap();
       }
+
       /**
        *
        *
@@ -5336,6 +5505,7 @@ public final class Mcf {
         internalGetMutableNodes().getMutableMap().put(key, value);
         return this;
       }
+
       /**
        *
        *

--- a/util/src/main/java/org/datacommons/proto/Recon.java
+++ b/util/src/main/java/org/datacommons/proto/Recon.java
@@ -23,6 +23,7 @@ public final class Recon {
      * @return The prop.
      */
     java.lang.String getProp();
+
     /**
      * <code>string prop = 1;</code>
      *
@@ -36,6 +37,7 @@ public final class Recon {
      * @return The val.
      */
     java.lang.String getVal();
+
     /**
      * <code>string val = 2;</code>
      *
@@ -43,12 +45,14 @@ public final class Recon {
      */
     com.google.protobuf.ByteString getValBytes();
   }
+
   /** Protobuf type {@code org.datacommons.proto.IdWithProperty} */
   public static final class IdWithProperty extends com.google.protobuf.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.IdWithProperty)
       IdWithPropertyOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use IdWithProperty.newBuilder() to construct.
     private IdWithProperty(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -138,6 +142,7 @@ public final class Recon {
 
     public static final int PROP_FIELD_NUMBER = 1;
     private volatile java.lang.Object prop_;
+
     /**
      * <code>string prop = 1;</code>
      *
@@ -155,6 +160,7 @@ public final class Recon {
         return s;
       }
     }
+
     /**
      * <code>string prop = 1;</code>
      *
@@ -175,6 +181,7 @@ public final class Recon {
 
     public static final int VAL_FIELD_NUMBER = 2;
     private volatile java.lang.Object val_;
+
     /**
      * <code>string val = 2;</code>
      *
@@ -192,6 +199,7 @@ public final class Recon {
         return s;
       }
     }
+
     /**
      * <code>string val = 2;</code>
      *
@@ -379,6 +387,7 @@ public final class Recon {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /** Protobuf type {@code org.datacommons.proto.IdWithProperty} */
     public static final class Builder
         extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -539,6 +548,7 @@ public final class Recon {
       }
 
       private java.lang.Object prop_ = "";
+
       /**
        * <code>string prop = 1;</code>
        *
@@ -555,6 +565,7 @@ public final class Recon {
           return (java.lang.String) ref;
         }
       }
+
       /**
        * <code>string prop = 1;</code>
        *
@@ -571,6 +582,7 @@ public final class Recon {
           return (com.google.protobuf.ByteString) ref;
         }
       }
+
       /**
        * <code>string prop = 1;</code>
        *
@@ -586,6 +598,7 @@ public final class Recon {
         onChanged();
         return this;
       }
+
       /**
        * <code>string prop = 1;</code>
        *
@@ -597,6 +610,7 @@ public final class Recon {
         onChanged();
         return this;
       }
+
       /**
        * <code>string prop = 1;</code>
        *
@@ -615,6 +629,7 @@ public final class Recon {
       }
 
       private java.lang.Object val_ = "";
+
       /**
        * <code>string val = 2;</code>
        *
@@ -631,6 +646,7 @@ public final class Recon {
           return (java.lang.String) ref;
         }
       }
+
       /**
        * <code>string val = 2;</code>
        *
@@ -647,6 +663,7 @@ public final class Recon {
           return (com.google.protobuf.ByteString) ref;
         }
       }
+
       /**
        * <code>string val = 2;</code>
        *
@@ -662,6 +679,7 @@ public final class Recon {
         onChanged();
         return this;
       }
+
       /**
        * <code>string val = 2;</code>
        *
@@ -673,6 +691,7 @@ public final class Recon {
         onChanged();
         return this;
       }
+
       /**
        * <code>string val = 2;</code>
        *
@@ -749,22 +768,28 @@ public final class Recon {
 
     /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
     java.util.List<org.datacommons.proto.Recon.IdWithProperty> getIdsList();
+
     /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
     org.datacommons.proto.Recon.IdWithProperty getIds(int index);
+
     /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
     int getIdsCount();
+
     /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
     java.util.List<? extends org.datacommons.proto.Recon.IdWithPropertyOrBuilder>
         getIdsOrBuilderList();
+
     /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
     org.datacommons.proto.Recon.IdWithPropertyOrBuilder getIdsOrBuilder(int index);
   }
+
   /** Protobuf type {@code org.datacommons.proto.EntityIds} */
   public static final class EntityIds extends com.google.protobuf.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.EntityIds)
       EntityIdsOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use EntityIds.newBuilder() to construct.
     private EntityIds(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -853,27 +878,32 @@ public final class Recon {
 
     public static final int IDS_FIELD_NUMBER = 1;
     private java.util.List<org.datacommons.proto.Recon.IdWithProperty> ids_;
+
     /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
     @java.lang.Override
     public java.util.List<org.datacommons.proto.Recon.IdWithProperty> getIdsList() {
       return ids_;
     }
+
     /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
     @java.lang.Override
     public java.util.List<? extends org.datacommons.proto.Recon.IdWithPropertyOrBuilder>
         getIdsOrBuilderList() {
       return ids_;
     }
+
     /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
     @java.lang.Override
     public int getIdsCount() {
       return ids_.size();
     }
+
     /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
     @java.lang.Override
     public org.datacommons.proto.Recon.IdWithProperty getIds(int index) {
       return ids_.get(index);
     }
+
     /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
     @java.lang.Override
     public org.datacommons.proto.Recon.IdWithPropertyOrBuilder getIdsOrBuilder(int index) {
@@ -1041,6 +1071,7 @@ public final class Recon {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /** Protobuf type {@code org.datacommons.proto.EntityIds} */
     public static final class Builder
         extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -1257,6 +1288,7 @@ public final class Recon {
           return idsBuilder_.getMessageList();
         }
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public int getIdsCount() {
         if (idsBuilder_ == null) {
@@ -1265,6 +1297,7 @@ public final class Recon {
           return idsBuilder_.getCount();
         }
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public org.datacommons.proto.Recon.IdWithProperty getIds(int index) {
         if (idsBuilder_ == null) {
@@ -1273,6 +1306,7 @@ public final class Recon {
           return idsBuilder_.getMessage(index);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public Builder setIds(int index, org.datacommons.proto.Recon.IdWithProperty value) {
         if (idsBuilder_ == null) {
@@ -1287,6 +1321,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public Builder setIds(
           int index, org.datacommons.proto.Recon.IdWithProperty.Builder builderForValue) {
@@ -1299,6 +1334,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public Builder addIds(org.datacommons.proto.Recon.IdWithProperty value) {
         if (idsBuilder_ == null) {
@@ -1313,6 +1349,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public Builder addIds(int index, org.datacommons.proto.Recon.IdWithProperty value) {
         if (idsBuilder_ == null) {
@@ -1327,6 +1364,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public Builder addIds(org.datacommons.proto.Recon.IdWithProperty.Builder builderForValue) {
         if (idsBuilder_ == null) {
@@ -1338,6 +1376,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public Builder addIds(
           int index, org.datacommons.proto.Recon.IdWithProperty.Builder builderForValue) {
@@ -1350,6 +1389,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public Builder addAllIds(
           java.lang.Iterable<? extends org.datacommons.proto.Recon.IdWithProperty> values) {
@@ -1362,6 +1402,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public Builder clearIds() {
         if (idsBuilder_ == null) {
@@ -1373,6 +1414,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public Builder removeIds(int index) {
         if (idsBuilder_ == null) {
@@ -1384,10 +1426,12 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public org.datacommons.proto.Recon.IdWithProperty.Builder getIdsBuilder(int index) {
         return getIdsFieldBuilder().getBuilder(index);
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public org.datacommons.proto.Recon.IdWithPropertyOrBuilder getIdsOrBuilder(int index) {
         if (idsBuilder_ == null) {
@@ -1396,6 +1440,7 @@ public final class Recon {
           return idsBuilder_.getMessageOrBuilder(index);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public java.util.List<? extends org.datacommons.proto.Recon.IdWithPropertyOrBuilder>
           getIdsOrBuilderList() {
@@ -1405,16 +1450,19 @@ public final class Recon {
           return java.util.Collections.unmodifiableList(ids_);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public org.datacommons.proto.Recon.IdWithProperty.Builder addIdsBuilder() {
         return getIdsFieldBuilder()
             .addBuilder(org.datacommons.proto.Recon.IdWithProperty.getDefaultInstance());
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public org.datacommons.proto.Recon.IdWithProperty.Builder addIdsBuilder(int index) {
         return getIdsFieldBuilder()
             .addBuilder(index, org.datacommons.proto.Recon.IdWithProperty.getDefaultInstance());
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       public java.util.List<org.datacommons.proto.Recon.IdWithProperty.Builder>
           getIdsBuilderList() {
@@ -1507,6 +1555,7 @@ public final class Recon {
      * @return The sourceId.
      */
     java.lang.String getSourceId();
+
     /**
      *
      *
@@ -1526,12 +1575,14 @@ public final class Recon {
      * @return Whether the subGraph field is set.
      */
     boolean hasSubGraph();
+
     /**
      * <code>.org.datacommons.proto.McfGraph sub_graph = 2;</code>
      *
      * @return The subGraph.
      */
     org.datacommons.proto.Mcf.McfGraph getSubGraph();
+
     /** <code>.org.datacommons.proto.McfGraph sub_graph = 2;</code> */
     org.datacommons.proto.Mcf.McfGraphOrBuilder getSubGraphOrBuilder();
 
@@ -1541,18 +1592,21 @@ public final class Recon {
      * @return Whether the entityIds field is set.
      */
     boolean hasEntityIds();
+
     /**
      * <code>.org.datacommons.proto.EntityIds entity_ids = 3;</code>
      *
      * @return The entityIds.
      */
     org.datacommons.proto.Recon.EntityIds getEntityIds();
+
     /** <code>.org.datacommons.proto.EntityIds entity_ids = 3;</code> */
     org.datacommons.proto.Recon.EntityIdsOrBuilder getEntityIdsOrBuilder();
 
     public org.datacommons.proto.Recon.EntitySubGraph.GraphRepresentationCase
         getGraphRepresentationCase();
   }
+
   /**
    *
    *
@@ -1567,6 +1621,7 @@ public final class Recon {
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.EntitySubGraph)
       EntitySubGraphOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use EntitySubGraph.newBuilder() to construct.
     private EntitySubGraph(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -1695,6 +1750,7 @@ public final class Recon {
       private GraphRepresentationCase(int value) {
         this.value = value;
       }
+
       /**
        * @param value The number of the enum to look for.
        * @return The enum associated with the given number.
@@ -1729,6 +1785,7 @@ public final class Recon {
 
     public static final int SOURCE_ID_FIELD_NUMBER = 1;
     private volatile java.lang.Object sourceId_;
+
     /**
      *
      *
@@ -1752,6 +1809,7 @@ public final class Recon {
         return s;
       }
     }
+
     /**
      *
      *
@@ -1777,6 +1835,7 @@ public final class Recon {
     }
 
     public static final int SUB_GRAPH_FIELD_NUMBER = 2;
+
     /**
      * <code>.org.datacommons.proto.McfGraph sub_graph = 2;</code>
      *
@@ -1786,6 +1845,7 @@ public final class Recon {
     public boolean hasSubGraph() {
       return graphRepresentationCase_ == 2;
     }
+
     /**
      * <code>.org.datacommons.proto.McfGraph sub_graph = 2;</code>
      *
@@ -1798,6 +1858,7 @@ public final class Recon {
       }
       return org.datacommons.proto.Mcf.McfGraph.getDefaultInstance();
     }
+
     /** <code>.org.datacommons.proto.McfGraph sub_graph = 2;</code> */
     @java.lang.Override
     public org.datacommons.proto.Mcf.McfGraphOrBuilder getSubGraphOrBuilder() {
@@ -1808,6 +1869,7 @@ public final class Recon {
     }
 
     public static final int ENTITY_IDS_FIELD_NUMBER = 3;
+
     /**
      * <code>.org.datacommons.proto.EntityIds entity_ids = 3;</code>
      *
@@ -1817,6 +1879,7 @@ public final class Recon {
     public boolean hasEntityIds() {
       return graphRepresentationCase_ == 3;
     }
+
     /**
      * <code>.org.datacommons.proto.EntityIds entity_ids = 3;</code>
      *
@@ -1829,6 +1892,7 @@ public final class Recon {
       }
       return org.datacommons.proto.Recon.EntityIds.getDefaultInstance();
     }
+
     /** <code>.org.datacommons.proto.EntityIds entity_ids = 3;</code> */
     @java.lang.Override
     public org.datacommons.proto.Recon.EntityIdsOrBuilder getEntityIdsOrBuilder() {
@@ -2037,6 +2101,7 @@ public final class Recon {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /**
      *
      *
@@ -2245,6 +2310,7 @@ public final class Recon {
       }
 
       private java.lang.Object sourceId_ = "";
+
       /**
        *
        *
@@ -2267,6 +2333,7 @@ public final class Recon {
           return (java.lang.String) ref;
         }
       }
+
       /**
        *
        *
@@ -2289,6 +2356,7 @@ public final class Recon {
           return (com.google.protobuf.ByteString) ref;
         }
       }
+
       /**
        *
        *
@@ -2310,6 +2378,7 @@ public final class Recon {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -2327,6 +2396,7 @@ public final class Recon {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -2355,6 +2425,7 @@ public final class Recon {
               org.datacommons.proto.Mcf.McfGraph.Builder,
               org.datacommons.proto.Mcf.McfGraphOrBuilder>
           subGraphBuilder_;
+
       /**
        * <code>.org.datacommons.proto.McfGraph sub_graph = 2;</code>
        *
@@ -2364,6 +2435,7 @@ public final class Recon {
       public boolean hasSubGraph() {
         return graphRepresentationCase_ == 2;
       }
+
       /**
        * <code>.org.datacommons.proto.McfGraph sub_graph = 2;</code>
        *
@@ -2383,6 +2455,7 @@ public final class Recon {
           return org.datacommons.proto.Mcf.McfGraph.getDefaultInstance();
         }
       }
+
       /** <code>.org.datacommons.proto.McfGraph sub_graph = 2;</code> */
       public Builder setSubGraph(org.datacommons.proto.Mcf.McfGraph value) {
         if (subGraphBuilder_ == null) {
@@ -2397,6 +2470,7 @@ public final class Recon {
         graphRepresentationCase_ = 2;
         return this;
       }
+
       /** <code>.org.datacommons.proto.McfGraph sub_graph = 2;</code> */
       public Builder setSubGraph(org.datacommons.proto.Mcf.McfGraph.Builder builderForValue) {
         if (subGraphBuilder_ == null) {
@@ -2408,6 +2482,7 @@ public final class Recon {
         graphRepresentationCase_ = 2;
         return this;
       }
+
       /** <code>.org.datacommons.proto.McfGraph sub_graph = 2;</code> */
       public Builder mergeSubGraph(org.datacommons.proto.Mcf.McfGraph value) {
         if (subGraphBuilder_ == null) {
@@ -2431,6 +2506,7 @@ public final class Recon {
         graphRepresentationCase_ = 2;
         return this;
       }
+
       /** <code>.org.datacommons.proto.McfGraph sub_graph = 2;</code> */
       public Builder clearSubGraph() {
         if (subGraphBuilder_ == null) {
@@ -2448,10 +2524,12 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>.org.datacommons.proto.McfGraph sub_graph = 2;</code> */
       public org.datacommons.proto.Mcf.McfGraph.Builder getSubGraphBuilder() {
         return getSubGraphFieldBuilder().getBuilder();
       }
+
       /** <code>.org.datacommons.proto.McfGraph sub_graph = 2;</code> */
       @java.lang.Override
       public org.datacommons.proto.Mcf.McfGraphOrBuilder getSubGraphOrBuilder() {
@@ -2464,6 +2542,7 @@ public final class Recon {
           return org.datacommons.proto.Mcf.McfGraph.getDefaultInstance();
         }
       }
+
       /** <code>.org.datacommons.proto.McfGraph sub_graph = 2;</code> */
       private com.google.protobuf.SingleFieldBuilderV3<
               org.datacommons.proto.Mcf.McfGraph,
@@ -2495,6 +2574,7 @@ public final class Recon {
               org.datacommons.proto.Recon.EntityIds.Builder,
               org.datacommons.proto.Recon.EntityIdsOrBuilder>
           entityIdsBuilder_;
+
       /**
        * <code>.org.datacommons.proto.EntityIds entity_ids = 3;</code>
        *
@@ -2504,6 +2584,7 @@ public final class Recon {
       public boolean hasEntityIds() {
         return graphRepresentationCase_ == 3;
       }
+
       /**
        * <code>.org.datacommons.proto.EntityIds entity_ids = 3;</code>
        *
@@ -2523,6 +2604,7 @@ public final class Recon {
           return org.datacommons.proto.Recon.EntityIds.getDefaultInstance();
         }
       }
+
       /** <code>.org.datacommons.proto.EntityIds entity_ids = 3;</code> */
       public Builder setEntityIds(org.datacommons.proto.Recon.EntityIds value) {
         if (entityIdsBuilder_ == null) {
@@ -2537,6 +2619,7 @@ public final class Recon {
         graphRepresentationCase_ = 3;
         return this;
       }
+
       /** <code>.org.datacommons.proto.EntityIds entity_ids = 3;</code> */
       public Builder setEntityIds(org.datacommons.proto.Recon.EntityIds.Builder builderForValue) {
         if (entityIdsBuilder_ == null) {
@@ -2548,6 +2631,7 @@ public final class Recon {
         graphRepresentationCase_ = 3;
         return this;
       }
+
       /** <code>.org.datacommons.proto.EntityIds entity_ids = 3;</code> */
       public Builder mergeEntityIds(org.datacommons.proto.Recon.EntityIds value) {
         if (entityIdsBuilder_ == null) {
@@ -2572,6 +2656,7 @@ public final class Recon {
         graphRepresentationCase_ = 3;
         return this;
       }
+
       /** <code>.org.datacommons.proto.EntityIds entity_ids = 3;</code> */
       public Builder clearEntityIds() {
         if (entityIdsBuilder_ == null) {
@@ -2589,10 +2674,12 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>.org.datacommons.proto.EntityIds entity_ids = 3;</code> */
       public org.datacommons.proto.Recon.EntityIds.Builder getEntityIdsBuilder() {
         return getEntityIdsFieldBuilder().getBuilder();
       }
+
       /** <code>.org.datacommons.proto.EntityIds entity_ids = 3;</code> */
       @java.lang.Override
       public org.datacommons.proto.Recon.EntityIdsOrBuilder getEntityIdsOrBuilder() {
@@ -2605,6 +2692,7 @@ public final class Recon {
           return org.datacommons.proto.Recon.EntityIds.getDefaultInstance();
         }
       }
+
       /** <code>.org.datacommons.proto.EntityIds entity_ids = 3;</code> */
       private com.google.protobuf.SingleFieldBuilderV3<
               org.datacommons.proto.Recon.EntityIds,
@@ -2694,12 +2782,14 @@ public final class Recon {
      * @return Whether the entityOne field is set.
      */
     boolean hasEntityOne();
+
     /**
      * <code>.org.datacommons.proto.EntitySubGraph entity_one = 1;</code>
      *
      * @return The entityOne.
      */
     org.datacommons.proto.Recon.EntitySubGraph getEntityOne();
+
     /** <code>.org.datacommons.proto.EntitySubGraph entity_one = 1;</code> */
     org.datacommons.proto.Recon.EntitySubGraphOrBuilder getEntityOneOrBuilder();
 
@@ -2709,21 +2799,25 @@ public final class Recon {
      * @return Whether the entityTwo field is set.
      */
     boolean hasEntityTwo();
+
     /**
      * <code>.org.datacommons.proto.EntitySubGraph entity_two = 2;</code>
      *
      * @return The entityTwo.
      */
     org.datacommons.proto.Recon.EntitySubGraph getEntityTwo();
+
     /** <code>.org.datacommons.proto.EntitySubGraph entity_two = 2;</code> */
     org.datacommons.proto.Recon.EntitySubGraphOrBuilder getEntityTwoOrBuilder();
   }
+
   /** Protobuf type {@code org.datacommons.proto.EntityPair} */
   public static final class EntityPair extends com.google.protobuf.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.EntityPair)
       EntityPairOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use EntityPair.newBuilder() to construct.
     private EntityPair(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -2828,6 +2922,7 @@ public final class Recon {
 
     public static final int ENTITY_ONE_FIELD_NUMBER = 1;
     private org.datacommons.proto.Recon.EntitySubGraph entityOne_;
+
     /**
      * <code>.org.datacommons.proto.EntitySubGraph entity_one = 1;</code>
      *
@@ -2837,6 +2932,7 @@ public final class Recon {
     public boolean hasEntityOne() {
       return entityOne_ != null;
     }
+
     /**
      * <code>.org.datacommons.proto.EntitySubGraph entity_one = 1;</code>
      *
@@ -2848,6 +2944,7 @@ public final class Recon {
           ? org.datacommons.proto.Recon.EntitySubGraph.getDefaultInstance()
           : entityOne_;
     }
+
     /** <code>.org.datacommons.proto.EntitySubGraph entity_one = 1;</code> */
     @java.lang.Override
     public org.datacommons.proto.Recon.EntitySubGraphOrBuilder getEntityOneOrBuilder() {
@@ -2856,6 +2953,7 @@ public final class Recon {
 
     public static final int ENTITY_TWO_FIELD_NUMBER = 2;
     private org.datacommons.proto.Recon.EntitySubGraph entityTwo_;
+
     /**
      * <code>.org.datacommons.proto.EntitySubGraph entity_two = 2;</code>
      *
@@ -2865,6 +2963,7 @@ public final class Recon {
     public boolean hasEntityTwo() {
       return entityTwo_ != null;
     }
+
     /**
      * <code>.org.datacommons.proto.EntitySubGraph entity_two = 2;</code>
      *
@@ -2876,6 +2975,7 @@ public final class Recon {
           ? org.datacommons.proto.Recon.EntitySubGraph.getDefaultInstance()
           : entityTwo_;
     }
+
     /** <code>.org.datacommons.proto.EntitySubGraph entity_two = 2;</code> */
     @java.lang.Override
     public org.datacommons.proto.Recon.EntitySubGraphOrBuilder getEntityTwoOrBuilder() {
@@ -3060,6 +3160,7 @@ public final class Recon {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /** Protobuf type {@code org.datacommons.proto.EntityPair} */
     public static final class Builder
         extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -3239,6 +3340,7 @@ public final class Recon {
               org.datacommons.proto.Recon.EntitySubGraph.Builder,
               org.datacommons.proto.Recon.EntitySubGraphOrBuilder>
           entityOneBuilder_;
+
       /**
        * <code>.org.datacommons.proto.EntitySubGraph entity_one = 1;</code>
        *
@@ -3247,6 +3349,7 @@ public final class Recon {
       public boolean hasEntityOne() {
         return entityOneBuilder_ != null || entityOne_ != null;
       }
+
       /**
        * <code>.org.datacommons.proto.EntitySubGraph entity_one = 1;</code>
        *
@@ -3261,6 +3364,7 @@ public final class Recon {
           return entityOneBuilder_.getMessage();
         }
       }
+
       /** <code>.org.datacommons.proto.EntitySubGraph entity_one = 1;</code> */
       public Builder setEntityOne(org.datacommons.proto.Recon.EntitySubGraph value) {
         if (entityOneBuilder_ == null) {
@@ -3275,6 +3379,7 @@ public final class Recon {
 
         return this;
       }
+
       /** <code>.org.datacommons.proto.EntitySubGraph entity_one = 1;</code> */
       public Builder setEntityOne(
           org.datacommons.proto.Recon.EntitySubGraph.Builder builderForValue) {
@@ -3287,6 +3392,7 @@ public final class Recon {
 
         return this;
       }
+
       /** <code>.org.datacommons.proto.EntitySubGraph entity_one = 1;</code> */
       public Builder mergeEntityOne(org.datacommons.proto.Recon.EntitySubGraph value) {
         if (entityOneBuilder_ == null) {
@@ -3305,6 +3411,7 @@ public final class Recon {
 
         return this;
       }
+
       /** <code>.org.datacommons.proto.EntitySubGraph entity_one = 1;</code> */
       public Builder clearEntityOne() {
         if (entityOneBuilder_ == null) {
@@ -3317,12 +3424,14 @@ public final class Recon {
 
         return this;
       }
+
       /** <code>.org.datacommons.proto.EntitySubGraph entity_one = 1;</code> */
       public org.datacommons.proto.Recon.EntitySubGraph.Builder getEntityOneBuilder() {
 
         onChanged();
         return getEntityOneFieldBuilder().getBuilder();
       }
+
       /** <code>.org.datacommons.proto.EntitySubGraph entity_one = 1;</code> */
       public org.datacommons.proto.Recon.EntitySubGraphOrBuilder getEntityOneOrBuilder() {
         if (entityOneBuilder_ != null) {
@@ -3333,6 +3442,7 @@ public final class Recon {
               : entityOne_;
         }
       }
+
       /** <code>.org.datacommons.proto.EntitySubGraph entity_one = 1;</code> */
       private com.google.protobuf.SingleFieldBuilderV3<
               org.datacommons.proto.Recon.EntitySubGraph,
@@ -3357,6 +3467,7 @@ public final class Recon {
               org.datacommons.proto.Recon.EntitySubGraph.Builder,
               org.datacommons.proto.Recon.EntitySubGraphOrBuilder>
           entityTwoBuilder_;
+
       /**
        * <code>.org.datacommons.proto.EntitySubGraph entity_two = 2;</code>
        *
@@ -3365,6 +3476,7 @@ public final class Recon {
       public boolean hasEntityTwo() {
         return entityTwoBuilder_ != null || entityTwo_ != null;
       }
+
       /**
        * <code>.org.datacommons.proto.EntitySubGraph entity_two = 2;</code>
        *
@@ -3379,6 +3491,7 @@ public final class Recon {
           return entityTwoBuilder_.getMessage();
         }
       }
+
       /** <code>.org.datacommons.proto.EntitySubGraph entity_two = 2;</code> */
       public Builder setEntityTwo(org.datacommons.proto.Recon.EntitySubGraph value) {
         if (entityTwoBuilder_ == null) {
@@ -3393,6 +3506,7 @@ public final class Recon {
 
         return this;
       }
+
       /** <code>.org.datacommons.proto.EntitySubGraph entity_two = 2;</code> */
       public Builder setEntityTwo(
           org.datacommons.proto.Recon.EntitySubGraph.Builder builderForValue) {
@@ -3405,6 +3519,7 @@ public final class Recon {
 
         return this;
       }
+
       /** <code>.org.datacommons.proto.EntitySubGraph entity_two = 2;</code> */
       public Builder mergeEntityTwo(org.datacommons.proto.Recon.EntitySubGraph value) {
         if (entityTwoBuilder_ == null) {
@@ -3423,6 +3538,7 @@ public final class Recon {
 
         return this;
       }
+
       /** <code>.org.datacommons.proto.EntitySubGraph entity_two = 2;</code> */
       public Builder clearEntityTwo() {
         if (entityTwoBuilder_ == null) {
@@ -3435,12 +3551,14 @@ public final class Recon {
 
         return this;
       }
+
       /** <code>.org.datacommons.proto.EntitySubGraph entity_two = 2;</code> */
       public org.datacommons.proto.Recon.EntitySubGraph.Builder getEntityTwoBuilder() {
 
         onChanged();
         return getEntityTwoFieldBuilder().getBuilder();
       }
+
       /** <code>.org.datacommons.proto.EntitySubGraph entity_two = 2;</code> */
       public org.datacommons.proto.Recon.EntitySubGraphOrBuilder getEntityTwoOrBuilder() {
         if (entityTwoBuilder_ != null) {
@@ -3451,6 +3569,7 @@ public final class Recon {
               : entityTwo_;
         }
       }
+
       /** <code>.org.datacommons.proto.EntitySubGraph entity_two = 2;</code> */
       private com.google.protobuf.SingleFieldBuilderV3<
               org.datacommons.proto.Recon.EntitySubGraph,
@@ -3528,22 +3647,28 @@ public final class Recon {
 
     /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
     java.util.List<org.datacommons.proto.Recon.EntityPair> getEntityPairsList();
+
     /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
     org.datacommons.proto.Recon.EntityPair getEntityPairs(int index);
+
     /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
     int getEntityPairsCount();
+
     /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
     java.util.List<? extends org.datacommons.proto.Recon.EntityPairOrBuilder>
         getEntityPairsOrBuilderList();
+
     /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
     org.datacommons.proto.Recon.EntityPairOrBuilder getEntityPairsOrBuilder(int index);
   }
+
   /** Protobuf type {@code org.datacommons.proto.CompareEntitiesRequest} */
   public static final class CompareEntitiesRequest extends com.google.protobuf.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.CompareEntitiesRequest)
       CompareEntitiesRequestOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use CompareEntitiesRequest.newBuilder() to construct.
     private CompareEntitiesRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -3633,27 +3758,32 @@ public final class Recon {
 
     public static final int ENTITY_PAIRS_FIELD_NUMBER = 1;
     private java.util.List<org.datacommons.proto.Recon.EntityPair> entityPairs_;
+
     /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
     @java.lang.Override
     public java.util.List<org.datacommons.proto.Recon.EntityPair> getEntityPairsList() {
       return entityPairs_;
     }
+
     /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
     @java.lang.Override
     public java.util.List<? extends org.datacommons.proto.Recon.EntityPairOrBuilder>
         getEntityPairsOrBuilderList() {
       return entityPairs_;
     }
+
     /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
     @java.lang.Override
     public int getEntityPairsCount() {
       return entityPairs_.size();
     }
+
     /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
     @java.lang.Override
     public org.datacommons.proto.Recon.EntityPair getEntityPairs(int index) {
       return entityPairs_.get(index);
     }
+
     /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
     @java.lang.Override
     public org.datacommons.proto.Recon.EntityPairOrBuilder getEntityPairsOrBuilder(int index) {
@@ -3822,6 +3952,7 @@ public final class Recon {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /** Protobuf type {@code org.datacommons.proto.CompareEntitiesRequest} */
     public static final class Builder
         extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -4041,6 +4172,7 @@ public final class Recon {
           return entityPairsBuilder_.getMessageList();
         }
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public int getEntityPairsCount() {
         if (entityPairsBuilder_ == null) {
@@ -4049,6 +4181,7 @@ public final class Recon {
           return entityPairsBuilder_.getCount();
         }
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public org.datacommons.proto.Recon.EntityPair getEntityPairs(int index) {
         if (entityPairsBuilder_ == null) {
@@ -4057,6 +4190,7 @@ public final class Recon {
           return entityPairsBuilder_.getMessage(index);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public Builder setEntityPairs(int index, org.datacommons.proto.Recon.EntityPair value) {
         if (entityPairsBuilder_ == null) {
@@ -4071,6 +4205,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public Builder setEntityPairs(
           int index, org.datacommons.proto.Recon.EntityPair.Builder builderForValue) {
@@ -4083,6 +4218,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public Builder addEntityPairs(org.datacommons.proto.Recon.EntityPair value) {
         if (entityPairsBuilder_ == null) {
@@ -4097,6 +4233,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public Builder addEntityPairs(int index, org.datacommons.proto.Recon.EntityPair value) {
         if (entityPairsBuilder_ == null) {
@@ -4111,6 +4248,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public Builder addEntityPairs(
           org.datacommons.proto.Recon.EntityPair.Builder builderForValue) {
@@ -4123,6 +4261,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public Builder addEntityPairs(
           int index, org.datacommons.proto.Recon.EntityPair.Builder builderForValue) {
@@ -4135,6 +4274,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public Builder addAllEntityPairs(
           java.lang.Iterable<? extends org.datacommons.proto.Recon.EntityPair> values) {
@@ -4147,6 +4287,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public Builder clearEntityPairs() {
         if (entityPairsBuilder_ == null) {
@@ -4158,6 +4299,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public Builder removeEntityPairs(int index) {
         if (entityPairsBuilder_ == null) {
@@ -4169,10 +4311,12 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public org.datacommons.proto.Recon.EntityPair.Builder getEntityPairsBuilder(int index) {
         return getEntityPairsFieldBuilder().getBuilder(index);
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public org.datacommons.proto.Recon.EntityPairOrBuilder getEntityPairsOrBuilder(int index) {
         if (entityPairsBuilder_ == null) {
@@ -4181,6 +4325,7 @@ public final class Recon {
           return entityPairsBuilder_.getMessageOrBuilder(index);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public java.util.List<? extends org.datacommons.proto.Recon.EntityPairOrBuilder>
           getEntityPairsOrBuilderList() {
@@ -4190,16 +4335,19 @@ public final class Recon {
           return java.util.Collections.unmodifiableList(entityPairs_);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public org.datacommons.proto.Recon.EntityPair.Builder addEntityPairsBuilder() {
         return getEntityPairsFieldBuilder()
             .addBuilder(org.datacommons.proto.Recon.EntityPair.getDefaultInstance());
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public org.datacommons.proto.Recon.EntityPair.Builder addEntityPairsBuilder(int index) {
         return getEntityPairsFieldBuilder()
             .addBuilder(index, org.datacommons.proto.Recon.EntityPair.getDefaultInstance());
       }
+
       /** <code>repeated .org.datacommons.proto.EntityPair entity_pairs = 1;</code> */
       public java.util.List<org.datacommons.proto.Recon.EntityPair.Builder>
           getEntityPairsBuilderList() {
@@ -4289,16 +4437,19 @@ public final class Recon {
      */
     java.util.List<org.datacommons.proto.Recon.CompareEntitiesResponse.Comparison>
         getComparisonsList();
+
     /**
      * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
      * </code>
      */
     org.datacommons.proto.Recon.CompareEntitiesResponse.Comparison getComparisons(int index);
+
     /**
      * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
      * </code>
      */
     int getComparisonsCount();
+
     /**
      * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
      * </code>
@@ -4306,6 +4457,7 @@ public final class Recon {
     java.util.List<
             ? extends org.datacommons.proto.Recon.CompareEntitiesResponse.ComparisonOrBuilder>
         getComparisonsOrBuilderList();
+
     /**
      * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
      * </code>
@@ -4313,12 +4465,14 @@ public final class Recon {
     org.datacommons.proto.Recon.CompareEntitiesResponse.ComparisonOrBuilder getComparisonsOrBuilder(
         int index);
   }
+
   /** Protobuf type {@code org.datacommons.proto.CompareEntitiesResponse} */
   public static final class CompareEntitiesResponse extends com.google.protobuf.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.CompareEntitiesResponse)
       CompareEntitiesResponseOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use CompareEntitiesResponse.newBuilder() to construct.
     private CompareEntitiesResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -4426,6 +4580,7 @@ public final class Recon {
        * @return A list containing the sourceIds.
        */
       java.util.List<java.lang.String> getSourceIdsList();
+
       /**
        *
        *
@@ -4438,6 +4593,7 @@ public final class Recon {
        * @return The count of sourceIds.
        */
       int getSourceIdsCount();
+
       /**
        *
        *
@@ -4451,6 +4607,7 @@ public final class Recon {
        * @return The sourceIds at the given index.
        */
       java.lang.String getSourceIds(int index);
+
       /**
        *
        *
@@ -4472,12 +4629,14 @@ public final class Recon {
        */
       double getProbability();
     }
+
     /** Protobuf type {@code org.datacommons.proto.CompareEntitiesResponse.Comparison} */
     public static final class Comparison extends com.google.protobuf.GeneratedMessageV3
         implements
         // @@protoc_insertion_point(message_implements:org.datacommons.proto.CompareEntitiesResponse.Comparison)
         ComparisonOrBuilder {
       private static final long serialVersionUID = 0L;
+
       // Use Comparison.newBuilder() to construct.
       private Comparison(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
@@ -4572,6 +4731,7 @@ public final class Recon {
 
       public static final int SOURCE_IDS_FIELD_NUMBER = 1;
       private com.google.protobuf.LazyStringList sourceIds_;
+
       /**
        *
        *
@@ -4586,6 +4746,7 @@ public final class Recon {
       public com.google.protobuf.ProtocolStringList getSourceIdsList() {
         return sourceIds_;
       }
+
       /**
        *
        *
@@ -4600,6 +4761,7 @@ public final class Recon {
       public int getSourceIdsCount() {
         return sourceIds_.size();
       }
+
       /**
        *
        *
@@ -4615,6 +4777,7 @@ public final class Recon {
       public java.lang.String getSourceIds(int index) {
         return sourceIds_.get(index);
       }
+
       /**
        *
        *
@@ -4633,6 +4796,7 @@ public final class Recon {
 
       public static final int PROBABILITY_FIELD_NUMBER = 2;
       private double probability_;
+
       /**
        * <code>double probability = 2;</code>
        *
@@ -4826,6 +4990,7 @@ public final class Recon {
         Builder builder = new Builder(parent);
         return builder;
       }
+
       /** Protobuf type {@code org.datacommons.proto.CompareEntitiesResponse.Comparison} */
       public static final class Builder
           extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -5015,6 +5180,7 @@ public final class Recon {
             bitField0_ |= 0x00000001;
           }
         }
+
         /**
          *
          *
@@ -5029,6 +5195,7 @@ public final class Recon {
         public com.google.protobuf.ProtocolStringList getSourceIdsList() {
           return sourceIds_.getUnmodifiableView();
         }
+
         /**
          *
          *
@@ -5043,6 +5210,7 @@ public final class Recon {
         public int getSourceIdsCount() {
           return sourceIds_.size();
         }
+
         /**
          *
          *
@@ -5058,6 +5226,7 @@ public final class Recon {
         public java.lang.String getSourceIds(int index) {
           return sourceIds_.get(index);
         }
+
         /**
          *
          *
@@ -5073,6 +5242,7 @@ public final class Recon {
         public com.google.protobuf.ByteString getSourceIdsBytes(int index) {
           return sourceIds_.getByteString(index);
         }
+
         /**
          *
          *
@@ -5095,6 +5265,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -5116,6 +5287,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -5134,6 +5306,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -5151,6 +5324,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          *
          *
@@ -5175,6 +5349,7 @@ public final class Recon {
         }
 
         private double probability_;
+
         /**
          * <code>double probability = 2;</code>
          *
@@ -5184,6 +5359,7 @@ public final class Recon {
         public double getProbability() {
           return probability_;
         }
+
         /**
          * <code>double probability = 2;</code>
          *
@@ -5196,6 +5372,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>double probability = 2;</code>
          *
@@ -5266,6 +5443,7 @@ public final class Recon {
     public static final int COMPARISONS_FIELD_NUMBER = 1;
     private java.util.List<org.datacommons.proto.Recon.CompareEntitiesResponse.Comparison>
         comparisons_;
+
     /**
      * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
      * </code>
@@ -5275,6 +5453,7 @@ public final class Recon {
         getComparisonsList() {
       return comparisons_;
     }
+
     /**
      * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
      * </code>
@@ -5285,6 +5464,7 @@ public final class Recon {
         getComparisonsOrBuilderList() {
       return comparisons_;
     }
+
     /**
      * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
      * </code>
@@ -5293,6 +5473,7 @@ public final class Recon {
     public int getComparisonsCount() {
       return comparisons_.size();
     }
+
     /**
      * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
      * </code>
@@ -5302,6 +5483,7 @@ public final class Recon {
         int index) {
       return comparisons_.get(index);
     }
+
     /**
      * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
      * </code>
@@ -5475,6 +5657,7 @@ public final class Recon {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /** Protobuf type {@code org.datacommons.proto.CompareEntitiesResponse} */
     public static final class Builder
         extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -5699,6 +5882,7 @@ public final class Recon {
           return comparisonsBuilder_.getMessageList();
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5710,6 +5894,7 @@ public final class Recon {
           return comparisonsBuilder_.getCount();
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5722,6 +5907,7 @@ public final class Recon {
           return comparisonsBuilder_.getMessage(index);
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5740,6 +5926,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5756,6 +5943,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5774,6 +5962,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5792,6 +5981,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5807,6 +5997,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5823,6 +6014,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5840,6 +6032,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5854,6 +6047,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5868,6 +6062,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5876,6 +6071,7 @@ public final class Recon {
           getComparisonsBuilder(int index) {
         return getComparisonsFieldBuilder().getBuilder(index);
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5888,6 +6084,7 @@ public final class Recon {
           return comparisonsBuilder_.getMessageOrBuilder(index);
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5901,6 +6098,7 @@ public final class Recon {
           return java.util.Collections.unmodifiableList(comparisons_);
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5912,6 +6110,7 @@ public final class Recon {
                 org.datacommons.proto.Recon.CompareEntitiesResponse.Comparison
                     .getDefaultInstance());
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -5924,6 +6123,7 @@ public final class Recon {
                 org.datacommons.proto.Recon.CompareEntitiesResponse.Comparison
                     .getDefaultInstance());
       }
+
       /**
        * <code>repeated .org.datacommons.proto.CompareEntitiesResponse.Comparison comparisons = 1;
        * </code>
@@ -6012,13 +6212,17 @@ public final class Recon {
 
     /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
     java.util.List<org.datacommons.proto.Recon.EntitySubGraph> getEntitiesList();
+
     /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
     org.datacommons.proto.Recon.EntitySubGraph getEntities(int index);
+
     /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
     int getEntitiesCount();
+
     /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
     java.util.List<? extends org.datacommons.proto.Recon.EntitySubGraphOrBuilder>
         getEntitiesOrBuilderList();
+
     /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
     org.datacommons.proto.Recon.EntitySubGraphOrBuilder getEntitiesOrBuilder(int index);
 
@@ -6034,6 +6238,7 @@ public final class Recon {
      * @return A list containing the wantedIdProperties.
      */
     java.util.List<java.lang.String> getWantedIdPropertiesList();
+
     /**
      *
      *
@@ -6046,6 +6251,7 @@ public final class Recon {
      * @return The count of wantedIdProperties.
      */
     int getWantedIdPropertiesCount();
+
     /**
      *
      *
@@ -6059,6 +6265,7 @@ public final class Recon {
      * @return The wantedIdProperties at the given index.
      */
     java.lang.String getWantedIdProperties(int index);
+
     /**
      *
      *
@@ -6073,12 +6280,14 @@ public final class Recon {
      */
     com.google.protobuf.ByteString getWantedIdPropertiesBytes(int index);
   }
+
   /** Protobuf type {@code org.datacommons.proto.ResolveEntitiesRequest} */
   public static final class ResolveEntitiesRequest extends com.google.protobuf.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.ResolveEntitiesRequest)
       ResolveEntitiesRequestOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use ResolveEntitiesRequest.newBuilder() to construct.
     private ResolveEntitiesRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -6182,27 +6391,32 @@ public final class Recon {
 
     public static final int ENTITIES_FIELD_NUMBER = 1;
     private java.util.List<org.datacommons.proto.Recon.EntitySubGraph> entities_;
+
     /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
     @java.lang.Override
     public java.util.List<org.datacommons.proto.Recon.EntitySubGraph> getEntitiesList() {
       return entities_;
     }
+
     /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
     @java.lang.Override
     public java.util.List<? extends org.datacommons.proto.Recon.EntitySubGraphOrBuilder>
         getEntitiesOrBuilderList() {
       return entities_;
     }
+
     /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
     @java.lang.Override
     public int getEntitiesCount() {
       return entities_.size();
     }
+
     /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
     @java.lang.Override
     public org.datacommons.proto.Recon.EntitySubGraph getEntities(int index) {
       return entities_.get(index);
     }
+
     /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
     @java.lang.Override
     public org.datacommons.proto.Recon.EntitySubGraphOrBuilder getEntitiesOrBuilder(int index) {
@@ -6211,6 +6425,7 @@ public final class Recon {
 
     public static final int WANTED_ID_PROPERTIES_FIELD_NUMBER = 2;
     private com.google.protobuf.LazyStringList wantedIdProperties_;
+
     /**
      *
      *
@@ -6225,6 +6440,7 @@ public final class Recon {
     public com.google.protobuf.ProtocolStringList getWantedIdPropertiesList() {
       return wantedIdProperties_;
     }
+
     /**
      *
      *
@@ -6239,6 +6455,7 @@ public final class Recon {
     public int getWantedIdPropertiesCount() {
       return wantedIdProperties_.size();
     }
+
     /**
      *
      *
@@ -6254,6 +6471,7 @@ public final class Recon {
     public java.lang.String getWantedIdProperties(int index) {
       return wantedIdProperties_.get(index);
     }
+
     /**
      *
      *
@@ -6449,6 +6667,7 @@ public final class Recon {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /** Protobuf type {@code org.datacommons.proto.ResolveEntitiesRequest} */
     public static final class Builder
         extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -6685,6 +6904,7 @@ public final class Recon {
           return entitiesBuilder_.getMessageList();
         }
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public int getEntitiesCount() {
         if (entitiesBuilder_ == null) {
@@ -6693,6 +6913,7 @@ public final class Recon {
           return entitiesBuilder_.getCount();
         }
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public org.datacommons.proto.Recon.EntitySubGraph getEntities(int index) {
         if (entitiesBuilder_ == null) {
@@ -6701,6 +6922,7 @@ public final class Recon {
           return entitiesBuilder_.getMessage(index);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public Builder setEntities(int index, org.datacommons.proto.Recon.EntitySubGraph value) {
         if (entitiesBuilder_ == null) {
@@ -6715,6 +6937,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public Builder setEntities(
           int index, org.datacommons.proto.Recon.EntitySubGraph.Builder builderForValue) {
@@ -6727,6 +6950,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public Builder addEntities(org.datacommons.proto.Recon.EntitySubGraph value) {
         if (entitiesBuilder_ == null) {
@@ -6741,6 +6965,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public Builder addEntities(int index, org.datacommons.proto.Recon.EntitySubGraph value) {
         if (entitiesBuilder_ == null) {
@@ -6755,6 +6980,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public Builder addEntities(
           org.datacommons.proto.Recon.EntitySubGraph.Builder builderForValue) {
@@ -6767,6 +6993,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public Builder addEntities(
           int index, org.datacommons.proto.Recon.EntitySubGraph.Builder builderForValue) {
@@ -6779,6 +7006,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public Builder addAllEntities(
           java.lang.Iterable<? extends org.datacommons.proto.Recon.EntitySubGraph> values) {
@@ -6791,6 +7019,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public Builder clearEntities() {
         if (entitiesBuilder_ == null) {
@@ -6802,6 +7031,7 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public Builder removeEntities(int index) {
         if (entitiesBuilder_ == null) {
@@ -6813,10 +7043,12 @@ public final class Recon {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public org.datacommons.proto.Recon.EntitySubGraph.Builder getEntitiesBuilder(int index) {
         return getEntitiesFieldBuilder().getBuilder(index);
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public org.datacommons.proto.Recon.EntitySubGraphOrBuilder getEntitiesOrBuilder(int index) {
         if (entitiesBuilder_ == null) {
@@ -6825,6 +7057,7 @@ public final class Recon {
           return entitiesBuilder_.getMessageOrBuilder(index);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public java.util.List<? extends org.datacommons.proto.Recon.EntitySubGraphOrBuilder>
           getEntitiesOrBuilderList() {
@@ -6834,16 +7067,19 @@ public final class Recon {
           return java.util.Collections.unmodifiableList(entities_);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public org.datacommons.proto.Recon.EntitySubGraph.Builder addEntitiesBuilder() {
         return getEntitiesFieldBuilder()
             .addBuilder(org.datacommons.proto.Recon.EntitySubGraph.getDefaultInstance());
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public org.datacommons.proto.Recon.EntitySubGraph.Builder addEntitiesBuilder(int index) {
         return getEntitiesFieldBuilder()
             .addBuilder(index, org.datacommons.proto.Recon.EntitySubGraph.getDefaultInstance());
       }
+
       /** <code>repeated .org.datacommons.proto.EntitySubGraph entities = 1;</code> */
       public java.util.List<org.datacommons.proto.Recon.EntitySubGraph.Builder>
           getEntitiesBuilderList() {
@@ -6876,6 +7112,7 @@ public final class Recon {
           bitField0_ |= 0x00000002;
         }
       }
+
       /**
        *
        *
@@ -6890,6 +7127,7 @@ public final class Recon {
       public com.google.protobuf.ProtocolStringList getWantedIdPropertiesList() {
         return wantedIdProperties_.getUnmodifiableView();
       }
+
       /**
        *
        *
@@ -6904,6 +7142,7 @@ public final class Recon {
       public int getWantedIdPropertiesCount() {
         return wantedIdProperties_.size();
       }
+
       /**
        *
        *
@@ -6919,6 +7158,7 @@ public final class Recon {
       public java.lang.String getWantedIdProperties(int index) {
         return wantedIdProperties_.get(index);
       }
+
       /**
        *
        *
@@ -6934,6 +7174,7 @@ public final class Recon {
       public com.google.protobuf.ByteString getWantedIdPropertiesBytes(int index) {
         return wantedIdProperties_.getByteString(index);
       }
+
       /**
        *
        *
@@ -6956,6 +7197,7 @@ public final class Recon {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -6977,6 +7219,7 @@ public final class Recon {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -6995,6 +7238,7 @@ public final class Recon {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -7012,6 +7256,7 @@ public final class Recon {
         onChanged();
         return this;
       }
+
       /**
        *
        *
@@ -7099,6 +7344,7 @@ public final class Recon {
      */
     java.util.List<org.datacommons.proto.Recon.ResolveEntitiesResponse.ResolvedEntity>
         getResolvedEntitiesList();
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -7106,12 +7352,14 @@ public final class Recon {
      */
     org.datacommons.proto.Recon.ResolveEntitiesResponse.ResolvedEntity getResolvedEntities(
         int index);
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
      * </code>
      */
     int getResolvedEntitiesCount();
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -7120,6 +7368,7 @@ public final class Recon {
     java.util.List<
             ? extends org.datacommons.proto.Recon.ResolveEntitiesResponse.ResolvedEntityOrBuilder>
         getResolvedEntitiesOrBuilderList();
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -7128,12 +7377,14 @@ public final class Recon {
     org.datacommons.proto.Recon.ResolveEntitiesResponse.ResolvedEntityOrBuilder
         getResolvedEntitiesOrBuilder(int index);
   }
+
   /** Protobuf type {@code org.datacommons.proto.ResolveEntitiesResponse} */
   public static final class ResolveEntitiesResponse extends com.google.protobuf.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.ResolveEntitiesResponse)
       ResolveEntitiesResponseOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use ResolveEntitiesResponse.newBuilder() to construct.
     private ResolveEntitiesResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -7231,13 +7482,17 @@ public final class Recon {
 
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       java.util.List<org.datacommons.proto.Recon.IdWithProperty> getIdsList();
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       org.datacommons.proto.Recon.IdWithProperty getIds(int index);
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       int getIdsCount();
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       java.util.List<? extends org.datacommons.proto.Recon.IdWithPropertyOrBuilder>
           getIdsOrBuilderList();
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       org.datacommons.proto.Recon.IdWithPropertyOrBuilder getIdsOrBuilder(int index);
 
@@ -7248,12 +7503,14 @@ public final class Recon {
        */
       double getProbability();
     }
+
     /** Protobuf type {@code org.datacommons.proto.ResolveEntitiesResponse.ResolvedId} */
     public static final class ResolvedId extends com.google.protobuf.GeneratedMessageV3
         implements
         // @@protoc_insertion_point(message_implements:org.datacommons.proto.ResolveEntitiesResponse.ResolvedId)
         ResolvedIdOrBuilder {
       private static final long serialVersionUID = 0L;
+
       // Use ResolvedId.newBuilder() to construct.
       private ResolvedId(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
@@ -7349,27 +7606,32 @@ public final class Recon {
 
       public static final int IDS_FIELD_NUMBER = 1;
       private java.util.List<org.datacommons.proto.Recon.IdWithProperty> ids_;
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       @java.lang.Override
       public java.util.List<org.datacommons.proto.Recon.IdWithProperty> getIdsList() {
         return ids_;
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       @java.lang.Override
       public java.util.List<? extends org.datacommons.proto.Recon.IdWithPropertyOrBuilder>
           getIdsOrBuilderList() {
         return ids_;
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       @java.lang.Override
       public int getIdsCount() {
         return ids_.size();
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       @java.lang.Override
       public org.datacommons.proto.Recon.IdWithProperty getIds(int index) {
         return ids_.get(index);
       }
+
       /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
       @java.lang.Override
       public org.datacommons.proto.Recon.IdWithPropertyOrBuilder getIdsOrBuilder(int index) {
@@ -7378,6 +7640,7 @@ public final class Recon {
 
       public static final int PROBABILITY_FIELD_NUMBER = 2;
       private double probability_;
+
       /**
        * <code>double probability = 2;</code>
        *
@@ -7566,6 +7829,7 @@ public final class Recon {
         Builder builder = new Builder(parent);
         return builder;
       }
+
       /** Protobuf type {@code org.datacommons.proto.ResolveEntitiesResponse.ResolvedId} */
       public static final class Builder
           extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -7797,6 +8061,7 @@ public final class Recon {
             return idsBuilder_.getMessageList();
           }
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public int getIdsCount() {
           if (idsBuilder_ == null) {
@@ -7805,6 +8070,7 @@ public final class Recon {
             return idsBuilder_.getCount();
           }
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public org.datacommons.proto.Recon.IdWithProperty getIds(int index) {
           if (idsBuilder_ == null) {
@@ -7813,6 +8079,7 @@ public final class Recon {
             return idsBuilder_.getMessage(index);
           }
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public Builder setIds(int index, org.datacommons.proto.Recon.IdWithProperty value) {
           if (idsBuilder_ == null) {
@@ -7827,6 +8094,7 @@ public final class Recon {
           }
           return this;
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public Builder setIds(
             int index, org.datacommons.proto.Recon.IdWithProperty.Builder builderForValue) {
@@ -7839,6 +8107,7 @@ public final class Recon {
           }
           return this;
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public Builder addIds(org.datacommons.proto.Recon.IdWithProperty value) {
           if (idsBuilder_ == null) {
@@ -7853,6 +8122,7 @@ public final class Recon {
           }
           return this;
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public Builder addIds(int index, org.datacommons.proto.Recon.IdWithProperty value) {
           if (idsBuilder_ == null) {
@@ -7867,6 +8137,7 @@ public final class Recon {
           }
           return this;
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public Builder addIds(org.datacommons.proto.Recon.IdWithProperty.Builder builderForValue) {
           if (idsBuilder_ == null) {
@@ -7878,6 +8149,7 @@ public final class Recon {
           }
           return this;
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public Builder addIds(
             int index, org.datacommons.proto.Recon.IdWithProperty.Builder builderForValue) {
@@ -7890,6 +8162,7 @@ public final class Recon {
           }
           return this;
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public Builder addAllIds(
             java.lang.Iterable<? extends org.datacommons.proto.Recon.IdWithProperty> values) {
@@ -7902,6 +8175,7 @@ public final class Recon {
           }
           return this;
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public Builder clearIds() {
           if (idsBuilder_ == null) {
@@ -7913,6 +8187,7 @@ public final class Recon {
           }
           return this;
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public Builder removeIds(int index) {
           if (idsBuilder_ == null) {
@@ -7924,10 +8199,12 @@ public final class Recon {
           }
           return this;
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public org.datacommons.proto.Recon.IdWithProperty.Builder getIdsBuilder(int index) {
           return getIdsFieldBuilder().getBuilder(index);
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public org.datacommons.proto.Recon.IdWithPropertyOrBuilder getIdsOrBuilder(int index) {
           if (idsBuilder_ == null) {
@@ -7936,6 +8213,7 @@ public final class Recon {
             return idsBuilder_.getMessageOrBuilder(index);
           }
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public java.util.List<? extends org.datacommons.proto.Recon.IdWithPropertyOrBuilder>
             getIdsOrBuilderList() {
@@ -7945,16 +8223,19 @@ public final class Recon {
             return java.util.Collections.unmodifiableList(ids_);
           }
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public org.datacommons.proto.Recon.IdWithProperty.Builder addIdsBuilder() {
           return getIdsFieldBuilder()
               .addBuilder(org.datacommons.proto.Recon.IdWithProperty.getDefaultInstance());
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public org.datacommons.proto.Recon.IdWithProperty.Builder addIdsBuilder(int index) {
           return getIdsFieldBuilder()
               .addBuilder(index, org.datacommons.proto.Recon.IdWithProperty.getDefaultInstance());
         }
+
         /** <code>repeated .org.datacommons.proto.IdWithProperty ids = 1;</code> */
         public java.util.List<org.datacommons.proto.Recon.IdWithProperty.Builder>
             getIdsBuilderList() {
@@ -7979,6 +8260,7 @@ public final class Recon {
         }
 
         private double probability_;
+
         /**
          * <code>double probability = 2;</code>
          *
@@ -7988,6 +8270,7 @@ public final class Recon {
         public double getProbability() {
           return probability_;
         }
+
         /**
          * <code>double probability = 2;</code>
          *
@@ -8000,6 +8283,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>double probability = 2;</code>
          *
@@ -8078,6 +8362,7 @@ public final class Recon {
        * @return The sourceId.
        */
       java.lang.String getSourceId();
+
       /**
        * <code>string source_id = 1;</code>
        *
@@ -8091,16 +8376,19 @@ public final class Recon {
        */
       java.util.List<org.datacommons.proto.Recon.ResolveEntitiesResponse.ResolvedId>
           getResolvedIdsList();
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
        * </code>
        */
       org.datacommons.proto.Recon.ResolveEntitiesResponse.ResolvedId getResolvedIds(int index);
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
        * </code>
        */
       int getResolvedIdsCount();
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
        * </code>
@@ -8108,6 +8396,7 @@ public final class Recon {
       java.util.List<
               ? extends org.datacommons.proto.Recon.ResolveEntitiesResponse.ResolvedIdOrBuilder>
           getResolvedIdsOrBuilderList();
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
        * </code>
@@ -8115,12 +8404,14 @@ public final class Recon {
       org.datacommons.proto.Recon.ResolveEntitiesResponse.ResolvedIdOrBuilder
           getResolvedIdsOrBuilder(int index);
     }
+
     /** Protobuf type {@code org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity} */
     public static final class ResolvedEntity extends com.google.protobuf.GeneratedMessageV3
         implements
         // @@protoc_insertion_point(message_implements:org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity)
         ResolvedEntityOrBuilder {
       private static final long serialVersionUID = 0L;
+
       // Use ResolvedEntity.newBuilder() to construct.
       private ResolvedEntity(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
@@ -8222,6 +8513,7 @@ public final class Recon {
 
       public static final int SOURCE_ID_FIELD_NUMBER = 1;
       private volatile java.lang.Object sourceId_;
+
       /**
        * <code>string source_id = 1;</code>
        *
@@ -8239,6 +8531,7 @@ public final class Recon {
           return s;
         }
       }
+
       /**
        * <code>string source_id = 1;</code>
        *
@@ -8260,6 +8553,7 @@ public final class Recon {
       public static final int RESOLVED_IDS_FIELD_NUMBER = 2;
       private java.util.List<org.datacommons.proto.Recon.ResolveEntitiesResponse.ResolvedId>
           resolvedIds_;
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
        * </code>
@@ -8269,6 +8563,7 @@ public final class Recon {
           getResolvedIdsList() {
         return resolvedIds_;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
        * </code>
@@ -8279,6 +8574,7 @@ public final class Recon {
           getResolvedIdsOrBuilderList() {
         return resolvedIds_;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
        * </code>
@@ -8287,6 +8583,7 @@ public final class Recon {
       public int getResolvedIdsCount() {
         return resolvedIds_.size();
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
        * </code>
@@ -8296,6 +8593,7 @@ public final class Recon {
           int index) {
         return resolvedIds_.get(index);
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
        * </code>
@@ -8480,6 +8778,7 @@ public final class Recon {
         Builder builder = new Builder(parent);
         return builder;
       }
+
       /** Protobuf type {@code org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity} */
       public static final class Builder
           extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -8690,6 +8989,7 @@ public final class Recon {
         private int bitField0_;
 
         private java.lang.Object sourceId_ = "";
+
         /**
          * <code>string source_id = 1;</code>
          *
@@ -8706,6 +9006,7 @@ public final class Recon {
             return (java.lang.String) ref;
           }
         }
+
         /**
          * <code>string source_id = 1;</code>
          *
@@ -8722,6 +9023,7 @@ public final class Recon {
             return (com.google.protobuf.ByteString) ref;
           }
         }
+
         /**
          * <code>string source_id = 1;</code>
          *
@@ -8737,6 +9039,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>string source_id = 1;</code>
          *
@@ -8748,6 +9051,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>string source_id = 1;</code>
          *
@@ -8796,6 +9100,7 @@ public final class Recon {
             return resolvedIdsBuilder_.getMessageList();
           }
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -8808,6 +9113,7 @@ public final class Recon {
             return resolvedIdsBuilder_.getCount();
           }
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -8821,6 +9127,7 @@ public final class Recon {
             return resolvedIdsBuilder_.getMessage(index);
           }
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -8840,6 +9147,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -8858,6 +9166,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -8877,6 +9186,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -8896,6 +9206,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -8913,6 +9224,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -8931,6 +9243,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -8949,6 +9262,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -8964,6 +9278,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -8979,6 +9294,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -8988,6 +9304,7 @@ public final class Recon {
             getResolvedIdsBuilder(int index) {
           return getResolvedIdsFieldBuilder().getBuilder(index);
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -9001,6 +9318,7 @@ public final class Recon {
             return resolvedIdsBuilder_.getMessageOrBuilder(index);
           }
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -9015,6 +9333,7 @@ public final class Recon {
             return java.util.Collections.unmodifiableList(resolvedIds_);
           }
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -9027,6 +9346,7 @@ public final class Recon {
                   org.datacommons.proto.Recon.ResolveEntitiesResponse.ResolvedId
                       .getDefaultInstance());
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -9040,6 +9360,7 @@ public final class Recon {
                   org.datacommons.proto.Recon.ResolveEntitiesResponse.ResolvedId
                       .getDefaultInstance());
         }
+
         /**
          * <code>
          * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedId resolved_ids = 2;
@@ -9129,6 +9450,7 @@ public final class Recon {
     public static final int RESOLVED_ENTITIES_FIELD_NUMBER = 1;
     private java.util.List<org.datacommons.proto.Recon.ResolveEntitiesResponse.ResolvedEntity>
         resolvedEntities_;
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9139,6 +9461,7 @@ public final class Recon {
         getResolvedEntitiesList() {
       return resolvedEntities_;
     }
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9150,6 +9473,7 @@ public final class Recon {
         getResolvedEntitiesOrBuilderList() {
       return resolvedEntities_;
     }
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9159,6 +9483,7 @@ public final class Recon {
     public int getResolvedEntitiesCount() {
       return resolvedEntities_.size();
     }
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9169,6 +9494,7 @@ public final class Recon {
         int index) {
       return resolvedEntities_.get(index);
     }
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9344,6 +9670,7 @@ public final class Recon {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /** Protobuf type {@code org.datacommons.proto.ResolveEntitiesResponse} */
     public static final class Builder
         extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -9570,6 +9897,7 @@ public final class Recon {
           return resolvedEntitiesBuilder_.getMessageList();
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9582,6 +9910,7 @@ public final class Recon {
           return resolvedEntitiesBuilder_.getCount();
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9595,6 +9924,7 @@ public final class Recon {
           return resolvedEntitiesBuilder_.getMessage(index);
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9614,6 +9944,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9632,6 +9963,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9651,6 +9983,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9670,6 +10003,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9687,6 +10021,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9705,6 +10040,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9723,6 +10059,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9738,6 +10075,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9753,6 +10091,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9762,6 +10101,7 @@ public final class Recon {
           getResolvedEntitiesBuilder(int index) {
         return getResolvedEntitiesFieldBuilder().getBuilder(index);
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9775,6 +10115,7 @@ public final class Recon {
           return resolvedEntitiesBuilder_.getMessageOrBuilder(index);
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9789,6 +10130,7 @@ public final class Recon {
           return java.util.Collections.unmodifiableList(resolvedEntities_);
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9801,6 +10143,7 @@ public final class Recon {
                 org.datacommons.proto.Recon.ResolveEntitiesResponse.ResolvedEntity
                     .getDefaultInstance());
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9814,6 +10157,7 @@ public final class Recon {
                 org.datacommons.proto.Recon.ResolveEntitiesResponse.ResolvedEntity
                     .getDefaultInstance());
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveEntitiesResponse.ResolvedEntity resolved_entities = 1;
@@ -9908,16 +10252,19 @@ public final class Recon {
      */
     java.util.List<org.datacommons.proto.Recon.ResolveCoordinatesRequest.Coordinate>
         getCoordinatesList();
+
     /**
      * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
      * </code>
      */
     org.datacommons.proto.Recon.ResolveCoordinatesRequest.Coordinate getCoordinates(int index);
+
     /**
      * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
      * </code>
      */
     int getCoordinatesCount();
+
     /**
      * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
      * </code>
@@ -9925,6 +10272,7 @@ public final class Recon {
     java.util.List<
             ? extends org.datacommons.proto.Recon.ResolveCoordinatesRequest.CoordinateOrBuilder>
         getCoordinatesOrBuilderList();
+
     /**
      * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
      * </code>
@@ -9932,12 +10280,14 @@ public final class Recon {
     org.datacommons.proto.Recon.ResolveCoordinatesRequest.CoordinateOrBuilder
         getCoordinatesOrBuilder(int index);
   }
+
   /** Protobuf type {@code org.datacommons.proto.ResolveCoordinatesRequest} */
   public static final class ResolveCoordinatesRequest extends com.google.protobuf.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.ResolveCoordinatesRequest)
       ResolveCoordinatesRequestOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use ResolveCoordinatesRequest.newBuilder() to construct.
     private ResolveCoordinatesRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -10047,12 +10397,14 @@ public final class Recon {
        */
       double getLongitude();
     }
+
     /** Protobuf type {@code org.datacommons.proto.ResolveCoordinatesRequest.Coordinate} */
     public static final class Coordinate extends com.google.protobuf.GeneratedMessageV3
         implements
         // @@protoc_insertion_point(message_implements:org.datacommons.proto.ResolveCoordinatesRequest.Coordinate)
         CoordinateOrBuilder {
       private static final long serialVersionUID = 0L;
+
       // Use Coordinate.newBuilder() to construct.
       private Coordinate(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
@@ -10136,6 +10488,7 @@ public final class Recon {
 
       public static final int LATITUDE_FIELD_NUMBER = 1;
       private double latitude_;
+
       /**
        * <code>double latitude = 1;</code>
        *
@@ -10148,6 +10501,7 @@ public final class Recon {
 
       public static final int LONGITUDE_FIELD_NUMBER = 2;
       private double longitude_;
+
       /**
        * <code>double longitude = 2;</code>
        *
@@ -10338,6 +10692,7 @@ public final class Recon {
         Builder builder = new Builder(parent);
         return builder;
       }
+
       /** Protobuf type {@code org.datacommons.proto.ResolveCoordinatesRequest.Coordinate} */
       public static final class Builder
           extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -10505,6 +10860,7 @@ public final class Recon {
         }
 
         private double latitude_;
+
         /**
          * <code>double latitude = 1;</code>
          *
@@ -10514,6 +10870,7 @@ public final class Recon {
         public double getLatitude() {
           return latitude_;
         }
+
         /**
          * <code>double latitude = 1;</code>
          *
@@ -10526,6 +10883,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>double latitude = 1;</code>
          *
@@ -10539,6 +10897,7 @@ public final class Recon {
         }
 
         private double longitude_;
+
         /**
          * <code>double longitude = 2;</code>
          *
@@ -10548,6 +10907,7 @@ public final class Recon {
         public double getLongitude() {
           return longitude_;
         }
+
         /**
          * <code>double longitude = 2;</code>
          *
@@ -10560,6 +10920,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>double longitude = 2;</code>
          *
@@ -10630,6 +10991,7 @@ public final class Recon {
     public static final int COORDINATES_FIELD_NUMBER = 1;
     private java.util.List<org.datacommons.proto.Recon.ResolveCoordinatesRequest.Coordinate>
         coordinates_;
+
     /**
      * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
      * </code>
@@ -10639,6 +11001,7 @@ public final class Recon {
         getCoordinatesList() {
       return coordinates_;
     }
+
     /**
      * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
      * </code>
@@ -10649,6 +11012,7 @@ public final class Recon {
         getCoordinatesOrBuilderList() {
       return coordinates_;
     }
+
     /**
      * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
      * </code>
@@ -10657,6 +11021,7 @@ public final class Recon {
     public int getCoordinatesCount() {
       return coordinates_.size();
     }
+
     /**
      * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
      * </code>
@@ -10666,6 +11031,7 @@ public final class Recon {
         int index) {
       return coordinates_.get(index);
     }
+
     /**
      * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
      * </code>
@@ -10839,6 +11205,7 @@ public final class Recon {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /** Protobuf type {@code org.datacommons.proto.ResolveCoordinatesRequest} */
     public static final class Builder
         extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -11063,6 +11430,7 @@ public final class Recon {
           return coordinatesBuilder_.getMessageList();
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11074,6 +11442,7 @@ public final class Recon {
           return coordinatesBuilder_.getCount();
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11086,6 +11455,7 @@ public final class Recon {
           return coordinatesBuilder_.getMessage(index);
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11104,6 +11474,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11121,6 +11492,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11139,6 +11511,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11157,6 +11530,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11173,6 +11547,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11190,6 +11565,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11207,6 +11583,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11221,6 +11598,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11235,6 +11613,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11243,6 +11622,7 @@ public final class Recon {
           getCoordinatesBuilder(int index) {
         return getCoordinatesFieldBuilder().getBuilder(index);
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11255,6 +11635,7 @@ public final class Recon {
           return coordinatesBuilder_.getMessageOrBuilder(index);
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11268,6 +11649,7 @@ public final class Recon {
           return java.util.Collections.unmodifiableList(coordinates_);
         }
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11279,6 +11661,7 @@ public final class Recon {
                 org.datacommons.proto.Recon.ResolveCoordinatesRequest.Coordinate
                     .getDefaultInstance());
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11291,6 +11674,7 @@ public final class Recon {
                 org.datacommons.proto.Recon.ResolveCoordinatesRequest.Coordinate
                     .getDefaultInstance());
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesRequest.Coordinate coordinates = 1;
        * </code>
@@ -11385,6 +11769,7 @@ public final class Recon {
      */
     java.util.List<org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceCoordinate>
         getPlaceCoordinatesList();
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -11392,12 +11777,14 @@ public final class Recon {
      */
     org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceCoordinate getPlaceCoordinates(
         int index);
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
      * </code>
      */
     int getPlaceCoordinatesCount();
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -11407,6 +11794,7 @@ public final class Recon {
             ? extends
                 org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceCoordinateOrBuilder>
         getPlaceCoordinatesOrBuilderList();
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -11415,6 +11803,7 @@ public final class Recon {
     org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceCoordinateOrBuilder
         getPlaceCoordinatesOrBuilder(int index);
   }
+
   /** Protobuf type {@code org.datacommons.proto.ResolveCoordinatesResponse} */
   public static final class ResolveCoordinatesResponse
       extends com.google.protobuf.GeneratedMessageV3
@@ -11422,6 +11811,7 @@ public final class Recon {
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.ResolveCoordinatesResponse)
       ResolveCoordinatesResponseOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use ResolveCoordinatesResponse.newBuilder() to construct.
     private ResolveCoordinatesResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -11524,6 +11914,7 @@ public final class Recon {
        * @return The dcid.
        */
       java.lang.String getDcid();
+
       /**
        * <code>string dcid = 1;</code>
        *
@@ -11537,6 +11928,7 @@ public final class Recon {
        * @return The dominantType.
        */
       java.lang.String getDominantType();
+
       /**
        * <code>string dominant_type = 2;</code>
        *
@@ -11544,12 +11936,14 @@ public final class Recon {
        */
       com.google.protobuf.ByteString getDominantTypeBytes();
     }
+
     /** Protobuf type {@code org.datacommons.proto.ResolveCoordinatesResponse.Place} */
     public static final class Place extends com.google.protobuf.GeneratedMessageV3
         implements
         // @@protoc_insertion_point(message_implements:org.datacommons.proto.ResolveCoordinatesResponse.Place)
         PlaceOrBuilder {
       private static final long serialVersionUID = 0L;
+
       // Use Place.newBuilder() to construct.
       private Place(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
@@ -11640,6 +12034,7 @@ public final class Recon {
 
       public static final int DCID_FIELD_NUMBER = 1;
       private volatile java.lang.Object dcid_;
+
       /**
        * <code>string dcid = 1;</code>
        *
@@ -11657,6 +12052,7 @@ public final class Recon {
           return s;
         }
       }
+
       /**
        * <code>string dcid = 1;</code>
        *
@@ -11677,6 +12073,7 @@ public final class Recon {
 
       public static final int DOMINANT_TYPE_FIELD_NUMBER = 2;
       private volatile java.lang.Object dominantType_;
+
       /**
        * <code>string dominant_type = 2;</code>
        *
@@ -11694,6 +12091,7 @@ public final class Recon {
           return s;
         }
       }
+
       /**
        * <code>string dominant_type = 2;</code>
        *
@@ -11882,6 +12280,7 @@ public final class Recon {
         Builder builder = new Builder(parent);
         return builder;
       }
+
       /** Protobuf type {@code org.datacommons.proto.ResolveCoordinatesResponse.Place} */
       public static final class Builder
           extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -12048,6 +12447,7 @@ public final class Recon {
         }
 
         private java.lang.Object dcid_ = "";
+
         /**
          * <code>string dcid = 1;</code>
          *
@@ -12064,6 +12464,7 @@ public final class Recon {
             return (java.lang.String) ref;
           }
         }
+
         /**
          * <code>string dcid = 1;</code>
          *
@@ -12080,6 +12481,7 @@ public final class Recon {
             return (com.google.protobuf.ByteString) ref;
           }
         }
+
         /**
          * <code>string dcid = 1;</code>
          *
@@ -12095,6 +12497,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>string dcid = 1;</code>
          *
@@ -12106,6 +12509,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>string dcid = 1;</code>
          *
@@ -12124,6 +12528,7 @@ public final class Recon {
         }
 
         private java.lang.Object dominantType_ = "";
+
         /**
          * <code>string dominant_type = 2;</code>
          *
@@ -12140,6 +12545,7 @@ public final class Recon {
             return (java.lang.String) ref;
           }
         }
+
         /**
          * <code>string dominant_type = 2;</code>
          *
@@ -12156,6 +12562,7 @@ public final class Recon {
             return (com.google.protobuf.ByteString) ref;
           }
         }
+
         /**
          * <code>string dominant_type = 2;</code>
          *
@@ -12171,6 +12578,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>string dominant_type = 2;</code>
          *
@@ -12182,6 +12590,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>string dominant_type = 2;</code>
          *
@@ -12279,12 +12688,14 @@ public final class Recon {
        * @return A list containing the placeDcids.
        */
       java.util.List<java.lang.String> getPlaceDcidsList();
+
       /**
        * <code>repeated string place_dcids = 3;</code>
        *
        * @return The count of placeDcids.
        */
       int getPlaceDcidsCount();
+
       /**
        * <code>repeated string place_dcids = 3;</code>
        *
@@ -12292,6 +12703,7 @@ public final class Recon {
        * @return The placeDcids at the given index.
        */
       java.lang.String getPlaceDcids(int index);
+
       /**
        * <code>repeated string place_dcids = 3;</code>
        *
@@ -12304,32 +12716,38 @@ public final class Recon {
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
        */
       java.util.List<org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place> getPlacesList();
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
        */
       org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place getPlaces(int index);
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
        */
       int getPlacesCount();
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
        */
       java.util.List<
               ? extends org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceOrBuilder>
           getPlacesOrBuilderList();
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
        */
       org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceOrBuilder getPlacesOrBuilder(
           int index);
     }
+
     /** Protobuf type {@code org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate} */
     public static final class PlaceCoordinate extends com.google.protobuf.GeneratedMessageV3
         implements
         // @@protoc_insertion_point(message_implements:org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate)
         PlaceCoordinateOrBuilder {
       private static final long serialVersionUID = 0L;
+
       // Use PlaceCoordinate.newBuilder() to construct.
       private PlaceCoordinate(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
@@ -12448,6 +12866,7 @@ public final class Recon {
 
       public static final int LATITUDE_FIELD_NUMBER = 1;
       private double latitude_;
+
       /**
        * <code>double latitude = 1;</code>
        *
@@ -12460,6 +12879,7 @@ public final class Recon {
 
       public static final int LONGITUDE_FIELD_NUMBER = 2;
       private double longitude_;
+
       /**
        * <code>double longitude = 2;</code>
        *
@@ -12472,6 +12892,7 @@ public final class Recon {
 
       public static final int PLACE_DCIDS_FIELD_NUMBER = 3;
       private com.google.protobuf.LazyStringList placeDcids_;
+
       /**
        * <code>repeated string place_dcids = 3;</code>
        *
@@ -12480,6 +12901,7 @@ public final class Recon {
       public com.google.protobuf.ProtocolStringList getPlaceDcidsList() {
         return placeDcids_;
       }
+
       /**
        * <code>repeated string place_dcids = 3;</code>
        *
@@ -12488,6 +12910,7 @@ public final class Recon {
       public int getPlaceDcidsCount() {
         return placeDcids_.size();
       }
+
       /**
        * <code>repeated string place_dcids = 3;</code>
        *
@@ -12497,6 +12920,7 @@ public final class Recon {
       public java.lang.String getPlaceDcids(int index) {
         return placeDcids_.get(index);
       }
+
       /**
        * <code>repeated string place_dcids = 3;</code>
        *
@@ -12509,6 +12933,7 @@ public final class Recon {
 
       public static final int PLACES_FIELD_NUMBER = 4;
       private java.util.List<org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place> places_;
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
        */
@@ -12517,6 +12942,7 @@ public final class Recon {
           getPlacesList() {
         return places_;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
        */
@@ -12526,6 +12952,7 @@ public final class Recon {
           getPlacesOrBuilderList() {
         return places_;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
        */
@@ -12533,6 +12960,7 @@ public final class Recon {
       public int getPlacesCount() {
         return places_.size();
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
        */
@@ -12540,6 +12968,7 @@ public final class Recon {
       public org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place getPlaces(int index) {
         return places_.get(index);
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
        */
@@ -12763,6 +13192,7 @@ public final class Recon {
         Builder builder = new Builder(parent);
         return builder;
       }
+
       /** Protobuf type {@code org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate} */
       public static final class Builder
           extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -12999,6 +13429,7 @@ public final class Recon {
         private int bitField0_;
 
         private double latitude_;
+
         /**
          * <code>double latitude = 1;</code>
          *
@@ -13008,6 +13439,7 @@ public final class Recon {
         public double getLatitude() {
           return latitude_;
         }
+
         /**
          * <code>double latitude = 1;</code>
          *
@@ -13020,6 +13452,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>double latitude = 1;</code>
          *
@@ -13033,6 +13466,7 @@ public final class Recon {
         }
 
         private double longitude_;
+
         /**
          * <code>double longitude = 2;</code>
          *
@@ -13042,6 +13476,7 @@ public final class Recon {
         public double getLongitude() {
           return longitude_;
         }
+
         /**
          * <code>double longitude = 2;</code>
          *
@@ -13054,6 +13489,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>double longitude = 2;</code>
          *
@@ -13075,6 +13511,7 @@ public final class Recon {
             bitField0_ |= 0x00000001;
           }
         }
+
         /**
          * <code>repeated string place_dcids = 3;</code>
          *
@@ -13083,6 +13520,7 @@ public final class Recon {
         public com.google.protobuf.ProtocolStringList getPlaceDcidsList() {
           return placeDcids_.getUnmodifiableView();
         }
+
         /**
          * <code>repeated string place_dcids = 3;</code>
          *
@@ -13091,6 +13529,7 @@ public final class Recon {
         public int getPlaceDcidsCount() {
           return placeDcids_.size();
         }
+
         /**
          * <code>repeated string place_dcids = 3;</code>
          *
@@ -13100,6 +13539,7 @@ public final class Recon {
         public java.lang.String getPlaceDcids(int index) {
           return placeDcids_.get(index);
         }
+
         /**
          * <code>repeated string place_dcids = 3;</code>
          *
@@ -13109,6 +13549,7 @@ public final class Recon {
         public com.google.protobuf.ByteString getPlaceDcidsBytes(int index) {
           return placeDcids_.getByteString(index);
         }
+
         /**
          * <code>repeated string place_dcids = 3;</code>
          *
@@ -13125,6 +13566,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>repeated string place_dcids = 3;</code>
          *
@@ -13140,6 +13582,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>repeated string place_dcids = 3;</code>
          *
@@ -13152,6 +13595,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>repeated string place_dcids = 3;</code>
          *
@@ -13163,6 +13607,7 @@ public final class Recon {
           onChanged();
           return this;
         }
+
         /**
          * <code>repeated string place_dcids = 3;</code>
          *
@@ -13209,6 +13654,7 @@ public final class Recon {
             return placesBuilder_.getMessageList();
           }
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13219,6 +13665,7 @@ public final class Recon {
             return placesBuilder_.getCount();
           }
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13229,6 +13676,7 @@ public final class Recon {
             return placesBuilder_.getMessage(index);
           }
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13246,6 +13694,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13261,6 +13710,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13278,6 +13728,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13295,6 +13746,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13309,6 +13761,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13324,6 +13777,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13340,6 +13794,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13353,6 +13808,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13366,6 +13822,7 @@ public final class Recon {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13373,6 +13830,7 @@ public final class Recon {
             getPlacesBuilder(int index) {
           return getPlacesFieldBuilder().getBuilder(index);
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13384,6 +13842,7 @@ public final class Recon {
             return placesBuilder_.getMessageOrBuilder(index);
           }
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13396,6 +13855,7 @@ public final class Recon {
             return java.util.Collections.unmodifiableList(places_);
           }
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13406,6 +13866,7 @@ public final class Recon {
                   org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place
                       .getDefaultInstance());
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13417,6 +13878,7 @@ public final class Recon {
                   org.datacommons.proto.Recon.ResolveCoordinatesResponse.Place
                       .getDefaultInstance());
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveCoordinatesResponse.Place places = 4;</code>
          */
@@ -13501,6 +13963,7 @@ public final class Recon {
     public static final int PLACE_COORDINATES_FIELD_NUMBER = 1;
     private java.util.List<org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceCoordinate>
         placeCoordinates_;
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -13511,6 +13974,7 @@ public final class Recon {
         getPlaceCoordinatesList() {
       return placeCoordinates_;
     }
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -13523,6 +13987,7 @@ public final class Recon {
         getPlaceCoordinatesOrBuilderList() {
       return placeCoordinates_;
     }
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -13532,6 +13997,7 @@ public final class Recon {
     public int getPlaceCoordinatesCount() {
       return placeCoordinates_.size();
     }
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -13542,6 +14008,7 @@ public final class Recon {
         getPlaceCoordinates(int index) {
       return placeCoordinates_.get(index);
     }
+
     /**
      * <code>
      * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -13717,6 +14184,7 @@ public final class Recon {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /** Protobuf type {@code org.datacommons.proto.ResolveCoordinatesResponse} */
     public static final class Builder
         extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -13943,6 +14411,7 @@ public final class Recon {
           return placeCoordinatesBuilder_.getMessageList();
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -13955,6 +14424,7 @@ public final class Recon {
           return placeCoordinatesBuilder_.getCount();
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -13968,6 +14438,7 @@ public final class Recon {
           return placeCoordinatesBuilder_.getMessage(index);
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -13987,6 +14458,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -14005,6 +14477,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -14024,6 +14497,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -14043,6 +14517,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -14060,6 +14535,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -14078,6 +14554,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -14096,6 +14573,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -14111,6 +14589,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -14126,6 +14605,7 @@ public final class Recon {
         }
         return this;
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -14135,6 +14615,7 @@ public final class Recon {
           getPlaceCoordinatesBuilder(int index) {
         return getPlaceCoordinatesFieldBuilder().getBuilder(index);
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -14148,6 +14629,7 @@ public final class Recon {
           return placeCoordinatesBuilder_.getMessageOrBuilder(index);
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -14163,6 +14645,7 @@ public final class Recon {
           return java.util.Collections.unmodifiableList(placeCoordinates_);
         }
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -14175,6 +14658,7 @@ public final class Recon {
                 org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceCoordinate
                     .getDefaultInstance());
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;
@@ -14188,6 +14672,7 @@ public final class Recon {
                 org.datacommons.proto.Recon.ResolveCoordinatesResponse.PlaceCoordinate
                     .getDefaultInstance());
       }
+
       /**
        * <code>
        * repeated .org.datacommons.proto.ResolveCoordinatesResponse.PlaceCoordinate place_coordinates = 1;

--- a/util/src/main/java/org/datacommons/proto/Resolve.java
+++ b/util/src/main/java/org/datacommons/proto/Resolve.java
@@ -23,12 +23,14 @@ public final class Resolve {
      * @return A list containing the nodes.
      */
     java.util.List<java.lang.String> getNodesList();
+
     /**
      * <code>repeated string nodes = 1;</code>
      *
      * @return The count of nodes.
      */
     int getNodesCount();
+
     /**
      * <code>repeated string nodes = 1;</code>
      *
@@ -36,6 +38,7 @@ public final class Resolve {
      * @return The nodes at the given index.
      */
     java.lang.String getNodes(int index);
+
     /**
      * <code>repeated string nodes = 1;</code>
      *
@@ -50,6 +53,7 @@ public final class Resolve {
      * @return The property.
      */
     java.lang.String getProperty();
+
     /**
      * <code>string property = 2;</code>
      *
@@ -57,6 +61,7 @@ public final class Resolve {
      */
     com.google.protobuf.ByteString getPropertyBytes();
   }
+
   /**
    *
    *
@@ -80,6 +85,7 @@ public final class Resolve {
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.ResolveRequest)
       ResolveRequestOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use ResolveRequest.newBuilder() to construct.
     private ResolveRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -176,6 +182,7 @@ public final class Resolve {
 
     public static final int NODES_FIELD_NUMBER = 1;
     private com.google.protobuf.LazyStringList nodes_;
+
     /**
      * <code>repeated string nodes = 1;</code>
      *
@@ -184,6 +191,7 @@ public final class Resolve {
     public com.google.protobuf.ProtocolStringList getNodesList() {
       return nodes_;
     }
+
     /**
      * <code>repeated string nodes = 1;</code>
      *
@@ -192,6 +200,7 @@ public final class Resolve {
     public int getNodesCount() {
       return nodes_.size();
     }
+
     /**
      * <code>repeated string nodes = 1;</code>
      *
@@ -201,6 +210,7 @@ public final class Resolve {
     public java.lang.String getNodes(int index) {
       return nodes_.get(index);
     }
+
     /**
      * <code>repeated string nodes = 1;</code>
      *
@@ -213,6 +223,7 @@ public final class Resolve {
 
     public static final int PROPERTY_FIELD_NUMBER = 2;
     private volatile java.lang.Object property_;
+
     /**
      * <code>string property = 2;</code>
      *
@@ -230,6 +241,7 @@ public final class Resolve {
         return s;
       }
     }
+
     /**
      * <code>string property = 2;</code>
      *
@@ -424,6 +436,7 @@ public final class Resolve {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /**
      *
      *
@@ -622,6 +635,7 @@ public final class Resolve {
           bitField0_ |= 0x00000001;
         }
       }
+
       /**
        * <code>repeated string nodes = 1;</code>
        *
@@ -630,6 +644,7 @@ public final class Resolve {
       public com.google.protobuf.ProtocolStringList getNodesList() {
         return nodes_.getUnmodifiableView();
       }
+
       /**
        * <code>repeated string nodes = 1;</code>
        *
@@ -638,6 +653,7 @@ public final class Resolve {
       public int getNodesCount() {
         return nodes_.size();
       }
+
       /**
        * <code>repeated string nodes = 1;</code>
        *
@@ -647,6 +663,7 @@ public final class Resolve {
       public java.lang.String getNodes(int index) {
         return nodes_.get(index);
       }
+
       /**
        * <code>repeated string nodes = 1;</code>
        *
@@ -656,6 +673,7 @@ public final class Resolve {
       public com.google.protobuf.ByteString getNodesBytes(int index) {
         return nodes_.getByteString(index);
       }
+
       /**
        * <code>repeated string nodes = 1;</code>
        *
@@ -672,6 +690,7 @@ public final class Resolve {
         onChanged();
         return this;
       }
+
       /**
        * <code>repeated string nodes = 1;</code>
        *
@@ -687,6 +706,7 @@ public final class Resolve {
         onChanged();
         return this;
       }
+
       /**
        * <code>repeated string nodes = 1;</code>
        *
@@ -699,6 +719,7 @@ public final class Resolve {
         onChanged();
         return this;
       }
+
       /**
        * <code>repeated string nodes = 1;</code>
        *
@@ -710,6 +731,7 @@ public final class Resolve {
         onChanged();
         return this;
       }
+
       /**
        * <code>repeated string nodes = 1;</code>
        *
@@ -728,6 +750,7 @@ public final class Resolve {
       }
 
       private java.lang.Object property_ = "";
+
       /**
        * <code>string property = 2;</code>
        *
@@ -744,6 +767,7 @@ public final class Resolve {
           return (java.lang.String) ref;
         }
       }
+
       /**
        * <code>string property = 2;</code>
        *
@@ -760,6 +784,7 @@ public final class Resolve {
           return (com.google.protobuf.ByteString) ref;
         }
       }
+
       /**
        * <code>string property = 2;</code>
        *
@@ -775,6 +800,7 @@ public final class Resolve {
         onChanged();
         return this;
       }
+
       /**
        * <code>string property = 2;</code>
        *
@@ -786,6 +812,7 @@ public final class Resolve {
         onChanged();
         return this;
       }
+
       /**
        * <code>string property = 2;</code>
        *
@@ -862,22 +889,28 @@ public final class Resolve {
 
     /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
     java.util.List<org.datacommons.proto.Resolve.ResolveResponse.Entity> getEntitiesList();
+
     /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
     org.datacommons.proto.Resolve.ResolveResponse.Entity getEntities(int index);
+
     /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
     int getEntitiesCount();
+
     /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
     java.util.List<? extends org.datacommons.proto.Resolve.ResolveResponse.EntityOrBuilder>
         getEntitiesOrBuilderList();
+
     /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
     org.datacommons.proto.Resolve.ResolveResponse.EntityOrBuilder getEntitiesOrBuilder(int index);
   }
+
   /** Protobuf type {@code org.datacommons.proto.ResolveResponse} */
   public static final class ResolveResponse extends com.google.protobuf.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:org.datacommons.proto.ResolveResponse)
       ResolveResponseOrBuilder {
     private static final long serialVersionUID = 0L;
+
     // Use ResolveResponse.newBuilder() to construct.
     private ResolveResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
@@ -979,6 +1012,7 @@ public final class Resolve {
        * @return The node.
        */
       java.lang.String getNode();
+
       /**
        * <code>string node = 1;</code>
        *
@@ -987,76 +1021,24 @@ public final class Resolve {
       com.google.protobuf.ByteString getNodeBytes();
 
       /**
-       *
-       *
-       * <pre>
-       * TODO(ws): Deprecate this field once not used in website:
-       * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-       * </pre>
-       *
-       * <code>repeated string resolved_ids = 2;</code>
-       *
-       * @return A list containing the resolvedIds.
-       */
-      java.util.List<java.lang.String> getResolvedIdsList();
-      /**
-       *
-       *
-       * <pre>
-       * TODO(ws): Deprecate this field once not used in website:
-       * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-       * </pre>
-       *
-       * <code>repeated string resolved_ids = 2;</code>
-       *
-       * @return The count of resolvedIds.
-       */
-      int getResolvedIdsCount();
-      /**
-       *
-       *
-       * <pre>
-       * TODO(ws): Deprecate this field once not used in website:
-       * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-       * </pre>
-       *
-       * <code>repeated string resolved_ids = 2;</code>
-       *
-       * @param index The index of the element to return.
-       * @return The resolvedIds at the given index.
-       */
-      java.lang.String getResolvedIds(int index);
-      /**
-       *
-       *
-       * <pre>
-       * TODO(ws): Deprecate this field once not used in website:
-       * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-       * </pre>
-       *
-       * <code>repeated string resolved_ids = 2;</code>
-       *
-       * @param index The index of the value to return.
-       * @return The bytes of the resolvedIds at the given index.
-       */
-      com.google.protobuf.ByteString getResolvedIdsBytes(int index);
-
-      /**
        * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
        * </code>
        */
       java.util.List<org.datacommons.proto.Resolve.ResolveResponse.Entity.Candidate>
           getCandidatesList();
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
        * </code>
        */
       org.datacommons.proto.Resolve.ResolveResponse.Entity.Candidate getCandidates(int index);
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
        * </code>
        */
       int getCandidatesCount();
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
        * </code>
@@ -1064,6 +1046,7 @@ public final class Resolve {
       java.util.List<
               ? extends org.datacommons.proto.Resolve.ResolveResponse.Entity.CandidateOrBuilder>
           getCandidatesOrBuilderList();
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
        * </code>
@@ -1071,12 +1054,14 @@ public final class Resolve {
       org.datacommons.proto.Resolve.ResolveResponse.Entity.CandidateOrBuilder
           getCandidatesOrBuilder(int index);
     }
+
     /** Protobuf type {@code org.datacommons.proto.ResolveResponse.Entity} */
     public static final class Entity extends com.google.protobuf.GeneratedMessageV3
         implements
         // @@protoc_insertion_point(message_implements:org.datacommons.proto.ResolveResponse.Entity)
         EntityOrBuilder {
       private static final long serialVersionUID = 0L;
+
       // Use Entity.newBuilder() to construct.
       private Entity(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
         super(builder);
@@ -1084,7 +1069,6 @@ public final class Resolve {
 
       private Entity() {
         node_ = "";
-        resolvedIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         candidates_ = java.util.Collections.emptyList();
       }
 
@@ -1125,23 +1109,13 @@ public final class Resolve {
                   node_ = s;
                   break;
                 }
-              case 18:
-                {
-                  java.lang.String s = input.readStringRequireUtf8();
-                  if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                    resolvedIds_ = new com.google.protobuf.LazyStringArrayList();
-                    mutable_bitField0_ |= 0x00000001;
-                  }
-                  resolvedIds_.add(s);
-                  break;
-                }
               case 26:
                 {
-                  if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+                  if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                     candidates_ =
                         new java.util.ArrayList<
                             org.datacommons.proto.Resolve.ResolveResponse.Entity.Candidate>();
-                    mutable_bitField0_ |= 0x00000002;
+                    mutable_bitField0_ |= 0x00000001;
                   }
                   candidates_.add(
                       input.readMessage(
@@ -1165,9 +1139,6 @@ public final class Resolve {
               .setUnfinishedMessage(this);
         } finally {
           if (((mutable_bitField0_ & 0x00000001) != 0)) {
-            resolvedIds_ = resolvedIds_.getUnmodifiableView();
-          }
-          if (((mutable_bitField0_ & 0x00000002) != 0)) {
             candidates_ = java.util.Collections.unmodifiableList(candidates_);
           }
           this.unknownFields = unknownFields.build();
@@ -1201,6 +1172,7 @@ public final class Resolve {
          * @return The dcid.
          */
         java.lang.String getDcid();
+
         /**
          * <code>string dcid = 1;</code>
          *
@@ -1214,6 +1186,7 @@ public final class Resolve {
          * @return The dominantType.
          */
         java.lang.String getDominantType();
+
         /**
          * <code>string dominant_type = 2;</code>
          *
@@ -1221,12 +1194,14 @@ public final class Resolve {
          */
         com.google.protobuf.ByteString getDominantTypeBytes();
       }
+
       /** Protobuf type {@code org.datacommons.proto.ResolveResponse.Entity.Candidate} */
       public static final class Candidate extends com.google.protobuf.GeneratedMessageV3
           implements
           // @@protoc_insertion_point(message_implements:org.datacommons.proto.ResolveResponse.Entity.Candidate)
           CandidateOrBuilder {
         private static final long serialVersionUID = 0L;
+
         // Use Candidate.newBuilder() to construct.
         private Candidate(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
           super(builder);
@@ -1317,6 +1292,7 @@ public final class Resolve {
 
         public static final int DCID_FIELD_NUMBER = 1;
         private volatile java.lang.Object dcid_;
+
         /**
          * <code>string dcid = 1;</code>
          *
@@ -1334,6 +1310,7 @@ public final class Resolve {
             return s;
           }
         }
+
         /**
          * <code>string dcid = 1;</code>
          *
@@ -1354,6 +1331,7 @@ public final class Resolve {
 
         public static final int DOMINANT_TYPE_FIELD_NUMBER = 2;
         private volatile java.lang.Object dominantType_;
+
         /**
          * <code>string dominant_type = 2;</code>
          *
@@ -1371,6 +1349,7 @@ public final class Resolve {
             return s;
           }
         }
+
         /**
          * <code>string dominant_type = 2;</code>
          *
@@ -1563,6 +1542,7 @@ public final class Resolve {
           Builder builder = new Builder(parent);
           return builder;
         }
+
         /** Protobuf type {@code org.datacommons.proto.ResolveResponse.Entity.Candidate} */
         public static final class Builder
             extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -1732,6 +1712,7 @@ public final class Resolve {
           }
 
           private java.lang.Object dcid_ = "";
+
           /**
            * <code>string dcid = 1;</code>
            *
@@ -1748,6 +1729,7 @@ public final class Resolve {
               return (java.lang.String) ref;
             }
           }
+
           /**
            * <code>string dcid = 1;</code>
            *
@@ -1764,6 +1746,7 @@ public final class Resolve {
               return (com.google.protobuf.ByteString) ref;
             }
           }
+
           /**
            * <code>string dcid = 1;</code>
            *
@@ -1779,6 +1762,7 @@ public final class Resolve {
             onChanged();
             return this;
           }
+
           /**
            * <code>string dcid = 1;</code>
            *
@@ -1790,6 +1774,7 @@ public final class Resolve {
             onChanged();
             return this;
           }
+
           /**
            * <code>string dcid = 1;</code>
            *
@@ -1808,6 +1793,7 @@ public final class Resolve {
           }
 
           private java.lang.Object dominantType_ = "";
+
           /**
            * <code>string dominant_type = 2;</code>
            *
@@ -1824,6 +1810,7 @@ public final class Resolve {
               return (java.lang.String) ref;
             }
           }
+
           /**
            * <code>string dominant_type = 2;</code>
            *
@@ -1840,6 +1827,7 @@ public final class Resolve {
               return (com.google.protobuf.ByteString) ref;
             }
           }
+
           /**
            * <code>string dominant_type = 2;</code>
            *
@@ -1855,6 +1843,7 @@ public final class Resolve {
             onChanged();
             return this;
           }
+
           /**
            * <code>string dominant_type = 2;</code>
            *
@@ -1866,6 +1855,7 @@ public final class Resolve {
             onChanged();
             return this;
           }
+
           /**
            * <code>string dominant_type = 2;</code>
            *
@@ -1940,6 +1930,7 @@ public final class Resolve {
 
       public static final int NODE_FIELD_NUMBER = 1;
       private volatile java.lang.Object node_;
+
       /**
        * <code>string node = 1;</code>
        *
@@ -1957,6 +1948,7 @@ public final class Resolve {
           return s;
         }
       }
+
       /**
        * <code>string node = 1;</code>
        *
@@ -1975,74 +1967,10 @@ public final class Resolve {
         }
       }
 
-      public static final int RESOLVED_IDS_FIELD_NUMBER = 2;
-      private com.google.protobuf.LazyStringList resolvedIds_;
-      /**
-       *
-       *
-       * <pre>
-       * TODO(ws): Deprecate this field once not used in website:
-       * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-       * </pre>
-       *
-       * <code>repeated string resolved_ids = 2;</code>
-       *
-       * @return A list containing the resolvedIds.
-       */
-      public com.google.protobuf.ProtocolStringList getResolvedIdsList() {
-        return resolvedIds_;
-      }
-      /**
-       *
-       *
-       * <pre>
-       * TODO(ws): Deprecate this field once not used in website:
-       * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-       * </pre>
-       *
-       * <code>repeated string resolved_ids = 2;</code>
-       *
-       * @return The count of resolvedIds.
-       */
-      public int getResolvedIdsCount() {
-        return resolvedIds_.size();
-      }
-      /**
-       *
-       *
-       * <pre>
-       * TODO(ws): Deprecate this field once not used in website:
-       * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-       * </pre>
-       *
-       * <code>repeated string resolved_ids = 2;</code>
-       *
-       * @param index The index of the element to return.
-       * @return The resolvedIds at the given index.
-       */
-      public java.lang.String getResolvedIds(int index) {
-        return resolvedIds_.get(index);
-      }
-      /**
-       *
-       *
-       * <pre>
-       * TODO(ws): Deprecate this field once not used in website:
-       * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-       * </pre>
-       *
-       * <code>repeated string resolved_ids = 2;</code>
-       *
-       * @param index The index of the value to return.
-       * @return The bytes of the resolvedIds at the given index.
-       */
-      public com.google.protobuf.ByteString getResolvedIdsBytes(int index) {
-        return resolvedIds_.getByteString(index);
-      }
-
       public static final int CANDIDATES_FIELD_NUMBER = 3;
       private java.util.List<org.datacommons.proto.Resolve.ResolveResponse.Entity.Candidate>
           candidates_;
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
        * </code>
@@ -2052,6 +1980,7 @@ public final class Resolve {
           getCandidatesList() {
         return candidates_;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
        * </code>
@@ -2062,6 +1991,7 @@ public final class Resolve {
           getCandidatesOrBuilderList() {
         return candidates_;
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
        * </code>
@@ -2070,6 +2000,7 @@ public final class Resolve {
       public int getCandidatesCount() {
         return candidates_.size();
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
        * </code>
@@ -2079,6 +2010,7 @@ public final class Resolve {
           int index) {
         return candidates_.get(index);
       }
+
       /**
        * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
        * </code>
@@ -2106,9 +2038,6 @@ public final class Resolve {
         if (!getNodeBytes().isEmpty()) {
           com.google.protobuf.GeneratedMessageV3.writeString(output, 1, node_);
         }
-        for (int i = 0; i < resolvedIds_.size(); i++) {
-          com.google.protobuf.GeneratedMessageV3.writeString(output, 2, resolvedIds_.getRaw(i));
-        }
         for (int i = 0; i < candidates_.size(); i++) {
           output.writeMessage(3, candidates_.get(i));
         }
@@ -2123,14 +2052,6 @@ public final class Resolve {
         size = 0;
         if (!getNodeBytes().isEmpty()) {
           size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, node_);
-        }
-        {
-          int dataSize = 0;
-          for (int i = 0; i < resolvedIds_.size(); i++) {
-            dataSize += computeStringSizeNoTag(resolvedIds_.getRaw(i));
-          }
-          size += dataSize;
-          size += 1 * getResolvedIdsList().size();
         }
         for (int i = 0; i < candidates_.size(); i++) {
           size += com.google.protobuf.CodedOutputStream.computeMessageSize(3, candidates_.get(i));
@@ -2152,7 +2073,6 @@ public final class Resolve {
             (org.datacommons.proto.Resolve.ResolveResponse.Entity) obj;
 
         if (!getNode().equals(other.getNode())) return false;
-        if (!getResolvedIdsList().equals(other.getResolvedIdsList())) return false;
         if (!getCandidatesList().equals(other.getCandidatesList())) return false;
         if (!unknownFields.equals(other.unknownFields)) return false;
         return true;
@@ -2167,10 +2087,6 @@ public final class Resolve {
         hash = (19 * hash) + getDescriptor().hashCode();
         hash = (37 * hash) + NODE_FIELD_NUMBER;
         hash = (53 * hash) + getNode().hashCode();
-        if (getResolvedIdsCount() > 0) {
-          hash = (37 * hash) + RESOLVED_IDS_FIELD_NUMBER;
-          hash = (53 * hash) + getResolvedIdsList().hashCode();
-        }
         if (getCandidatesCount() > 0) {
           hash = (37 * hash) + CANDIDATES_FIELD_NUMBER;
           hash = (53 * hash) + getCandidatesList().hashCode();
@@ -2277,6 +2193,7 @@ public final class Resolve {
         Builder builder = new Builder(parent);
         return builder;
       }
+
       /** Protobuf type {@code org.datacommons.proto.ResolveResponse.Entity} */
       public static final class Builder
           extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -2319,11 +2236,9 @@ public final class Resolve {
           super.clear();
           node_ = "";
 
-          resolvedIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-          bitField0_ = (bitField0_ & ~0x00000001);
           if (candidatesBuilder_ == null) {
             candidates_ = java.util.Collections.emptyList();
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ = (bitField0_ & ~0x00000001);
           } else {
             candidatesBuilder_.clear();
           }
@@ -2356,15 +2271,10 @@ public final class Resolve {
               new org.datacommons.proto.Resolve.ResolveResponse.Entity(this);
           int from_bitField0_ = bitField0_;
           result.node_ = node_;
-          if (((bitField0_ & 0x00000001) != 0)) {
-            resolvedIds_ = resolvedIds_.getUnmodifiableView();
-            bitField0_ = (bitField0_ & ~0x00000001);
-          }
-          result.resolvedIds_ = resolvedIds_;
           if (candidatesBuilder_ == null) {
-            if (((bitField0_ & 0x00000002) != 0)) {
+            if (((bitField0_ & 0x00000001) != 0)) {
               candidates_ = java.util.Collections.unmodifiableList(candidates_);
-              bitField0_ = (bitField0_ & ~0x00000002);
+              bitField0_ = (bitField0_ & ~0x00000001);
             }
             result.candidates_ = candidates_;
           } else {
@@ -2426,21 +2336,11 @@ public final class Resolve {
             node_ = other.node_;
             onChanged();
           }
-          if (!other.resolvedIds_.isEmpty()) {
-            if (resolvedIds_.isEmpty()) {
-              resolvedIds_ = other.resolvedIds_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-            } else {
-              ensureResolvedIdsIsMutable();
-              resolvedIds_.addAll(other.resolvedIds_);
-            }
-            onChanged();
-          }
           if (candidatesBuilder_ == null) {
             if (!other.candidates_.isEmpty()) {
               if (candidates_.isEmpty()) {
                 candidates_ = other.candidates_;
-                bitField0_ = (bitField0_ & ~0x00000002);
+                bitField0_ = (bitField0_ & ~0x00000001);
               } else {
                 ensureCandidatesIsMutable();
                 candidates_.addAll(other.candidates_);
@@ -2453,7 +2353,7 @@ public final class Resolve {
                 candidatesBuilder_.dispose();
                 candidatesBuilder_ = null;
                 candidates_ = other.candidates_;
-                bitField0_ = (bitField0_ & ~0x00000002);
+                bitField0_ = (bitField0_ & ~0x00000001);
                 candidatesBuilder_ =
                     com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders
                         ? getCandidatesFieldBuilder()
@@ -2496,6 +2396,7 @@ public final class Resolve {
         private int bitField0_;
 
         private java.lang.Object node_ = "";
+
         /**
          * <code>string node = 1;</code>
          *
@@ -2512,6 +2413,7 @@ public final class Resolve {
             return (java.lang.String) ref;
           }
         }
+
         /**
          * <code>string node = 1;</code>
          *
@@ -2528,6 +2430,7 @@ public final class Resolve {
             return (com.google.protobuf.ByteString) ref;
           }
         }
+
         /**
          * <code>string node = 1;</code>
          *
@@ -2543,6 +2446,7 @@ public final class Resolve {
           onChanged();
           return this;
         }
+
         /**
          * <code>string node = 1;</code>
          *
@@ -2554,6 +2458,7 @@ public final class Resolve {
           onChanged();
           return this;
         }
+
         /**
          * <code>string node = 1;</code>
          *
@@ -2571,192 +2476,15 @@ public final class Resolve {
           return this;
         }
 
-        private com.google.protobuf.LazyStringList resolvedIds_ =
-            com.google.protobuf.LazyStringArrayList.EMPTY;
-
-        private void ensureResolvedIdsIsMutable() {
-          if (!((bitField0_ & 0x00000001) != 0)) {
-            resolvedIds_ = new com.google.protobuf.LazyStringArrayList(resolvedIds_);
-            bitField0_ |= 0x00000001;
-          }
-        }
-        /**
-         *
-         *
-         * <pre>
-         * TODO(ws): Deprecate this field once not used in website:
-         * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-         * </pre>
-         *
-         * <code>repeated string resolved_ids = 2;</code>
-         *
-         * @return A list containing the resolvedIds.
-         */
-        public com.google.protobuf.ProtocolStringList getResolvedIdsList() {
-          return resolvedIds_.getUnmodifiableView();
-        }
-        /**
-         *
-         *
-         * <pre>
-         * TODO(ws): Deprecate this field once not used in website:
-         * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-         * </pre>
-         *
-         * <code>repeated string resolved_ids = 2;</code>
-         *
-         * @return The count of resolvedIds.
-         */
-        public int getResolvedIdsCount() {
-          return resolvedIds_.size();
-        }
-        /**
-         *
-         *
-         * <pre>
-         * TODO(ws): Deprecate this field once not used in website:
-         * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-         * </pre>
-         *
-         * <code>repeated string resolved_ids = 2;</code>
-         *
-         * @param index The index of the element to return.
-         * @return The resolvedIds at the given index.
-         */
-        public java.lang.String getResolvedIds(int index) {
-          return resolvedIds_.get(index);
-        }
-        /**
-         *
-         *
-         * <pre>
-         * TODO(ws): Deprecate this field once not used in website:
-         * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-         * </pre>
-         *
-         * <code>repeated string resolved_ids = 2;</code>
-         *
-         * @param index The index of the value to return.
-         * @return The bytes of the resolvedIds at the given index.
-         */
-        public com.google.protobuf.ByteString getResolvedIdsBytes(int index) {
-          return resolvedIds_.getByteString(index);
-        }
-        /**
-         *
-         *
-         * <pre>
-         * TODO(ws): Deprecate this field once not used in website:
-         * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-         * </pre>
-         *
-         * <code>repeated string resolved_ids = 2;</code>
-         *
-         * @param index The index to set the value at.
-         * @param value The resolvedIds to set.
-         * @return This builder for chaining.
-         */
-        public Builder setResolvedIds(int index, java.lang.String value) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureResolvedIdsIsMutable();
-          resolvedIds_.set(index, value);
-          onChanged();
-          return this;
-        }
-        /**
-         *
-         *
-         * <pre>
-         * TODO(ws): Deprecate this field once not used in website:
-         * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-         * </pre>
-         *
-         * <code>repeated string resolved_ids = 2;</code>
-         *
-         * @param value The resolvedIds to add.
-         * @return This builder for chaining.
-         */
-        public Builder addResolvedIds(java.lang.String value) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureResolvedIdsIsMutable();
-          resolvedIds_.add(value);
-          onChanged();
-          return this;
-        }
-        /**
-         *
-         *
-         * <pre>
-         * TODO(ws): Deprecate this field once not used in website:
-         * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-         * </pre>
-         *
-         * <code>repeated string resolved_ids = 2;</code>
-         *
-         * @param values The resolvedIds to add.
-         * @return This builder for chaining.
-         */
-        public Builder addAllResolvedIds(java.lang.Iterable<java.lang.String> values) {
-          ensureResolvedIdsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(values, resolvedIds_);
-          onChanged();
-          return this;
-        }
-        /**
-         *
-         *
-         * <pre>
-         * TODO(ws): Deprecate this field once not used in website:
-         * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-         * </pre>
-         *
-         * <code>repeated string resolved_ids = 2;</code>
-         *
-         * @return This builder for chaining.
-         */
-        public Builder clearResolvedIds() {
-          resolvedIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-          bitField0_ = (bitField0_ & ~0x00000001);
-          onChanged();
-          return this;
-        }
-        /**
-         *
-         *
-         * <pre>
-         * TODO(ws): Deprecate this field once not used in website:
-         * https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&amp;type=code
-         * </pre>
-         *
-         * <code>repeated string resolved_ids = 2;</code>
-         *
-         * @param value The bytes of the resolvedIds to add.
-         * @return This builder for chaining.
-         */
-        public Builder addResolvedIdsBytes(com.google.protobuf.ByteString value) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          checkByteStringIsUtf8(value);
-          ensureResolvedIdsIsMutable();
-          resolvedIds_.add(value);
-          onChanged();
-          return this;
-        }
-
         private java.util.List<org.datacommons.proto.Resolve.ResolveResponse.Entity.Candidate>
             candidates_ = java.util.Collections.emptyList();
 
         private void ensureCandidatesIsMutable() {
-          if (!((bitField0_ & 0x00000002) != 0)) {
+          if (!((bitField0_ & 0x00000001) != 0)) {
             candidates_ =
                 new java.util.ArrayList<
                     org.datacommons.proto.Resolve.ResolveResponse.Entity.Candidate>(candidates_);
-            bitField0_ |= 0x00000002;
+            bitField0_ |= 0x00000001;
           }
         }
 
@@ -2778,6 +2506,7 @@ public final class Resolve {
             return candidatesBuilder_.getMessageList();
           }
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2789,6 +2518,7 @@ public final class Resolve {
             return candidatesBuilder_.getCount();
           }
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2801,6 +2531,7 @@ public final class Resolve {
             return candidatesBuilder_.getMessage(index);
           }
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2819,6 +2550,7 @@ public final class Resolve {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2836,6 +2568,7 @@ public final class Resolve {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2854,6 +2587,7 @@ public final class Resolve {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2872,6 +2606,7 @@ public final class Resolve {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2888,6 +2623,7 @@ public final class Resolve {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2905,6 +2641,7 @@ public final class Resolve {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2922,6 +2659,7 @@ public final class Resolve {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2929,13 +2667,14 @@ public final class Resolve {
         public Builder clearCandidates() {
           if (candidatesBuilder_ == null) {
             candidates_ = java.util.Collections.emptyList();
-            bitField0_ = (bitField0_ & ~0x00000002);
+            bitField0_ = (bitField0_ & ~0x00000001);
             onChanged();
           } else {
             candidatesBuilder_.clear();
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2950,6 +2689,7 @@ public final class Resolve {
           }
           return this;
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2958,6 +2698,7 @@ public final class Resolve {
             getCandidatesBuilder(int index) {
           return getCandidatesFieldBuilder().getBuilder(index);
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2970,6 +2711,7 @@ public final class Resolve {
             return candidatesBuilder_.getMessageOrBuilder(index);
           }
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2983,6 +2725,7 @@ public final class Resolve {
             return java.util.Collections.unmodifiableList(candidates_);
           }
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -2994,6 +2737,7 @@ public final class Resolve {
                   org.datacommons.proto.Resolve.ResolveResponse.Entity.Candidate
                       .getDefaultInstance());
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -3006,6 +2750,7 @@ public final class Resolve {
                   org.datacommons.proto.Resolve.ResolveResponse.Entity.Candidate
                       .getDefaultInstance());
         }
+
         /**
          * <code>repeated .org.datacommons.proto.ResolveResponse.Entity.Candidate candidates = 3;
          * </code>
@@ -3028,7 +2773,7 @@ public final class Resolve {
                     org.datacommons.proto.Resolve.ResolveResponse.Entity.Candidate.Builder,
                     org.datacommons.proto.Resolve.ResolveResponse.Entity.CandidateOrBuilder>(
                     candidates_,
-                    ((bitField0_ & 0x00000002) != 0),
+                    ((bitField0_ & 0x00000001) != 0),
                     getParentForChildren(),
                     isClean());
             candidates_ = null;
@@ -3090,27 +2835,32 @@ public final class Resolve {
 
     public static final int ENTITIES_FIELD_NUMBER = 1;
     private java.util.List<org.datacommons.proto.Resolve.ResolveResponse.Entity> entities_;
+
     /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
     @java.lang.Override
     public java.util.List<org.datacommons.proto.Resolve.ResolveResponse.Entity> getEntitiesList() {
       return entities_;
     }
+
     /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
     @java.lang.Override
     public java.util.List<? extends org.datacommons.proto.Resolve.ResolveResponse.EntityOrBuilder>
         getEntitiesOrBuilderList() {
       return entities_;
     }
+
     /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
     @java.lang.Override
     public int getEntitiesCount() {
       return entities_.size();
     }
+
     /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
     @java.lang.Override
     public org.datacommons.proto.Resolve.ResolveResponse.Entity getEntities(int index) {
       return entities_.get(index);
     }
+
     /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
     @java.lang.Override
     public org.datacommons.proto.Resolve.ResolveResponse.EntityOrBuilder getEntitiesOrBuilder(
@@ -3280,6 +3030,7 @@ public final class Resolve {
       Builder builder = new Builder(parent);
       return builder;
     }
+
     /** Protobuf type {@code org.datacommons.proto.ResolveResponse} */
     public static final class Builder
         extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
@@ -3500,6 +3251,7 @@ public final class Resolve {
           return entitiesBuilder_.getMessageList();
         }
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public int getEntitiesCount() {
         if (entitiesBuilder_ == null) {
@@ -3508,6 +3260,7 @@ public final class Resolve {
           return entitiesBuilder_.getCount();
         }
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public org.datacommons.proto.Resolve.ResolveResponse.Entity getEntities(int index) {
         if (entitiesBuilder_ == null) {
@@ -3516,6 +3269,7 @@ public final class Resolve {
           return entitiesBuilder_.getMessage(index);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public Builder setEntities(
           int index, org.datacommons.proto.Resolve.ResolveResponse.Entity value) {
@@ -3531,6 +3285,7 @@ public final class Resolve {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public Builder setEntities(
           int index, org.datacommons.proto.Resolve.ResolveResponse.Entity.Builder builderForValue) {
@@ -3543,6 +3298,7 @@ public final class Resolve {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public Builder addEntities(org.datacommons.proto.Resolve.ResolveResponse.Entity value) {
         if (entitiesBuilder_ == null) {
@@ -3557,6 +3313,7 @@ public final class Resolve {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public Builder addEntities(
           int index, org.datacommons.proto.Resolve.ResolveResponse.Entity value) {
@@ -3572,6 +3329,7 @@ public final class Resolve {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public Builder addEntities(
           org.datacommons.proto.Resolve.ResolveResponse.Entity.Builder builderForValue) {
@@ -3584,6 +3342,7 @@ public final class Resolve {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public Builder addEntities(
           int index, org.datacommons.proto.Resolve.ResolveResponse.Entity.Builder builderForValue) {
@@ -3596,6 +3355,7 @@ public final class Resolve {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public Builder addAllEntities(
           java.lang.Iterable<? extends org.datacommons.proto.Resolve.ResolveResponse.Entity>
@@ -3609,6 +3369,7 @@ public final class Resolve {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public Builder clearEntities() {
         if (entitiesBuilder_ == null) {
@@ -3620,6 +3381,7 @@ public final class Resolve {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public Builder removeEntities(int index) {
         if (entitiesBuilder_ == null) {
@@ -3631,11 +3393,13 @@ public final class Resolve {
         }
         return this;
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public org.datacommons.proto.Resolve.ResolveResponse.Entity.Builder getEntitiesBuilder(
           int index) {
         return getEntitiesFieldBuilder().getBuilder(index);
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public org.datacommons.proto.Resolve.ResolveResponse.EntityOrBuilder getEntitiesOrBuilder(
           int index) {
@@ -3645,6 +3409,7 @@ public final class Resolve {
           return entitiesBuilder_.getMessageOrBuilder(index);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public java.util.List<? extends org.datacommons.proto.Resolve.ResolveResponse.EntityOrBuilder>
           getEntitiesOrBuilderList() {
@@ -3654,11 +3419,13 @@ public final class Resolve {
           return java.util.Collections.unmodifiableList(entities_);
         }
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public org.datacommons.proto.Resolve.ResolveResponse.Entity.Builder addEntitiesBuilder() {
         return getEntitiesFieldBuilder()
             .addBuilder(org.datacommons.proto.Resolve.ResolveResponse.Entity.getDefaultInstance());
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public org.datacommons.proto.Resolve.ResolveResponse.Entity.Builder addEntitiesBuilder(
           int index) {
@@ -3666,6 +3433,7 @@ public final class Resolve {
             .addBuilder(
                 index, org.datacommons.proto.Resolve.ResolveResponse.Entity.getDefaultInstance());
       }
+
       /** <code>repeated .org.datacommons.proto.ResolveResponse.Entity entities = 1;</code> */
       public java.util.List<org.datacommons.proto.Resolve.ResolveResponse.Entity.Builder>
           getEntitiesBuilderList() {
@@ -3768,13 +3536,13 @@ public final class Resolve {
     java.lang.String[] descriptorData = {
       "\n\rresolve.proto\022\025org.datacommons.proto\"1"
           + "\n\016ResolveRequest\022\r\n\005nodes\030\001 \003(\t\022\020\n\010prope"
-          + "rty\030\002 \001(\t\"\200\002\n\017ResolveResponse\022?\n\010entitie"
+          + "rty\030\002 \001(\t\"\360\001\n\017ResolveResponse\022?\n\010entitie"
           + "s\030\001 \003(\0132-.org.datacommons.proto.ResolveR"
-          + "esponse.Entity\032\253\001\n\006Entity\022\014\n\004node\030\001 \001(\t\022"
-          + "\024\n\014resolved_ids\030\002 \003(\t\022K\n\ncandidates\030\003 \003("
-          + "\01327.org.datacommons.proto.ResolveRespons"
-          + "e.Entity.Candidate\0320\n\tCandidate\022\014\n\004dcid\030"
-          + "\001 \001(\t\022\025\n\rdominant_type\030\002 \001(\tb\006proto3"
+          + "esponse.Entity\032\233\001\n\006Entity\022\014\n\004node\030\001 \001(\t\022"
+          + "K\n\ncandidates\030\003 \003(\01327.org.datacommons.pr"
+          + "oto.ResolveResponse.Entity.Candidate\0320\n\t"
+          + "Candidate\022\014\n\004dcid\030\001 \001(\t\022\025\n\rdominant_type"
+          + "\030\002 \001(\tJ\004\010\002\020\003b\006proto3"
     };
     descriptor =
         com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
@@ -3801,7 +3569,7 @@ public final class Resolve {
         new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
             internal_static_org_datacommons_proto_ResolveResponse_Entity_descriptor,
             new java.lang.String[] {
-              "Node", "ResolvedIds", "Candidates",
+              "Node", "Candidates",
             });
     internal_static_org_datacommons_proto_ResolveResponse_Entity_Candidate_descriptor =
         internal_static_org_datacommons_proto_ResolveResponse_Entity_descriptor

--- a/util/src/main/java/org/datacommons/util/McfChecker.java
+++ b/util/src/main/java/org/datacommons/util/McfChecker.java
@@ -103,6 +103,7 @@ public class McfChecker {
       throws IOException, InterruptedException {
     return new McfChecker(graph, columns, existenceChecker, null, false, true, logCtx).check();
   }
+
   // Version of checkTemplate that allows to specify "allowNanSVObs"
   public static boolean checkTemplate(
       Mcf.McfGraph graph,

--- a/util/src/main/proto/resolve.proto
+++ b/util/src/main/proto/resolve.proto
@@ -47,10 +47,9 @@ message ResolveResponse{
       string dominant_type = 2;
     }
     string node = 1;
-    // TODO(ws): Deprecate this field once not used in website:
-    // https://github.com/search?q=repo%3Adatacommonsorg%2Fwebsite%20v2%2Fresolve&type=code
-    repeated string resolved_ids = 2;
     repeated Candidate candidates = 3;
+
+    reserved 2;
   }
   repeated Entity entities = 1;
 }

--- a/util/src/test/java/org/datacommons/util/StatVarStateTest.java
+++ b/util/src/test/java/org/datacommons/util/StatVarStateTest.java
@@ -111,6 +111,7 @@ public class StatVarStateTest {
 
     assertEquals(Vocabulary.MEASUREMENT_RESULT, returnValue);
   }
+
   // Test many things that parseApiStatTypeResponse should return null for
   // (i.e. incorrect/invalid inputs)
   @Test


### PR DESCRIPTION
Already deprecated from mixer: https://github.com/datacommonsorg/mixer/pull/1553

Also updated the version for fmt-maven-plugin since there were compilation errors, which edited the styling on some other files