### PR TITLE
Refactor ingestion data classes.

### DIFF
--- a/pipeline/ingestion/pom.xml
+++ b/pipeline/ingestion/pom.xml
@@ -37,6 +37,11 @@
       <version>1.7.32</version>
     </dependency>
     <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>33.4.8-jre</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/CacheReader.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/CacheReader.java
@@ -1,0 +1,199 @@
+package org.datacommons.ingestion.data;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+
+import org.datacommons.proto.CacheData.EntityInfo;
+import org.datacommons.proto.CacheData.PagedEntities;
+import org.datacommons.proto.ChartStoreOuterClass.ChartStore;
+import org.datacommons.proto.ChartStoreOuterClass.ObsTimeSeries.SourceSeries;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.google.protobuf.Message;
+import com.google.protobuf.Parser;
+
+/**
+ * CacheReader is a class that has utility methods to read data from BT cache.
+ */
+public class CacheReader {
+    private static final String OUT_ARC_CACHE_PREFIX = "d/m/";
+    private static final String IN_ARC_CACHE_PREFIX = "d/l/";
+    private static final String OBS_TIME_SERIES_CACHE_PREFIX = "d/3/";
+    private static final int CACHE_KEY_PREFIX_SIZE = 4;
+    private static final String CACHE_KEY_VALUE_SEPARATOR_REGEX = ",";
+    private static final String CACHE_KEY_SEPARATOR_REGEX = "\\^";
+
+    /**
+     * Returns the GCS cache path for the import group.
+     */
+    public static String getCachePath(String projectId, String bucketId, String importGroup) {
+        Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+        Page<Blob> blobs = storage.list(
+                bucketId,
+                Storage.BlobListOption.prefix(importGroup),
+                Storage.BlobListOption.currentDirectory());
+
+        // Currently this fetches the "last" blob in the directory which typically tends
+        // to be the latest.
+        // TODO: Update this code to fetch a specific blob and update the logic to
+        // definitively fetch the latest if none is provided.
+        String prefix = "";
+        for (Blob blob : blobs.iterateAll()) {
+            prefix = blob.getName();
+        }
+        return String.format("gs://%s/%scache.csv*", bucketId, prefix);
+    }
+
+    /**
+     * Parses an arc cache row to extract nodes and edges.
+     */
+    public static NodesEdges parseArcRow(String row) {
+        NodesEdges result = new NodesEdges();
+
+        // Cache format: <dcid^predicate^type^page>, PagedEntities
+        if (row != null && !row.isEmpty()) {
+            String[] items = row.split(CACHE_KEY_VALUE_SEPARATOR_REGEX);
+            if (items.length == 2) {
+                String key = items[0];
+                String value = items[1];
+                String suffix = key.substring(CACHE_KEY_PREFIX_SIZE);
+                String[] keys = suffix.split(CACHE_KEY_SEPARATOR_REGEX);
+                if (!(value.isEmpty()) && keys.length >= 2) {
+                    String dcid = keys[0];
+                    String predicate = keys[1];
+                    String typeOf = keys[2];
+                    PagedEntities elist = parseProto(value, PagedEntities.parser());
+                    for (EntityInfo entity : elist.getEntitiesList()) {
+                        String subjectId, objectId, nodeId = "";
+                        // Add a self edge if value is populated.
+                        if (!entity.getValue().isEmpty()) {
+                            subjectId = dcid;
+                            objectId = dcid;
+                            // Terminal edges won't produce any object nodes.
+                        } else {
+                            if (isOutArcCacheRow(row)) {
+                                subjectId = dcid;
+                                objectId = entity.getDcid();
+                                nodeId = entity.getDcid();
+                            } else { // in arc row
+                                subjectId = entity.getDcid();
+                                objectId = dcid;
+                                nodeId = entity.getDcid();
+                            }
+                        }
+                        List<String> types = entity.getTypesList();
+                        if (types.isEmpty() && !typeOf.isEmpty()) {
+                            types = Arrays.asList(typeOf);
+                        }
+
+                        // Add node.
+                        if (!nodeId.isEmpty() && !types.isEmpty()) {
+                            result.addNode(Node.builder()
+                                    .subjectId(nodeId)
+                                    .name(entity.getName())
+                                    .types(types)
+                                    .build());
+                        }
+
+                        // Add edge.
+                        if (!subjectId.isEmpty() && !objectId.isEmpty()) {
+                            result.addEdge(Edge.builder()
+                                    .subjectId(subjectId)
+                                    .predicate(predicate)
+                                    .objectId(objectId)
+                                    .objectValue(entity.getValue())
+                                    .provenance(entity.getProvenanceId())
+                                    .build());
+                        }
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Parses a time series cache row to extract observations.
+     */
+    public static List<Observation> parseTimeSeriesRow(String row) {
+        List<Observation> result = new ArrayList<>();
+
+        // Cache format: <placeId^statVarId>, ChartStore containing ObsTimeSeries.
+        if (row != null && !row.isEmpty()) {
+            String[] items = row.split(CACHE_KEY_VALUE_SEPARATOR_REGEX);
+            if (items.length == 2) {
+                String key = items[0];
+                String value = items[1];
+                String suffix = key.substring(CACHE_KEY_PREFIX_SIZE);
+                String[] keys = suffix.split(CACHE_KEY_SEPARATOR_REGEX);
+                if (!(value.isEmpty()) && keys.length >= 2) {
+                    String variableMeasured = keys[1];
+                    String observationAbout = keys[0];
+                    ChartStore chart = parseProto(value, ChartStore.parser());
+                    for (SourceSeries source : chart.getObsTimeSeries().getSourceSeriesList()) {
+                        Observation.Builder builder = Observation.builder()
+                                .variableMeasured(variableMeasured)
+                                .observationAbout(observationAbout)
+                                .observationPeriod(source.getObservationPeriod())
+                                .measurementMethod(source.getMeasurementMethod())
+                                .scalingFactor(source.getScalingFactor())
+                                .unit(source.getUnit())
+                                .provenance(source.getProvenanceDomain())
+                                .provenanceUrl(source.getProvenanceUrl())
+                                .importName(source.getImportName());
+                        for (Map.Entry<String, Double> e : source.getValMap().entrySet()) {
+                            builder.observation(new DateValue(e.getKey(), e.getValue().toString()));
+                        }
+                        for (Map.Entry<String, String> e : source.getStrValMap().entrySet()) {
+                            builder.observation(new DateValue(e.getKey(), e.getValue()));
+                        }
+                        result.add(builder.build());
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Parses a Base64-encoded, GZIP-compressed protobuf message from a cache row
+     * string.
+     */
+    private static <T extends Message> T parseProto(String value, Parser<T> parser) {
+        try (GZIPInputStream gzipInputStream = new GZIPInputStream(
+                new ByteArrayInputStream(Base64.getDecoder().decode(value)))) {
+            return parser.parseFrom(gzipInputStream);
+        } catch (IOException e) {
+            throw new RuntimeException("Error parsing protobuf message: " + e.getMessage(), e);
+        }
+    }
+
+    private static final boolean isInArcCacheRow(String row) {
+        return row.startsWith(IN_ARC_CACHE_PREFIX);
+    }
+
+    private static final boolean isOutArcCacheRow(String row) {
+        return row.startsWith(OUT_ARC_CACHE_PREFIX);
+    }
+
+    public static final boolean isArcCacheRow(String row) {
+        return isInArcCacheRow(row) || isOutArcCacheRow(row);
+    }
+
+    public static final boolean isObsTimeSeriesCacheRow(String row) {
+        return row.startsWith(OBS_TIME_SERIES_CACHE_PREFIX);
+    }
+}

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/DateValue.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/DateValue.java
@@ -1,0 +1,49 @@
+package org.datacommons.ingestion.data;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.apache.beam.sdk.coders.DefaultCoder;
+import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
+
+/**
+ * Models an observation value at a specific date.
+ */
+@DefaultCoder(AvroCoder.class)
+public class DateValue implements Serializable {
+    private String date;
+    private String value;
+
+    public DateValue(String date, String value) {
+        this.date = date;
+        this.value = value;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        DateValue dateValue = (DateValue) o;
+        return Objects.equals(date, dateValue.date) && Objects.equals(value, dateValue.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(date, value);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("DateValue{date='%s', value='%s'}", date, value);
+    }
+}

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Edge.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Edge.java
@@ -1,0 +1,156 @@
+package org.datacommons.ingestion.data;
+
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Objects;
+
+import org.apache.beam.sdk.coders.DefaultCoder;
+import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
+
+import com.google.common.hash.Hashing;
+
+/**
+ * Models a graph edge.
+ */
+@DefaultCoder(AvroCoder.class)
+public class Edge implements Serializable {
+
+    private String subjectId;
+    private String predicate;
+    private String objectId;
+    private String objectValue;
+    private String provenance;
+    private String objectHash;
+
+    // Private constructor to enforce use of Builder
+    private Edge(Builder builder) {
+        this.subjectId = builder.subjectId;
+        this.predicate = builder.predicate;
+        this.objectId = builder.objectId;
+        this.objectValue = builder.objectValue;
+        this.provenance = builder.provenance;
+        this.objectHash = builder.objectHash;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getSubjectId() {
+        return subjectId;
+    }
+
+    public String getPredicate() {
+        return predicate;
+    }
+
+    public String getObjectId() {
+        return objectId;
+    }
+
+    public String getObjectValue() {
+        return objectValue;
+    }
+
+    public String getProvenance() {
+        return provenance;
+    }
+
+    public String getObjectHash() {
+        return objectHash;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Edge edge = (Edge) o;
+        return subjectId.equals(edge.subjectId) && predicate.equals(edge.predicate) && objectId.equals(edge.objectId)
+                && Objects.equals(objectHash, edge.objectHash);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subjectId, predicate, objectId, objectHash);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "Edge{subjectId='%s', predicate='%s', objectId='%s', objectValue='%s', provenance='%s', objectHash='%s'}",
+                subjectId, predicate, objectId, objectValue, provenance, objectHash);
+    }
+
+    public static class Builder {
+        private String subjectId = "";
+        private String predicate = "";
+        private String objectId = "";
+        private String objectValue = "";
+        private String provenance = "";
+        private String objectHash = "";
+
+        private Builder() {
+        }
+
+        public Builder subjectId(String subjectId) {
+            this.subjectId = subjectId;
+            return this;
+        }
+
+        public Builder predicate(String predicate) {
+            this.predicate = predicate;
+            return this;
+        }
+
+        public Builder objectId(String objectId) {
+            this.objectId = objectId;
+            return this;
+        }
+
+        public Builder objectValue(String objectValue) {
+            this.objectValue = objectValue;
+            this.objectHash = generateSha256(objectValue);
+            return this;
+        }
+
+        public Builder provenance(String provenance) {
+            this.provenance = provenance;
+            return this;
+        }
+
+        public Builder objectHash(String objectHash) {
+            this.objectHash = objectHash;
+            return this;
+        }
+
+        public Edge build() {
+            if (subjectId == null || subjectId.isEmpty()) {
+                throw new IllegalArgumentException("subjectId cannot be null or empty");
+            }
+            if (predicate == null || predicate.isEmpty()) {
+                throw new IllegalArgumentException("predicate cannot be null or empty");
+            }
+            if (objectId == null || objectId.isEmpty()) {
+                throw new IllegalArgumentException("objectId cannot be null or empty");
+            }
+            return new Edge(this);
+        }
+
+        private String generateSha256(String input) {
+            if (input == null || input.isEmpty()) {
+                return "";
+            }
+            return Base64.getEncoder().encodeToString(
+                    Hashing.sha256()
+                            .hashString(input, StandardCharsets.UTF_8)
+                            .asBytes());
+        }
+    }
+
+    public static AvroCoder<Edge> getCoder() {
+        return AvroCoder.of(Edge.class);
+    }
+}

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Node.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Node.java
@@ -1,0 +1,99 @@
+package org.datacommons.ingestion.data;
+
+import org.apache.beam.sdk.coders.DefaultCoder;
+import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Models a graph node.
+ * Equality is based on the subjectId only.
+ * This is because the subjectId is unique for each node in the graph.
+ */
+@DefaultCoder(AvroCoder.class)
+public class Node implements Serializable {
+
+    private String subjectId;
+    private String name;
+    private List<String> types;
+
+    // Private constructor to enforce use of Builder
+    private Node(Builder builder) {
+        this.subjectId = builder.subjectId;
+        this.name = builder.name;
+        this.types = builder.types;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getSubjectId() {
+        return subjectId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<String> getTypes() {
+        return types;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Node node = (Node) o;
+        return subjectId.equals(node.subjectId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subjectId);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Node{subjectId='%s', name='%s', types=%s}", subjectId, name, types);
+    }
+
+    public static class Builder {
+        private String subjectId = "";
+        private String name = "";
+        private List<String> types = List.of();
+
+        private Builder() {
+        }
+
+        public Builder subjectId(String subjectId) {
+            this.subjectId = subjectId;
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder types(List<String> types) {
+            this.types = types;
+            return this;
+        }
+
+        public Node build() {
+            if (subjectId == null || subjectId.isEmpty()) {
+                throw new IllegalArgumentException("subjectId cannot be null or empty");
+            }
+            return new Node(this);
+        }
+    }
+
+    public static AvroCoder<Node> getCoder() {
+        return AvroCoder.of(Node.class);
+    }
+}

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/NodesEdges.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/NodesEdges.java
@@ -1,0 +1,74 @@
+package org.datacommons.ingestion.data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Models a collection of nodes and edges.
+ * Typically indvidual cache entries are parsed into objects of this class.
+ * 
+ * Objects of this class will only be used in-memory and will not be transmitted
+ * in the pipeline.
+ */
+public class NodesEdges {
+
+    private List<Node> nodes;
+    private List<Edge> edges;
+
+    public NodesEdges() {
+        this.nodes = new ArrayList<>();
+        this.edges = new ArrayList<>();
+    }
+
+    public List<Node> getNodes() {
+        return nodes;
+    }
+
+    public List<Edge> getEdges() {
+        return edges;
+    }
+
+    public NodesEdges addNode(Node node) {
+        this.nodes.add(node);
+        return this;
+    }
+
+    public NodesEdges addEdge(Edge edge) {
+        this.edges.add(edge);
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        NodesEdges that = (NodesEdges) o;
+        return Objects.equals(nodes, that.nodes) &&
+                Objects.equals(edges, that.edges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nodes, edges);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("NodesEdges {\n");
+        sb.append(String.format("\tNodes (%d): [\n", nodes.size()));
+        for (Node node : nodes) {
+            sb.append("\t\t").append(node.toString()).append("\n");
+        }
+        sb.append("\t],\n");
+        sb.append(String.format("\tEdges (%d): [\n", edges.size()));
+        for (Edge edge : edges) {
+            sb.append("\t\t").append(edge.toString()).append("\n");
+        }
+        sb.append("\t]\n");
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Observation.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Observation.java
@@ -1,0 +1,200 @@
+package org.datacommons.ingestion.data;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Objects;
+import org.apache.beam.sdk.coders.DefaultCoder;
+import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
+
+/**
+ * Models a statvar observation time series.
+ */
+@DefaultCoder(AvroCoder.class)
+public class Observation implements Serializable {
+
+    private String variableMeasured;
+    private String observationAbout;
+    private List<DateValue> observations;
+    private String provenance;
+    private String observationPeriod;
+    private String measurementMethod;
+    private String unit;
+    private String scalingFactor;
+    private String importName;
+    private String provenanceUrl;
+
+    private Observation(Builder builder) {
+        this.variableMeasured = builder.variableMeasured;
+        this.observationAbout = builder.observationAbout;
+        this.observations = builder.observations;
+        this.provenance = builder.provenance;
+        this.observationPeriod = builder.observationPeriod;
+        this.measurementMethod = builder.measurementMethod;
+        this.unit = builder.unit;
+        this.scalingFactor = builder.scalingFactor;
+        this.importName = builder.importName;
+        this.provenanceUrl = builder.provenanceUrl;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getVariableMeasured() {
+        return variableMeasured;
+    }
+
+    public String getObservationAbout() {
+        return observationAbout;
+    }
+
+    public List<DateValue> getObservations() {
+        return observations;
+    }
+
+    public String getProvenance() {
+        return provenance;
+    }
+
+    public String getObservationPeriod() {
+        return observationPeriod;
+    }
+
+    public String getMeasurementMethod() {
+        return measurementMethod;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public String getScalingFactor() {
+        return scalingFactor;
+    }
+
+    public String getImportName() {
+        return importName;
+    }
+
+    public String getProvenanceUrl() {
+        return provenanceUrl;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Observation that = (Observation) o;
+        return Objects.equals(variableMeasured, that.variableMeasured) &&
+                Objects.equals(observationAbout, that.observationAbout) &&
+                Objects.equals(observations, that.observations) &&
+                Objects.equals(provenance, that.provenance) &&
+                Objects.equals(observationPeriod, that.observationPeriod) &&
+                Objects.equals(measurementMethod, that.measurementMethod) &&
+                Objects.equals(unit, that.unit) &&
+                Objects.equals(scalingFactor, that.scalingFactor) &&
+                Objects.equals(importName, that.importName) &&
+                Objects.equals(provenanceUrl, that.provenanceUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(variableMeasured, observationAbout, observations, provenance, observationPeriod,
+                measurementMethod, unit, scalingFactor, importName, provenanceUrl);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "Observation{" +
+                        "variableMeasured='%s', " +
+                        "observationAbout='%s', " +
+                        "observations=%s, " +
+                        "provenance='%s', " +
+                        "observationPeriod='%s', " +
+                        "measurementMethod='%s', " +
+                        "unit='%s', " +
+                        "scalingFactor='%s', " +
+                        "importName='%s', " +
+                        "provenanceUrl='%s'" +
+                        "}",
+                variableMeasured, observationAbout, observations, provenance, observationPeriod, measurementMethod,
+                unit, scalingFactor, importName, provenanceUrl);
+    }
+
+    // Builder for Observation
+    public static class Builder {
+        private String variableMeasured = "";
+        private String observationAbout = "";
+        private List<DateValue> observations = new ArrayList<>();
+        private String provenance = "";
+        private String observationPeriod = "";
+        private String measurementMethod = "";
+        private String unit = "";
+        private String scalingFactor = "";
+        private String importName = "";
+        private String provenanceUrl = "";
+
+        public Builder variableMeasured(String variableMeasured) {
+            this.variableMeasured = variableMeasured;
+            return this;
+        }
+
+        public Builder observationAbout(String observationAbout) {
+            this.observationAbout = observationAbout;
+            return this;
+        }
+
+        public Builder observation(DateValue dateValue) {
+            this.observations.add(dateValue);
+            return this;
+        }
+
+        public Builder observations(List<DateValue> observations) {
+            this.observations = observations;
+            return this;
+        }
+
+        public Builder provenance(String provenance) {
+            this.provenance = provenance;
+            return this;
+        }
+
+        public Builder observationPeriod(String observationPeriod) {
+            this.observationPeriod = observationPeriod;
+            return this;
+        }
+
+        public Builder measurementMethod(String measurementMethod) {
+            this.measurementMethod = measurementMethod;
+            return this;
+        }
+
+        public Builder unit(String unit) {
+            this.unit = unit;
+            return this;
+        }
+
+        public Builder scalingFactor(String scalingFactor) {
+            this.scalingFactor = scalingFactor;
+            return this;
+        }
+
+        public Builder importName(String importName) {
+            this.importName = importName;
+            return this;
+        }
+
+        public Builder provenanceUrl(String provenanceUrl) {
+            this.provenanceUrl = provenanceUrl;
+            return this;
+        }
+
+        public Observation build() {
+            return new Observation(this);
+        }
+    }
+}

--- a/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/CacheReaderTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/CacheReaderTest.java
@@ -1,0 +1,116 @@
+package org.datacommons.ingestion.data;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class CacheReaderTest {
+        @Test
+        public void testParseArcRow_outArcwithNode() {
+                String row = "d/m/Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person^measuredProperty^Property^0,H4sIAAAAAAAAAOPS5WJNzi/NK5GCUEqyKcn6SYnFqfoepbmJeUGpiSmJSTmpwSWJJWGJRcWCDGDwwR4AejAnwDgAAAA=";
+
+                NodesEdges expected = new NodesEdges()
+                                .addNode(Node.builder()
+                                                .subjectId("count")
+                                                .name("count")
+                                                .types(List.of("Property")).build())
+                                .addEdge(Edge.builder()
+                                                .subjectId(
+                                                                "Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person")
+                                                .predicate("measuredProperty")
+                                                .objectId("count")
+                                                .objectValue("")
+                                                .provenance("dc/base/HumanReadableStatVars")
+                                                .build());
+
+                NodesEdges actual = CacheReader.parseArcRow(row);
+
+                assertEquals(expected, actual);
+        }
+
+        @Test
+        public void testParseArcRow_outArcwithoutNode() {
+                String row = "d/m/Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person^name^^0,H4sIAAAAAAAAAONqYFSSTUnWT0osTtX3KM1NzAtKTUxJTMpJDS5JLAlLLCrWig9ILUpOzStJTE9VCM8vylYISs1JLElNUQjIqCzOTE7MUXBMLsksyyyp1FHwzU9JLQJKwoUU/IsUPFITyyoRIo65+XnpCgH5BaVAYzLz8wQZwOCDPQA1JajOjAAAAA==";
+
+                NodesEdges expected = new NodesEdges()
+                                .addEdge(Edge.builder()
+                                                .subjectId(
+                                                                "Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person")
+                                                .predicate("name")
+                                                .objectId("Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person")
+                                                .objectValue(
+                                                                "Percentage Work Related Physical Activity, Moderate Activity Or Heavy Activity Among Population")
+                                                .provenance("dc/base/HumanReadableStatVars")
+                                                .build());
+
+                NodesEdges actual = CacheReader.parseArcRow(row);
+
+                assertEquals(expected, actual);
+        }
+
+        @Test
+        public void testParseArcRow_inArc() {
+                String row = "d/l/dc/d/UnitedNationsUn_SdgIndicatorsDatabase^isPartOf^Provenance^0,H4sIAAAAAAAAAOPS4GIL9YsPdnGX4ktJ1k9KLE7Vh/CV0PiCDGDwwR4AhMbiaDMAAAA=";
+
+                NodesEdges expected = new NodesEdges()
+                                .addNode(Node.builder()
+                                                .subjectId("dc/base/UN_SDG")
+                                                .name("UN_SDG")
+                                                .types(List.of("Provenance")).build())
+                                .addEdge(Edge.builder()
+                                                .subjectId(
+                                                                "dc/base/UN_SDG")
+                                                .predicate("isPartOf")
+                                                .objectId("dc/d/UnitedNationsUn_SdgIndicatorsDatabase")
+                                                .objectValue("")
+                                                .provenance("dc/base/UN_SDG")
+                                                .build());
+
+                NodesEdges actual = CacheReader.parseArcRow(row);
+
+                assertEquals(expected, actual);
+        }
+
+        @Test
+        public void testParseTimeSeriesRow() {
+                String row = "d/3/geoId/sch2915390^Mean_PrecipitableWater_Atmosphere,H4sIAAAAAAAAAOPqZpHi8igtykmtVAjS9TT6w8wlysVlZGBkqmtgpGtkIMgQvilZeYOoA4qwkeBcve7Os9OVUIWNBQOzZ5XPaVJBEjbWNTAU3OHQ9Oj4DD1U1aaCIvbH7mx9ookibGguqN6xi98hSwZV2EJQ0Mxmb5CYFqohJoJMszik59WpogobCq49MOHqWjk5VJcYCRac67h074AqqrCxoOOVWoag1QqohlgIpnUkx96ZZoQqbC7IeI+Js2s+mkvMBKub9X2WrdJENdtE0N9BOPHwZkVU71gKGoOBioMUh5+/o2O8u1uwEnOAoYuWBIwbH56aWJKRWuSWX5SanFhcYsSRl5+YqJeeX+bE5ZuZk5OZm1qSWuTBGOSZUVJSUGylr19eXq6Xl5yaqQdTqF9QlJ9SmlxSrF8OMUs3GagtsSRVNzc/JTWnWD89Jz8pMUc3DWoFAAwgwZ8OAgAA";
+
+                List<DateValue> series = Arrays.asList(
+                                new DateValue("2025-02-20", "5.42201"),
+                                new DateValue("2025-02-22", "9.29649"),
+                                new DateValue("2025-02-23", "10.2551"),
+                                new DateValue("2025-03-01", "15.2984"),
+                                new DateValue("2025-02-25", "12.9467"),
+                                new DateValue("2025-02-17", "7.10376"),
+                                new DateValue("2025-02-18", "13.0436"),
+                                new DateValue("2025-02-24", "10.7473"),
+                                new DateValue("2025-02-21", "7.52996"),
+                                new DateValue("2025-03-02", "10.8767"),
+                                new DateValue("2025-03-03", "8.33461"),
+                                new DateValue("2025-02-28", "18.5893"),
+                                new DateValue("2025-02-27", "13.3116"),
+                                new DateValue("2025-02-26", "12.8333"),
+                                new DateValue("2025-03-04", "8.8511"),
+                                new DateValue("2025-02-19", "10.1"));
+
+                List<Observation> expected = List.of(Observation.builder()
+                                .variableMeasured("Mean_PrecipitableWater_Atmosphere")
+                                .observationAbout("geoId/sch2915390")
+                                .observations(series)
+                                .observationPeriod("P1D")
+                                .measurementMethod("NOAA_GFS")
+                                .scalingFactor("")
+                                .unit("Millimeter")
+                                .provenance("noaa.gov")
+                                .provenanceUrl("https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast")
+                                .importName("NOAA_GFS_WeatherForecast")
+                                .build());
+
+                List<Observation> actual = CacheReader.parseTimeSeriesRow(row);
+
+                assertEquals(expected, actual);
+        }
+}


### PR DESCRIPTION
* Splitting refactoring the ingestion pipeline into multiple PRs to keep it manageable.
* Keeping the current code in its own package until the refactoring is fully done.
* This PR focuses on refactoring the data classes into its own package.
* For entities, it creates nodes and edges at the outset instead of a wrapper entity.
* For observations, it captures dates and values into typed Java objects instead of strings.
* The refactored CacheReader is only responsible for parsing the cached rows and not deal with pcollections. This makes it possible to test it standalone without requiring a test pipeline.
* Adopts the new schema - object value hash and no id field on edges.