### PR TITLE
Scale observation imports.

### DIFF
--- a/pipeline/ingestion/README.md
+++ b/pipeline/ingestion/README.md
@@ -32,7 +32,7 @@ mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.d
 
 ```shell
 mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.datacommons.ingestion.pipeline.IngestionPipeline \
--Dexec.args="--importGroupVersion=ipcc_2025_04_04_03_46_23 --skipProcessing=SKIP_GRAPH --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=20 --maxNumWorkers=20 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=n2-highmem-16"
+-Dexec.args="--importGroupVersion=ipcc_2025_04_04_03_46_23 --skipProcessing=SKIP_GRAPH --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=50 --maxNumWorkers=100 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
 ```
 
 ## org.datacommons.IngestionPipeline

--- a/pipeline/ingestion/README.md
+++ b/pipeline/ingestion/README.md
@@ -28,11 +28,11 @@ mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.d
 -Dexec.args="--importGroupVersion=ipcc_2025_04_04_03_46_23 --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=50 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
 ```
 
-### Import specific import group while skipping obs
+### Import specific import group while skipping graph
 
 ```shell
 mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.datacommons.ingestion.pipeline.IngestionPipeline \
--Dexec.args="--importGroupVersion=ipcc_2025_04_04_03_46_23 --skipProcessing=SKIP_GRAPH --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=50 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
+-Dexec.args="--importGroupVersion=ipcc_2025_04_04_03_46_23 --skipProcessing=SKIP_GRAPH --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=20 --maxNumWorkers=20 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=n2-highmem-16"
 ```
 
 ## org.datacommons.IngestionPipeline

--- a/pipeline/ingestion/README.md
+++ b/pipeline/ingestion/README.md
@@ -2,25 +2,37 @@
 
 ## org.datacommons.ingestion.pipeline.IngestionPipeline
 
-This module loads all tables (observations, nodes and edges) for all import groups into Spanner.
+This module loads all tables (observations, nodes and edges) for all or specified import groups into Spanner.
 The import group version to load from are fetched from the DC API's version endpoint.
 
-Example usage:
+Example usages:
+
+### Import all import groups
 
 ```shell
 mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.datacommons.ingestion.pipeline.IngestionPipeline \
--Dexec.args="--skipObservations=true --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=50 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
+-Dexec.args="--project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=50 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
 ```
 
-## org.datacommons.ingestion.pipeline.ImportGroupPipeline
-
-This module loads all tables (observations, nodes and edges) from a single import group version into Spanner.
-
-Example usage:
+### Import all import groups while skipping observations
 
 ```shell
-mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.datacommons.ingestion.pipeline.ImportGroupPipeline \
--Dexec.args="--importGroupVersion=auto1d_2025_03_26_02_16_23 --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=5 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
+mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.datacommons.ingestion.pipeline.IngestionPipeline \
+-Dexec.args="--skipProcessing=SKIP_OBS --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=50 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
+```
+
+### Import specific import group
+
+```shell
+mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.datacommons.ingestion.pipeline.IngestionPipeline \
+-Dexec.args="--importGroupVersion=ipcc_2025_04_04_03_46_23 --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=50 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
+```
+
+### Import specific import group while skipping obs
+
+```shell
+mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.datacommons.ingestion.pipeline.IngestionPipeline \
+-Dexec.args="--importGroupVersion=ipcc_2025_04_04_03_46_23 --skipProcessing=SKIP_GRAPH --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=50 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
 ```
 
 ## org.datacommons.IngestionPipeline

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/CacheReader.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/CacheReader.java
@@ -22,49 +22,46 @@ import org.datacommons.proto.ChartStoreOuterClass.ObsTimeSeries.SourceSeries;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * CacheReader is a class that has utility methods to read data from BT cache.
- */
+/** CacheReader is a class that has utility methods to read data from BT cache. */
 public class CacheReader implements Serializable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CacheReader.class);
-    private static final String OUT_ARC_CACHE_PREFIX = "d/m/";
-    private static final String IN_ARC_CACHE_PREFIX = "d/l/";
-    private static final String OBS_TIME_SERIES_CACHE_PREFIX = "d/3/";
-    private static final int CACHE_KEY_PREFIX_SIZE = 4;
-    private static final String CACHE_KEY_VALUE_SEPARATOR_REGEX = ",";
-    private static final String CACHE_KEY_SEPARATOR_REGEX = "\\^";
+  private static final Logger LOGGER = LoggerFactory.getLogger(CacheReader.class);
+  private static final String OUT_ARC_CACHE_PREFIX = "d/m/";
+  private static final String IN_ARC_CACHE_PREFIX = "d/l/";
+  private static final String OBS_TIME_SERIES_CACHE_PREFIX = "d/3/";
+  private static final int CACHE_KEY_PREFIX_SIZE = 4;
+  private static final String CACHE_KEY_VALUE_SEPARATOR_REGEX = ",";
+  private static final String CACHE_KEY_SEPARATOR_REGEX = "\\^";
 
-    private final String gcsBucketId;
-    private final List<String> skipPredicatePrefixes;
+  private final String gcsBucketId;
+  private final List<String> skipPredicatePrefixes;
 
-    public CacheReader(String gcsBucketId, List<String> skipPredicatePrefixes) {
-        this.gcsBucketId = gcsBucketId;
-        this.skipPredicatePrefixes = skipPredicatePrefixes;
+  public CacheReader(String gcsBucketId, List<String> skipPredicatePrefixes) {
+    this.gcsBucketId = gcsBucketId;
+    this.skipPredicatePrefixes = skipPredicatePrefixes;
+  }
+
+  /** Returns the GCS cache path for the import group. */
+  public static String getCachePath(String projectId, String bucketId, String importGroup) {
+    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    Page<Blob> blobs =
+        storage.list(
+            bucketId,
+            Storage.BlobListOption.prefix(importGroup),
+            Storage.BlobListOption.currentDirectory());
+
+    // Currently this fetches the "last" blob in the directory which typically tends
+    // to be the latest.
+    // TODO: Update this code to fetch a specific blob and update the logic to
+    // definitively fetch the latest if none is provided.
+    String prefix = "";
+    for (Blob blob : blobs.iterateAll()) {
+      prefix = blob.getName();
     }
-
-    /**
-     * Returns the GCS cache path for the import group.
-     */
-    public static String getCachePath(String projectId, String bucketId, String importGroup) {
-        Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
-        Page<Blob> blobs = storage.list(
-                bucketId,
-                Storage.BlobListOption.prefix(importGroup),
-                Storage.BlobListOption.currentDirectory());
-
-        // Currently this fetches the "last" blob in the directory which typically tends
-        // to be the latest.
-        // TODO: Update this code to fetch a specific blob and update the logic to
-        // definitively fetch the latest if none is provided.
-        String prefix = "";
-        for (Blob blob : blobs.iterateAll()) {
-            prefix = blob.getName();
-        }
-        if (prefix.isEmpty()) {
-            throw new RuntimeException(String.format("No blobs found for import group: %s", importGroup));
-        }
-        return String.format("gs://%s/%scache.csv*", bucketId, prefix);
+    if (prefix.isEmpty()) {
+      throw new RuntimeException(String.format("No blobs found for import group: %s", importGroup));
     }
+    return String.format("gs://%s/%scache.csv*", bucketId, prefix);
+  }
 
   /**
    * Returns the GCS path for the import group cache in the specified bucket with the specified
@@ -75,165 +72,156 @@ public class CacheReader implements Serializable {
    * <p>e.g. gs://datcom-store/auto1d_2025_03_26_02_16_23/cache.csv*
    */
   public String getImportGroupCachePath(String importGroupVersion) {
-        return String.format("gs://%s/%s/cache.csv*", gcsBucketId, importGroupVersion);
-    }
+    return String.format("gs://%s/%s/cache.csv*", gcsBucketId, importGroupVersion);
+  }
 
-    /**
-     * Parses an arc cache row to extract nodes and edges.
-     */
-    public NodesEdges parseArcRow(String row) {
-        NodesEdges result = new NodesEdges();
+  /** Parses an arc cache row to extract nodes and edges. */
+  public NodesEdges parseArcRow(String row) {
+    NodesEdges result = new NodesEdges();
 
-        // Cache format: <dcid^predicate^type^page>, PagedEntities
-        if (row != null && !row.isEmpty()) {
-            String[] items = row.split(CACHE_KEY_VALUE_SEPARATOR_REGEX);
-            if (items.length == 2) {
-                String key = items[0];
-                String value = items[1];
-                String suffix = key.substring(CACHE_KEY_PREFIX_SIZE);
-                String[] keys = suffix.split(CACHE_KEY_SEPARATOR_REGEX);
-                if (!(value.isEmpty()) && keys.length >= 2) {
-                    String dcid = keys[0];
-                    String predicate = keys[1];
-                    String typeOf = keys[2];
+    // Cache format: <dcid^predicate^type^page>, PagedEntities
+    if (row != null && !row.isEmpty()) {
+      String[] items = row.split(CACHE_KEY_VALUE_SEPARATOR_REGEX);
+      if (items.length == 2) {
+        String key = items[0];
+        String value = items[1];
+        String suffix = key.substring(CACHE_KEY_PREFIX_SIZE);
+        String[] keys = suffix.split(CACHE_KEY_SEPARATOR_REGEX);
+        if (!(value.isEmpty()) && keys.length >= 2) {
+          String dcid = keys[0];
+          String predicate = keys[1];
+          String typeOf = keys[2];
 
-                    // Skip predicates that are in the skip set.
-                    if (skipPredicate(predicate)) {
-                        LOGGER.info("Skipping predicate: {}", predicate);
-                        return result;
-                    }
+          // Skip predicates that are in the skip set.
+          if (skipPredicate(predicate)) {
+            return result;
+          }
 
-                    PagedEntities elist = parseProto(value, PagedEntities.parser());
-                    for (EntityInfo entity : elist.getEntitiesList()) {
-                        String subjectId, objectId, nodeId = "";
-                        // Add a self edge if value is populated.
-                        if (!entity.getValue().isEmpty()) {
-                            subjectId = dcid;
-                            objectId = dcid;
-                            // Terminal edges won't produce any object nodes.
-                        } else {
-                            if (isOutArcCacheRow(row)) {
-                                subjectId = dcid;
-                                objectId = entity.getDcid();
-                                nodeId = entity.getDcid();
-                            } else { // in arc row
-                                subjectId = entity.getDcid();
-                                objectId = dcid;
-                                nodeId = entity.getDcid();
-                            }
-                        }
-
-                        List<String> types = entity.getTypesList();
-                        if (types.isEmpty() && !typeOf.isEmpty()) {
-                            types = Arrays.asList(typeOf);
-                        }
-
-                        // Add node.
-                        if (!nodeId.isEmpty() && !types.isEmpty()) {
-                            result.addNode(Node.builder()
-                                    .subjectId(nodeId)
-                                    .name(entity.getName())
-                                    .types(types)
-                                    .build());
-                        }
-
-                        // Add edge.
-                        if (!subjectId.isEmpty() && !objectId.isEmpty()) {
-                            result.addEdge(Edge.builder()
-                                    .subjectId(subjectId)
-                                    .predicate(predicate)
-                                    .objectId(objectId)
-                                    .objectValue(entity.getValue())
-                                    .provenance(entity.getProvenanceId())
-                                    .build());
-                        }
-                    }
-                }
+          PagedEntities elist = parseProto(value, PagedEntities.parser());
+          for (EntityInfo entity : elist.getEntitiesList()) {
+            String subjectId, objectId, nodeId = "";
+            // Add a self edge if value is populated.
+            if (!entity.getValue().isEmpty()) {
+              subjectId = dcid;
+              objectId = dcid;
+              // Terminal edges won't produce any object nodes.
+            } else {
+              if (isOutArcCacheRow(row)) {
+                subjectId = dcid;
+                objectId = entity.getDcid();
+                nodeId = entity.getDcid();
+              } else { // in arc row
+                subjectId = entity.getDcid();
+                objectId = dcid;
+                nodeId = entity.getDcid();
+              }
             }
-        }
 
-        return result;
-    }
-
-    /**
-     * Parses a time series cache row to extract observations.
-     */
-    public List<Observation> parseTimeSeriesRow(String row) {
-        List<Observation> result = new ArrayList<>();
-
-        // Cache format: <placeId^statVarId>, ChartStore containing ObsTimeSeries.
-        if (row != null && !row.isEmpty()) {
-            String[] items = row.split(CACHE_KEY_VALUE_SEPARATOR_REGEX);
-            if (items.length == 2) {
-                String key = items[0];
-                String value = items[1];
-                String suffix = key.substring(CACHE_KEY_PREFIX_SIZE);
-                String[] keys = suffix.split(CACHE_KEY_SEPARATOR_REGEX);
-                if (!(value.isEmpty()) && keys.length >= 2) {
-                    String variableMeasured = keys[1];
-                    String observationAbout = keys[0];
-                    ChartStore chart = parseProto(value, ChartStore.parser());
-                    for (SourceSeries source : chart.getObsTimeSeries().getSourceSeriesList()) {
-                        Observation.Builder builder = Observation.builder()
-                                .variableMeasured(variableMeasured)
-                                .observationAbout(observationAbout)
-                                .observationPeriod(source.getObservationPeriod())
-                                .measurementMethod(source.getMeasurementMethod())
-                                .scalingFactor(source.getScalingFactor())
-                                .unit(source.getUnit())
-                                .provenance(source.getProvenanceDomain())
-                                .provenanceUrl(source.getProvenanceUrl())
-                                .importName(source.getImportName());
-                        for (Map.Entry<String, Double> e : source.getValMap().entrySet()) {
-                            builder.observation(new DateValue(e.getKey(), e.getValue().toString()));
-                        }
-                        for (Map.Entry<String, String> e : source.getStrValMap().entrySet()) {
-                            builder.observation(new DateValue(e.getKey(), e.getValue()));
-                        }
-                        result.add(builder.build());
-                    }
-                }
+            List<String> types = entity.getTypesList();
+            if (types.isEmpty() && !typeOf.isEmpty()) {
+              types = Arrays.asList(typeOf);
             }
-        }
 
-        return result;
-    }
-
-    private boolean skipPredicate(String predicate) {
-        for (String prefix : skipPredicatePrefixes) {
-            if (predicate.startsWith(prefix)) {
-                return true;
+            // Add node.
+            if (!nodeId.isEmpty() && !types.isEmpty()) {
+              result.addNode(
+                  Node.builder().subjectId(nodeId).name(entity.getName()).types(types).build());
             }
+
+            // Add edge.
+            if (!subjectId.isEmpty() && !objectId.isEmpty()) {
+              result.addEdge(
+                  Edge.builder()
+                      .subjectId(subjectId)
+                      .predicate(predicate)
+                      .objectId(objectId)
+                      .objectValue(entity.getValue())
+                      .provenance(entity.getProvenanceId())
+                      .build());
+            }
+          }
         }
-        return false;
+      }
     }
 
-    /**
-     * Parses a Base64-encoded, GZIP-compressed protobuf message from a cache row
-     * string.
-     */
-    private static <T extends Message> T parseProto(String value, Parser<T> parser) {
-        try (GZIPInputStream gzipInputStream = new GZIPInputStream(
-                new ByteArrayInputStream(Base64.getDecoder().decode(value)))) {
-            return parser.parseFrom(gzipInputStream);
-        } catch (IOException e) {
-            throw new RuntimeException("Error parsing protobuf message: " + e.getMessage(), e);
+    return result;
+  }
+
+  /** Parses a time series cache row to extract observations. */
+  public List<Observation> parseTimeSeriesRow(String row) {
+    List<Observation> result = new ArrayList<>();
+
+    // Cache format: <placeId^statVarId>, ChartStore containing ObsTimeSeries.
+    if (row != null && !row.isEmpty()) {
+      String[] items = row.split(CACHE_KEY_VALUE_SEPARATOR_REGEX);
+      if (items.length == 2) {
+        String key = items[0];
+        String value = items[1];
+        String suffix = key.substring(CACHE_KEY_PREFIX_SIZE);
+        String[] keys = suffix.split(CACHE_KEY_SEPARATOR_REGEX);
+        if (!(value.isEmpty()) && keys.length >= 2) {
+          String variableMeasured = keys[1];
+          String observationAbout = keys[0];
+          ChartStore chart = parseProto(value, ChartStore.parser());
+          for (SourceSeries source : chart.getObsTimeSeries().getSourceSeriesList()) {
+            Observation.Builder builder =
+                Observation.builder()
+                    .variableMeasured(variableMeasured)
+                    .observationAbout(observationAbout)
+                    .observationPeriod(source.getObservationPeriod())
+                    .measurementMethod(source.getMeasurementMethod())
+                    .scalingFactor(source.getScalingFactor())
+                    .unit(source.getUnit())
+                    .provenance(source.getProvenanceDomain())
+                    .provenanceUrl(source.getProvenanceUrl())
+                    .importName(source.getImportName());
+            for (Map.Entry<String, Double> e : source.getValMap().entrySet()) {
+              builder.observation(new DateValue(e.getKey(), e.getValue().toString()));
+            }
+            for (Map.Entry<String, String> e : source.getStrValMap().entrySet()) {
+              builder.observation(new DateValue(e.getKey(), e.getValue()));
+            }
+            result.add(builder.build());
+          }
         }
+      }
     }
 
-    private static final boolean isInArcCacheRow(String row) {
-        return row.startsWith(IN_ARC_CACHE_PREFIX);
-    }
+    return result;
+  }
 
-    private static final boolean isOutArcCacheRow(String row) {
-        return row.startsWith(OUT_ARC_CACHE_PREFIX);
+  private boolean skipPredicate(String predicate) {
+    for (String prefix : skipPredicatePrefixes) {
+      if (predicate.startsWith(prefix)) {
+        return true;
+      }
     }
+    return false;
+  }
 
-    public static final boolean isArcCacheRow(String row) {
-        return isInArcCacheRow(row) || isOutArcCacheRow(row);
+  /** Parses a Base64-encoded, GZIP-compressed protobuf message from a cache row string. */
+  private static <T extends Message> T parseProto(String value, Parser<T> parser) {
+    try (GZIPInputStream gzipInputStream =
+        new GZIPInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(value)))) {
+      return parser.parseFrom(gzipInputStream);
+    } catch (IOException e) {
+      throw new RuntimeException("Error parsing protobuf message: " + e.getMessage(), e);
     }
+  }
 
-    public static final boolean isObsTimeSeriesCacheRow(String row) {
-        return row.startsWith(OBS_TIME_SERIES_CACHE_PREFIX);
-    }
+  private static final boolean isInArcCacheRow(String row) {
+    return row.startsWith(IN_ARC_CACHE_PREFIX);
+  }
+
+  private static final boolean isOutArcCacheRow(String row) {
+    return row.startsWith(OUT_ARC_CACHE_PREFIX);
+  }
+
+  public static final boolean isArcCacheRow(String row) {
+    return isInArcCacheRow(row) || isOutArcCacheRow(row);
+  }
+
+  public static final boolean isObsTimeSeriesCacheRow(String row) {
+    return row.startsWith(OBS_TIME_SERIES_CACHE_PREFIX);
+  }
 }

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/CacheReader.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/CacheReader.java
@@ -172,7 +172,6 @@ public class CacheReader implements Serializable {
                     .measurementMethod(source.getMeasurementMethod())
                     .scalingFactor(source.getScalingFactor())
                     .unit(source.getUnit())
-                    .provenance(source.getProvenanceDomain())
                     .provenanceUrl(source.getProvenanceUrl())
                     .importName(source.getImportName());
             for (Map.Entry<String, Double> e : source.getValMap().entrySet()) {

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Observation.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Observation.java
@@ -1,11 +1,10 @@
 package org.datacommons.ingestion.data;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import org.apache.beam.sdk.coders.DefaultCoder;
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
+import org.datacommons.proto.Storage.Observations;
 
 /** Models a statvar observation time series. */
 @DefaultCoder(AvroCoder.class)
@@ -13,7 +12,7 @@ public class Observation implements Serializable {
 
   private String variableMeasured;
   private String observationAbout;
-  private List<DateValue> observations;
+  private Observations observations;
   private String observationPeriod;
   private String measurementMethod;
   private String unit;
@@ -24,7 +23,7 @@ public class Observation implements Serializable {
   private Observation(Builder builder) {
     this.variableMeasured = builder.variableMeasured;
     this.observationAbout = builder.observationAbout;
-    this.observations = builder.observations;
+    this.observations = builder.observations.build();
     this.observationPeriod = builder.observationPeriod;
     this.measurementMethod = builder.measurementMethod;
     this.unit = builder.unit;
@@ -45,12 +44,8 @@ public class Observation implements Serializable {
     return observationAbout;
   }
 
-  public List<DateValue> getObservations() {
+  public Observations getObservations() {
     return observations;
-  }
-
-  public List<String> getObservationsAsJsonStrings() {
-    return observations.stream().map(DateValue::toJsonString).toList();
   }
 
   public String getObservationPeriod() {
@@ -136,7 +131,7 @@ public class Observation implements Serializable {
   public static class Builder {
     private String variableMeasured = "";
     private String observationAbout = "";
-    private List<DateValue> observations = new ArrayList<>();
+    private Observations.Builder observations = Observations.newBuilder();
     private String observationPeriod = "";
     private String measurementMethod = "";
     private String unit = "";
@@ -154,13 +149,13 @@ public class Observation implements Serializable {
       return this;
     }
 
-    public Builder observation(DateValue dateValue) {
-      this.observations.add(dateValue);
+    public Builder observation(String date, String value) {
+      this.observations.putValues(date, value);
       return this;
     }
 
-    public Builder observations(List<DateValue> observations) {
-      this.observations = observations;
+    public Builder observations(Observations observations) {
+      this.observations = observations.toBuilder();
       return this;
     }
 

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Observation.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Observation.java
@@ -14,7 +14,6 @@ public class Observation implements Serializable {
   private String variableMeasured;
   private String observationAbout;
   private List<DateValue> observations;
-  private String provenance;
   private String observationPeriod;
   private String measurementMethod;
   private String unit;
@@ -26,7 +25,6 @@ public class Observation implements Serializable {
     this.variableMeasured = builder.variableMeasured;
     this.observationAbout = builder.observationAbout;
     this.observations = builder.observations;
-    this.provenance = builder.provenance;
     this.observationPeriod = builder.observationPeriod;
     this.measurementMethod = builder.measurementMethod;
     this.unit = builder.unit;
@@ -53,10 +51,6 @@ public class Observation implements Serializable {
 
   public List<String> getObservationsAsJsonStrings() {
     return observations.stream().map(DateValue::toJsonString).toList();
-  }
-
-  public String getProvenance() {
-    return provenance;
   }
 
   public String getObservationPeriod() {
@@ -91,7 +85,6 @@ public class Observation implements Serializable {
     return Objects.equals(variableMeasured, that.variableMeasured)
         && Objects.equals(observationAbout, that.observationAbout)
         && Objects.equals(observations, that.observations)
-        && Objects.equals(provenance, that.provenance)
         && Objects.equals(observationPeriod, that.observationPeriod)
         && Objects.equals(measurementMethod, that.measurementMethod)
         && Objects.equals(unit, that.unit)
@@ -106,7 +99,6 @@ public class Observation implements Serializable {
         variableMeasured,
         observationAbout,
         observations,
-        provenance,
         observationPeriod,
         measurementMethod,
         unit,
@@ -122,7 +114,6 @@ public class Observation implements Serializable {
             + "variableMeasured='%s', "
             + "observationAbout='%s', "
             + "observations=%s, "
-            + "provenance='%s', "
             + "observationPeriod='%s', "
             + "measurementMethod='%s', "
             + "unit='%s', "
@@ -133,7 +124,6 @@ public class Observation implements Serializable {
         variableMeasured,
         observationAbout,
         observations,
-        provenance,
         observationPeriod,
         measurementMethod,
         unit,
@@ -147,7 +137,6 @@ public class Observation implements Serializable {
     private String variableMeasured = "";
     private String observationAbout = "";
     private List<DateValue> observations = new ArrayList<>();
-    private String provenance = "";
     private String observationPeriod = "";
     private String measurementMethod = "";
     private String unit = "";
@@ -172,11 +161,6 @@ public class Observation implements Serializable {
 
     public Builder observations(List<DateValue> observations) {
       this.observations = observations;
-      return this;
-    }
-
-    public Builder provenance(String provenance) {
-      this.provenance = provenance;
       return this;
     }
 

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/ProtoUtil.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/ProtoUtil.java
@@ -1,0 +1,41 @@
+package org.datacommons.ingestion.data;
+
+import com.google.protobuf.Message;
+import com.google.protobuf.Parser;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+/** Utility functions related to protobuf messages. */
+public final class ProtoUtil {
+  /** Parses a Base64-encoded, GZIP-compressed BT cache protobuf message from a cache row string. */
+  public static <T extends Message> T parseCacheProto(String value, Parser<T> parser) {
+    try (GZIPInputStream gzipInputStream =
+        new GZIPInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(value)))) {
+      return parser.parseFrom(gzipInputStream);
+    } catch (IOException e) {
+      throw new RuntimeException("Error parsing protobuf message: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Serializes the specified proto to be stored in spanner as gzipped bytes.
+   *
+   * <p>Note that we don't Base64 encode them like we do in BT since base64 encoding almost triples
+   * the size.
+   */
+  public static byte[] serializeSpannerProto(Message proto) {
+    try {
+      var out = new ByteArrayOutputStream();
+      try (GZIPOutputStream gout = new GZIPOutputStream(out)) {
+        gout.write(proto.toByteArray());
+      }
+      return out.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException("Error serializing proto: " + e.getMessage(), e);
+    }
+  }
+}

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/ProtoUtil.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/ProtoUtil.java
@@ -22,12 +22,12 @@ public final class ProtoUtil {
   }
 
   /**
-   * Serializes the specified proto to be stored in spanner as gzipped bytes.
+   * Compresses the specified proto to be stored in spanner as gzipped bytes.
    *
    * <p>Note that we don't Base64 encode them like we do in BT since base64 encoding almost triples
    * the size.
    */
-  public static byte[] serializeSpannerProto(Message proto) {
+  public static byte[] compressProto(Message proto) {
     try {
       var out = new ByteArrayOutputStream();
       try (GZIPOutputStream gout = new GZIPOutputStream(out)) {

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
@@ -44,17 +44,17 @@ public interface IngestionPipelineOptions extends PipelineOptions {
 
   void setImportGroupVersion(String importGroupVersion);
 
-  @Description("The number of shards to generate for writing edge mutations.")
+  @Description("The number of shards to generate for writing mutations.")
   @Default.Integer(100)
-  int getNumEdgeShards();
+  int getNumShards();
 
-  void setNumEdgeShards(int numEdgeShards);
+  void setNumShards(int numShards);
 
   @Description("If true, observations will not be ingested.")
-  @Default.Boolean(false)
-  boolean getSkipObservations();
+  @Default.Enum("SKIP_NONE")
+  SkipProcessing getSkipProcessing();
 
-  void setSkipObservations(boolean skipObservations);
+  void setSkipProcessing(SkipProcessing skipProcessing);
 
   @Description("Spanner Observation table name")
   @Default.String("Observation")

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
@@ -50,7 +50,7 @@ public interface IngestionPipelineOptions extends PipelineOptions {
 
   void setNumShards(int numShards);
 
-  @Description("If true, observations will not be ingested.")
+  @Description("The type of processing to be skipped, if any.")
   @Default.Enum("SKIP_NONE")
   SkipProcessing getSkipProcessing();
 

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
@@ -45,7 +45,7 @@ public interface IngestionPipelineOptions extends PipelineOptions {
   void setImportGroupVersion(String importGroupVersion);
 
   @Description("The number of shards to generate for writing mutations.")
-  @Default.Integer(100)
+  @Default.Integer(1000)
   int getNumShards();
 
   void setNumShards(int numShards);

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/SkipProcessing.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/SkipProcessing.java
@@ -1,0 +1,7 @@
+package org.datacommons.ingestion.pipeline;
+
+public enum SkipProcessing {
+  SKIP_NONE,
+  SKIP_OBS,
+  SKIP_GRAPH
+}

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/Transforms.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/Transforms.java
@@ -9,12 +9,16 @@ import java.util.List;
 import java.util.Set;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.*;
 import org.apache.beam.sdk.values.*;
 import org.datacommons.ingestion.data.CacheReader;
 import org.datacommons.ingestion.data.ImportGroupVersions;
 import org.datacommons.ingestion.data.NodesEdges;
 import org.datacommons.ingestion.spanner.SpannerClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Transforms and DoFns for the ingestion pipeline. */
 public class Transforms {
@@ -64,6 +68,116 @@ public class Transforms {
       } else if (CacheReader.isObsTimeSeriesCacheRow(row) && skipProcessing != SKIP_OBS) {
         var obs = cacheReader.parseTimeSeriesRow(row);
         spannerClient.toObservationMutations(obs).forEach(out.get(observations)::output);
+      }
+    }
+  }
+
+  static class CacheRowKVMutationsDoFn extends DoFn<String, KV<String, Mutation>> {
+    private static final Counter DUPLICATE_OBS_COUNTER =
+        Metrics.counter(CacheRowKVMutationsDoFn.class, "dc_duplicate_obs_creation");
+    private static final Counter DUPLICATE_NODES_COUNTER =
+        Metrics.counter(CacheRowKVMutationsDoFn.class, "dc_duplicate_nodes_creation");
+
+    private final CacheReader cacheReader;
+    private final SpannerClient spannerClient;
+    private final SkipProcessing skipProcessing;
+    private final Set<String> seenNodes = new HashSet<>();
+    private final Set<String> seenObs = new HashSet<>();
+
+    private CacheRowKVMutationsDoFn(
+        CacheReader cacheReader, SpannerClient spannerClient, SkipProcessing skipProcessing) {
+      this.cacheReader = cacheReader;
+      this.spannerClient = spannerClient;
+      this.skipProcessing = skipProcessing;
+    }
+
+    @StartBundle
+    public void startBundle() {
+      seenNodes.clear();
+      seenObs.clear();
+    }
+
+    @FinishBundle
+    public void finishBundle() {
+      seenNodes.clear();
+      seenObs.clear();
+    }
+
+    @ProcessElement
+    public void processElement(@Element String row, OutputReceiver<KV<String, Mutation>> out) {
+      if (CacheReader.isArcCacheRow(row) && skipProcessing != SKIP_GRAPH) {
+        NodesEdges nodesEdges = cacheReader.parseArcRow(row);
+        var kvs = spannerClient.toGraphKVMutations(nodesEdges.getNodes(), nodesEdges.getEdges());
+        var filtered = spannerClient.filterGraphKVMutations(kvs, seenNodes);
+        filtered.forEach(out::output);
+
+        var dups = kvs.size() - filtered.size();
+        if (dups > 0) {
+          DUPLICATE_NODES_COUNTER.inc(dups);
+        }
+      } else if (CacheReader.isObsTimeSeriesCacheRow(row) && skipProcessing != SKIP_OBS) {
+        var obs = cacheReader.parseTimeSeriesRow(row);
+        var kvs = spannerClient.toObservationKVMutations(obs);
+        var filtered = spannerClient.filterObservationKVMutations(kvs, seenObs);
+        filtered.forEach(out::output);
+
+        var dups = kvs.size() - filtered.size();
+        if (dups > 0) {
+          DUPLICATE_OBS_COUNTER.inc(dups);
+        }
+      }
+    }
+  }
+
+  static class ExtractKVMutationsDoFn extends DoFn<KV<String, Iterable<Mutation>>, Mutation> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExtractKVMutationsDoFn.class);
+    private static final Counter DUPLICATE_OBS_COUNTER =
+        Metrics.counter(ExtractKVMutationsDoFn.class, "dc_duplicate_obs_extraction");
+    private static final Counter DUPLICATE_NODES_COUNTER =
+        Metrics.counter(ExtractKVMutationsDoFn.class, "dc_duplicate_nodes_extraction");
+
+    private final SpannerClient spannerClient;
+    private final Set<String> seenNodes = new HashSet<>();
+    private final Set<String> seenObs = new HashSet<>();
+
+    public ExtractKVMutationsDoFn(SpannerClient spannerClient) {
+      this.spannerClient = spannerClient;
+    }
+
+    @StartBundle
+    public void startBundle() {
+      seenNodes.clear();
+      seenObs.clear();
+    }
+
+    @FinishBundle
+    public void finishBundle() {
+      seenNodes.clear();
+      seenObs.clear();
+    }
+
+    @ProcessElement
+    public void processElement(
+        @Element KV<String, Iterable<Mutation>> kv, OutputReceiver<Mutation> out) {
+      for (var mutation : kv.getValue()) {
+        if (mutation.getTable().equals(spannerClient.getNodeTableName())) {
+          var subjectId = SpannerClient.getSubjectId(mutation);
+          if (seenNodes.contains(subjectId)) {
+            LOGGER.info("Duplicate node (extraction): {}", subjectId);
+            DUPLICATE_NODES_COUNTER.inc();
+            return;
+          }
+          seenNodes.add(subjectId);
+        } else if (mutation.getTable().equals(spannerClient.getObservationTableName())) {
+          var key = SpannerClient.getFullObservationKey(mutation);
+          if (seenObs.contains(key)) {
+            LOGGER.info("Duplicate observation (extraction): {}", key);
+            DUPLICATE_OBS_COUNTER.inc();
+            return;
+          }
+          seenObs.add(key);
+        }
+        out.output(mutation);
       }
     }
   }
@@ -150,6 +264,22 @@ public class Transforms {
 
     @Override
     public PCollection<Void> expand(PCollection<String> cacheRows) {
+      return groupBy(cacheRows);
+    }
+
+    private PCollection<Void> groupBy(PCollection<String> cacheRows) {
+      var kvs =
+          cacheRows.apply(
+              "CreateMutations",
+              ParDo.of(new CacheRowKVMutationsDoFn(cacheReader, spannerClient, skipProcessing)));
+      var grouped = kvs.apply("GroupMutations", GroupByKey.create());
+      var mutations =
+          grouped.apply("ExtractMutations", ParDo.of(new ExtractKVMutationsDoFn(spannerClient)));
+      var write = mutations.apply("WriteToSpanner", spannerClient.getWriteTransform());
+      return write.getOutput();
+    }
+
+    private PCollection<Void> separateMutations(PCollection<String> cacheRows) {
       TupleTag<Mutation> observations = new TupleTag<>() {};
       TupleTag<KV<String, Mutation>> graph = new TupleTag<>() {};
       CacheRowMutationsDoFn createMutations =

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/Transforms.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/Transforms.java
@@ -22,55 +22,7 @@ import org.slf4j.LoggerFactory;
 
 /** Transforms and DoFns for the ingestion pipeline. */
 public class Transforms {
-
-  /**
-   * DoFn that outputs observation and graph (nodes and edges) mutations for a single cache row.
-   * Both are output as KV<String, Mutation> objects. Observation mutations are keyed by variable.
-   * Graph mutations are keyed by subject ID.
-   */
-  static class CacheRowMutationsDoFn extends DoFn<String, KV<String, Mutation>> {
-    private final CacheReader cacheReader;
-    private final SpannerClient spannerClient;
-    private final TupleTag<KV<String, Mutation>> graph;
-    private final TupleTag<Mutation> observations;
-    private final SkipProcessing skipProcessing;
-    private final Set<String> seenNodes = new HashSet<>();
-
-    private CacheRowMutationsDoFn(
-        CacheReader cacheReader,
-        SpannerClient spannerClient,
-        SkipProcessing skipProcessing,
-        TupleTag<KV<String, Mutation>> graph,
-        TupleTag<Mutation> observations) {
-      this.cacheReader = cacheReader;
-      this.spannerClient = spannerClient;
-      this.skipProcessing = skipProcessing;
-      this.graph = graph;
-      this.observations = observations;
-    }
-
-    @StartBundle
-    public void startBundle() {
-      seenNodes.clear();
-    }
-
-    @FinishBundle
-    public void finishBundle() {
-      seenNodes.clear();
-    }
-
-    @ProcessElement
-    public void processElement(@Element String row, MultiOutputReceiver out) {
-      if (CacheReader.isArcCacheRow(row) && skipProcessing != SKIP_GRAPH) {
-        NodesEdges nodesEdges = cacheReader.parseArcRow(row);
-        var kvs = spannerClient.toGraphKVMutations(nodesEdges.getNodes(), nodesEdges.getEdges());
-        spannerClient.filterGraphKVMutations(kvs, seenNodes).forEach(out.get(graph)::output);
-      } else if (CacheReader.isObsTimeSeriesCacheRow(row) && skipProcessing != SKIP_OBS) {
-        var obs = cacheReader.parseTimeSeriesRow(row);
-        spannerClient.toObservationMutations(obs).forEach(out.get(observations)::output);
-      }
-    }
-  }
+  private static final int MAX_LOG_SAMPLES = 1000;
 
   static class CacheRowKVMutationsDoFn extends DoFn<String, KV<String, Mutation>> {
     private static final Counter DUPLICATE_OBS_COUNTER =
@@ -140,6 +92,9 @@ public class Transforms {
     private final Set<String> seenNodes = new HashSet<>();
     private final Set<String> seenObs = new HashSet<>();
 
+    private int numObsDupsLogged = 0;
+    private int numNodeDupsLogged = 0;
+
     public ExtractKVMutationsDoFn(SpannerClient spannerClient) {
       this.spannerClient = spannerClient;
     }
@@ -163,90 +118,30 @@ public class Transforms {
         if (mutation.getTable().equals(spannerClient.getNodeTableName())) {
           var subjectId = SpannerClient.getSubjectId(mutation);
           if (seenNodes.contains(subjectId)) {
-            LOGGER.info("Duplicate node (extraction): {}", subjectId);
+            if (numNodeDupsLogged < MAX_LOG_SAMPLES) {
+              LOGGER.info("Duplicate node (extraction): {}", subjectId);
+              numNodeDupsLogged++;
+            }
+
             DUPLICATE_NODES_COUNTER.inc();
-            return;
+            continue;
           }
           seenNodes.add(subjectId);
         } else if (mutation.getTable().equals(spannerClient.getObservationTableName())) {
           var key = SpannerClient.getFullObservationKey(mutation);
           if (seenObs.contains(key)) {
-            LOGGER.info("Duplicate observation (extraction): {}", key);
+            if (numObsDupsLogged < MAX_LOG_SAMPLES) {
+              LOGGER.info("Duplicate observation (extraction): {}", key);
+              numObsDupsLogged++;
+            }
+
             DUPLICATE_OBS_COUNTER.inc();
-            return;
+            continue;
           }
           seenObs.add(key);
         }
         out.output(mutation);
       }
-    }
-  }
-
-  static class ExtractGraphMutationsDoFn extends DoFn<KV<String, Mutation>, Mutation> {
-    private final SpannerClient spannerClient;
-    private final Set<String> seenNodes = new HashSet<>();
-
-    public ExtractGraphMutationsDoFn(SpannerClient spannerClient) {
-      this.spannerClient = spannerClient;
-    }
-
-    @StartBundle
-    public void startBundle() {
-      this.seenNodes.clear();
-    }
-
-    @FinishBundle
-    public void finishBundle() {
-      this.seenNodes.clear();
-    }
-
-    @ProcessElement
-    public void processElement(@Element KV<String, Mutation> kv, OutputReceiver<Mutation> out) {
-      var mutation = kv.getValue();
-      var subjectId = SpannerClient.getSubjectId(mutation);
-      if (mutation.getTable().equals(spannerClient.getNodeTableName())) {
-        if (seenNodes.contains(subjectId)) {
-          return;
-        }
-        seenNodes.add(subjectId);
-      }
-      out.output(mutation);
-    }
-  }
-
-  static class ExtractMutationsDoFn extends DoFn<KV<String, Iterable<Mutation>>, Mutation> {
-    private final SpannerClient spannerClient;
-    private final Set<String> seenNodes = new HashSet<>();
-
-    public ExtractMutationsDoFn(SpannerClient spannerClient) {
-      this.spannerClient = spannerClient;
-    }
-
-    @StartBundle
-    public void startBundle() {
-      this.seenNodes.clear();
-    }
-
-    @FinishBundle
-    public void finishBundle() {
-      this.seenNodes.clear();
-    }
-
-    @ProcessElement
-    public void processElement(
-        @Element KV<String, Iterable<Mutation>> kvs, OutputReceiver<Mutation> out) {
-      kvs.getValue()
-          .forEach(
-              mutation -> {
-                if (mutation.getTable().equals(spannerClient.getNodeTableName())) {
-                  var subjectId = SpannerClient.getSubjectId(mutation);
-                  if (seenNodes.contains(subjectId)) {
-                    return;
-                  }
-                  seenNodes.add(subjectId);
-                }
-                out.output(mutation);
-              });
     }
   }
 
@@ -264,6 +159,8 @@ public class Transforms {
 
     @Override
     public PCollection<Void> expand(PCollection<String> cacheRows) {
+      // While a separate method is not required here, doing so makes it easier to develop and test
+      // with other strategies.
       return groupBy(cacheRows);
     }
 
@@ -277,36 +174,6 @@ public class Transforms {
           grouped.apply("ExtractMutations", ParDo.of(new ExtractKVMutationsDoFn(spannerClient)));
       var write = mutations.apply("WriteToSpanner", spannerClient.getWriteTransform());
       return write.getOutput();
-    }
-
-    private PCollection<Void> separateMutations(PCollection<String> cacheRows) {
-      TupleTag<Mutation> observations = new TupleTag<>() {};
-      TupleTag<KV<String, Mutation>> graph = new TupleTag<>() {};
-      CacheRowMutationsDoFn createMutations =
-          new CacheRowMutationsDoFn(
-              cacheReader, spannerClient, skipProcessing, graph, observations);
-
-      PCollectionTuple mutations =
-          cacheRows.apply(
-              "CreateMutations",
-              ParDo.of(createMutations).withOutputTags(graph, TupleTagList.of(observations)));
-
-      // Write graph to spanner.
-      var graphResult =
-          mutations
-              .get(graph)
-              .apply("RedistributeGraphMutations", Redistribute.byKey())
-              .apply(
-                  "ExtractGraphMutations", ParDo.of(new ExtractGraphMutationsDoFn(spannerClient)))
-              .apply("WriteGraphToSpanner", spannerClient.getWriteTransform());
-
-      // Write observations to spanner.
-      var obsResult =
-          mutations.get(observations).apply("WriteObsToSpanner", spannerClient.getWriteTransform());
-
-      var writeResults = PCollectionList.of(graphResult.getOutput()).and(obsResult.getOutput());
-
-      return writeResults.apply("Done", Flatten.pCollections());
     }
   }
 

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
@@ -1,16 +1,15 @@
 package org.datacommons.ingestion.spanner;
 
-import static java.util.Comparator.comparing;
+import static org.datacommons.ingestion.data.ProtoUtil.serializeSpannerProto;
 
+import com.google.cloud.ByteArray;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Options.RpcPriority;
 import com.google.cloud.spanner.Value;
 import com.google.common.base.Joiner;
 import java.io.Serializable;
 import java.util.*;
-import java.util.AbstractMap.SimpleEntry;
 import java.util.stream.Stream;
-import org.apache.beam.sdk.io.gcp.spanner.MutationGroup;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO.Write;
@@ -30,7 +29,6 @@ public class SpannerClient implements Serializable {
   private int numObsDupsLogged = 0;
   private int numNodeDupsLogged = 0;
   private int numEdgeGroupByKeysLogged = 0;
-  private int numObsGroupByKeysLogged = 0;
 
   private final String gcpProjectId;
   private final String spannerInstanceId;
@@ -57,7 +55,7 @@ public class SpannerClient implements Serializable {
         .withInstanceId(spannerInstanceId)
         .withDatabaseId(spannerDatabaseId)
         .withMaxCommitDelay(50)
-        .withBatchSizeBytes(3 * 1024 * 1024)
+        .withBatchSizeBytes(1024 * 1024)
         .withMaxNumMutations(10000)
         .withGroupingFactor(100)
         .withCommitDeadline(Duration.standardSeconds(120));
@@ -110,30 +108,12 @@ public class SpannerClient implements Serializable {
         .set("scaling_factor")
         .to(observation.getScalingFactor())
         .set("observations")
-        .to(Value.jsonArray(observation.getObservationsAsJsonStrings()))
+        .to(ByteArray.copyFrom(serializeSpannerProto(observation.getObservations())))
         .set("import_name")
         .to(observation.getImportName())
         .set("provenance_url")
         .to(observation.getProvenanceUrl())
         .build();
-  }
-
-  public List<KV<String, Mutation>> toNodeMutations(List<Node> nodes) {
-    return nodes.stream().map(node -> KV.of(node.getSubjectId(), toNodeMutation(node))).toList();
-  }
-
-  public List<KV<String, Mutation>> toEdgeMutations(List<Edge> edges) {
-    return edges.stream().map(edge -> KV.of(edge.getSubjectId(), toEdgeMutation(edge))).toList();
-  }
-
-  public List<Mutation> toObservationMutations(List<Observation> observations) {
-    return observations.stream().map(this::toObservationMutation).toList();
-  }
-
-  public List<Mutation> toGraphMutations(List<Node> nodes, List<Edge> edges) {
-    return Stream.concat(
-            nodes.stream().map(this::toNodeMutation), edges.stream().map(this::toEdgeMutation))
-        .toList();
   }
 
   public List<KV<String, Mutation>> toGraphKVMutations(List<Node> nodes, List<Edge> edges) {
@@ -190,77 +170,6 @@ public class SpannerClient implements Serializable {
       filtered.add(kv);
     }
     return filtered;
-  }
-
-  public List<Mutation> sortObservationMutations(List<Mutation> mutations) {
-
-    return mutations.stream()
-        .sorted(comparing(mutation -> getMutationValue(mutation, "variable_measured")))
-        .toList();
-  }
-
-  /**
-   * Creates mutation groups for graph mutations. Each group contains mutations for the same
-   * subject_id.
-   */
-  public List<MutationGroup> toGraphMutationGroups(List<Mutation> mutations) {
-    Map<String, List<Mutation>> mutationMap = new HashMap<>();
-    Set<String> nodeIds = new HashSet<>();
-
-    for (Mutation mutation : mutations) {
-      String subjectId = getSubjectId(mutation);
-
-      // Skip duplicate node mutations for the same subject_id
-      if (mutation.getTable().equals(nodeTableName) && nodeIds.contains(subjectId)) {
-        continue;
-      }
-
-      nodeIds.add(subjectId);
-      mutationMap.computeIfAbsent(subjectId, k -> new ArrayList<>()).add(mutation);
-    }
-
-    List<MutationGroup> mutationGroups = new ArrayList<>();
-    for (List<Mutation> mutationList : mutationMap.values()) {
-      if (mutationList.size() == 1) {
-        mutationGroups.add(MutationGroup.create(mutationList.get(0)));
-      } else {
-        Mutation first = mutationList.get(0);
-        List<Mutation> rest = mutationList.subList(1, mutationList.size());
-        mutationGroups.add(MutationGroup.create(first, rest));
-      }
-    }
-    return mutationGroups;
-  }
-
-  /**
-   * Creates mutation groups for observations. Each group contains mutations for the same variable
-   * and place.
-   */
-  public List<MutationGroup> toObservationMutationGroups(List<Mutation> mutations) {
-    // Map from Pair(variable_measured, observation_about) to mutation.
-    // Using SimpleEntry for representing a pair.
-    Map<SimpleEntry<String, String>, List<Mutation>> mutationMap = new HashMap<>();
-
-    for (Mutation mutation : mutations) {
-      String variableMeasured = mutation.asMap().get("variable_measured").getString();
-      String observationAbout = mutation.asMap().get("observation_about").getString();
-
-      SimpleEntry<String, String> key = new SimpleEntry<>(variableMeasured, observationAbout);
-
-      mutationMap.computeIfAbsent(key, k -> new ArrayList<>()).add(mutation);
-    }
-
-    List<MutationGroup> mutationGroups = new ArrayList<>();
-    for (List<Mutation> mutationList : mutationMap.values()) {
-      if (mutationList.size() == 1) {
-        mutationGroups.add(MutationGroup.create(mutationList.get(0)));
-      } else {
-        Mutation first = mutationList.get(0);
-        List<Mutation> rest = mutationList.subList(1, mutationList.size());
-        mutationGroups.add(MutationGroup.create(first, rest));
-      }
-    }
-    return mutationGroups;
   }
 
   public static String getSubjectId(Mutation mutation) {

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
@@ -55,7 +55,7 @@ public class SpannerClient implements Serializable {
         .withInstanceId(spannerInstanceId)
         .withDatabaseId(spannerDatabaseId)
         .withMaxCommitDelay(50)
-        .withBatchSizeBytes(1024 * 1024)
+        .withBatchSizeBytes(3 * 1024 * 1024)
         .withMaxNumMutations(10000)
         .withGroupingFactor(100)
         .withCommitDeadline(Duration.standardSeconds(120));

--- a/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/CacheReaderTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/CacheReaderTest.java
@@ -2,14 +2,14 @@ package org.datacommons.ingestion.data;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
 import java.util.List;
+import org.datacommons.proto.Storage.Observations;
 import org.junit.Test;
 
 public class CacheReaderTest {
   @Test
   public void testParseArcRow_outArcwithNode() {
-    CacheReader reader = new CacheReader(List.of());
+    CacheReader reader = newCacheReader();
     String row =
         "d/m/Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person^measuredProperty^Property^0,H4sIAAAAAAAAAOPS5WJNzi/NK5GCUEqyKcn6SYnFqfoepbmJeUGpiSmJSTmpwSWJJWGJRcWCDGDwwR4AejAnwDgAAAA=";
 
@@ -34,7 +34,7 @@ public class CacheReaderTest {
 
   @Test
   public void testParseArcRow_outArcwithoutNode() {
-    CacheReader reader = new CacheReader(List.of());
+    CacheReader reader = newCacheReader();
     String row =
         "d/m/Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person^name^^0,H4sIAAAAAAAAAONqYFSSTUnWT0osTtX3KM1NzAtKTUxJTMpJDS5JLAlLLCrWig9ILUpOzStJTE9VCM8vylYISs1JLElNUQjIqCzOTE7MUXBMLsksyyyp1FHwzU9JLQJKwoUU/IsUPFITyyoRIo65+XnpCgH5BaVAYzLz8wQZwOCDPQA1JajOjAAAAA==";
 
@@ -59,7 +59,7 @@ public class CacheReaderTest {
 
   @Test
   public void testParseArcRow_inArc() {
-    CacheReader reader = new CacheReader(List.of());
+    CacheReader reader = newCacheReader();
     String row =
         "d/l/dc/d/UnitedNationsUn_SdgIndicatorsDatabase^isPartOf^Provenance^0,H4sIAAAAAAAAAOPS4GIL9YsPdnGX4ktJ1k9KLE7Vh/CV0PiCDGDwwR4AhMbiaDMAAAA=";
 
@@ -87,7 +87,7 @@ public class CacheReaderTest {
 
   @Test
   public void testParseArcRow_skipPredicate() {
-    CacheReader reader = new CacheReader(List.of("measuredProperty"));
+    CacheReader reader = newCacheReader(List.of("measuredProperty"));
     String row =
         "d/m/Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person^measuredProperty^Property^0,H4sIAAAAAAAAAOPS5WJNzi/NK5GCUEqyKcn6SYnFqfoepbmJeUGpiSmJSTmpwSWJJWGJRcWCDGDwwR4AejAnwDgAAAA=";
 
@@ -100,28 +100,29 @@ public class CacheReaderTest {
 
   @Test
   public void testParseTimeSeriesRow() {
-    CacheReader reader = new CacheReader(List.of("measuredProperty"));
+    CacheReader reader = newCacheReader();
     String row =
         "d/3/geoId/sch2915390^Mean_PrecipitableWater_Atmosphere,H4sIAAAAAAAAAOPqZpHi8igtykmtVAjS9TT6w8wlysVlZGBkqmtgpGtkIMgQvilZeYOoA4qwkeBcve7Os9OVUIWNBQOzZ5XPaVJBEjbWNTAU3OHQ9Oj4DD1U1aaCIvbH7mx9ookibGguqN6xi98hSwZV2EJQ0Mxmb5CYFqohJoJMszik59WpogobCq49MOHqWjk5VJcYCRac67h074AqqrCxoOOVWoag1QqohlgIpnUkx96ZZoQqbC7IeI+Js2s+mkvMBKub9X2WrdJENdtE0N9BOPHwZkVU71gKGoOBioMUh5+/o2O8u1uwEnOAoYuWBIwbH56aWJKRWuSWX5SanFhcYsSRl5+YqJeeX+bE5ZuZk5OZm1qSWuTBGOSZUVJSUGylr19eXq6Xl5yaqQdTqF9QlJ9SmlxSrF8OMUs3GagtsSRVNzc/JTWnWD89Jz8pMUc3DWoFAAwgwZ8OAgAA";
 
-    List<DateValue> series =
-        Arrays.asList(
-            new DateValue("2025-02-20", "5.42201"),
-            new DateValue("2025-02-22", "9.29649"),
-            new DateValue("2025-02-23", "10.2551"),
-            new DateValue("2025-03-01", "15.2984"),
-            new DateValue("2025-02-25", "12.9467"),
-            new DateValue("2025-02-17", "7.10376"),
-            new DateValue("2025-02-18", "13.0436"),
-            new DateValue("2025-02-24", "10.7473"),
-            new DateValue("2025-02-21", "7.52996"),
-            new DateValue("2025-03-02", "10.8767"),
-            new DateValue("2025-03-03", "8.33461"),
-            new DateValue("2025-02-28", "18.5893"),
-            new DateValue("2025-02-27", "13.3116"),
-            new DateValue("2025-02-26", "12.8333"),
-            new DateValue("2025-03-04", "8.8511"),
-            new DateValue("2025-02-19", "10.1"));
+    Observations series =
+        Observations.newBuilder()
+            .putValues("2025-02-20", "5.42201")
+            .putValues("2025-02-22", "9.29649")
+            .putValues("2025-02-23", "10.2551")
+            .putValues("2025-03-01", "15.2984")
+            .putValues("2025-02-25", "12.9467")
+            .putValues("2025-02-17", "7.10376")
+            .putValues("2025-02-18", "13.0436")
+            .putValues("2025-02-24", "10.7473")
+            .putValues("2025-02-21", "7.52996")
+            .putValues("2025-03-02", "10.8767")
+            .putValues("2025-03-03", "8.33461")
+            .putValues("2025-02-28", "18.5893")
+            .putValues("2025-02-27", "13.3116")
+            .putValues("2025-02-26", "12.8333")
+            .putValues("2025-03-04", "8.8511")
+            .putValues("2025-02-19", "10.1")
+            .build();
 
     List<Observation> expected =
         List.of(
@@ -133,7 +134,6 @@ public class CacheReaderTest {
                 .measurementMethod("NOAA_GFS")
                 .scalingFactor("")
                 .unit("Millimeter")
-                .provenance("noaa.gov")
                 .provenanceUrl(
                     "https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast")
                 .importName("NOAA_GFS_WeatherForecast")
@@ -142,5 +142,13 @@ public class CacheReaderTest {
     List<Observation> actual = reader.parseTimeSeriesRow(row);
 
     assertEquals(expected, actual);
+  }
+
+  private static CacheReader newCacheReader() {
+    return newCacheReader(List.of());
+  }
+
+  private static CacheReader newCacheReader(List<String> skipPredicatePrefixes) {
+    return new CacheReader("datcom-store", skipPredicatePrefixes);
   }
 }

--- a/pipeline/model/src/main/proto/storage.proto
+++ b/pipeline/model/src/main/proto/storage.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package org.datacommons.proto;
+
+// Includes protos that are used in spanner storage.
+// The protos are typically gzipped and stored in a bytes column.
+
+// Observations represent the observations (time series) stored in the observations column in the Observation table.
+message Observations {
+  // Map from date to value.
+  // Examples: "2024" -> "123", "2025-05" -> "-456.78"
+  map<string, string> values = 1;
+}


### PR DESCRIPTION
* Combined handling of graph and obs vs forking them earlier.
* Uses group-by for both.
* Experimented and landed on grouping keys that work well for the respective tables.
* Updated the default number of shards to a value that provides a good balance of batch size and distribution.