### PR TITLE
[Ingestion pipeline] Ingest observations without GroupByKey

### DIFF
--- a/pipeline/ingestion/README.md
+++ b/pipeline/ingestion/README.md
@@ -11,28 +11,29 @@ Example usages:
 
 ```shell
 mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.datacommons.ingestion.pipeline.IngestionPipeline \
--Dexec.args="--project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=50 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
+-Dexec.args="--project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=60 --maxNumWorkers=60 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=n2-custom-16-262144-ext"
 ```
 
 ### Import all import groups while skipping observations
 
 ```shell
 mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.datacommons.ingestion.pipeline.IngestionPipeline \
--Dexec.args="--skipProcessing=SKIP_OBS --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=50 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
+-Dexec.args="--skipProcessing=SKIP_OBS --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=30 --maxNumWorkers=40 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
 ```
 
 ### Import specific import group
 
 ```shell
 mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.datacommons.ingestion.pipeline.IngestionPipeline \
--Dexec.args="--importGroupVersion=ipcc_2025_04_04_03_46_23 --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=50 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
+-Dexec.args="--importGroupVersion=ipcc_2025_04_04_03_46_23 --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=20 --maxNumWorkers=30 \
+ --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
 ```
 
 ### Import specific import group while skipping graph
 
 ```shell
 mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.datacommons.ingestion.pipeline.IngestionPipeline \
--Dexec.args="--importGroupVersion=ipcc_2025_04_04_03_46_23 --skipProcessing=SKIP_GRAPH --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=50 --maxNumWorkers=100 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
+-Dexec.args="--importGroupVersion=ipcc_2025_04_04_03_46_23 --skipProcessing=SKIP_GRAPH --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=20 --maxNumWorkers=20 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
 ```
 
 ## org.datacommons.IngestionPipeline
@@ -49,7 +50,7 @@ When running any pipeline, various debug options are possible. Below are some th
 
 ```shell
 # Log hot keys
---hotKeyLoggingEnabled
+--hotKeyLoggingEnabled=true
 
 # Enable profiler
 --dataflowServiceOptions=enable_google_cloud_profiler

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
@@ -45,7 +45,7 @@ public interface IngestionPipelineOptions extends PipelineOptions {
   void setImportGroupVersion(String importGroupVersion);
 
   @Description("The number of shards to generate for writing mutations.")
-  @Default.Integer(1000)
+  @Default.Integer(1)
   int getNumShards();
 
   void setNumShards(int numShards);

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/Transforms.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/Transforms.java
@@ -26,49 +26,59 @@ public class Transforms {
         Metrics.counter(CacheRowKVMutationsDoFn.class, "dc_duplicate_obs_creation");
     private static final Counter DUPLICATE_NODES_COUNTER =
         Metrics.counter(CacheRowKVMutationsDoFn.class, "dc_duplicate_nodes_creation");
+    private static final Counter DUPLICATE_EDGES_COUNTER =
+        Metrics.counter(CacheRowKVMutationsDoFn.class, "dc_duplicate_edges_creation");
 
     private final CacheReader cacheReader;
     private final SpannerClient spannerClient;
     private final SkipProcessing skipProcessing;
+    private final TupleTag<KV<String, Mutation>> graphTag;
+    private final TupleTag<KV<String, Mutation>> observationTag;
     private final Set<String> seenNodes = new HashSet<>();
+    private final Set<String> seenEdges = new HashSet<>();
     private final Set<String> seenObs = new HashSet<>();
 
     private CacheRowKVMutationsDoFn(
-        CacheReader cacheReader, SpannerClient spannerClient, SkipProcessing skipProcessing) {
+        CacheReader cacheReader,
+        SpannerClient spannerClient,
+        SkipProcessing skipProcessing,
+        TupleTag<KV<String, Mutation>> graphTag,
+        TupleTag<KV<String, Mutation>> observationTag) {
       this.cacheReader = cacheReader;
       this.spannerClient = spannerClient;
       this.skipProcessing = skipProcessing;
+      this.graphTag = graphTag;
+      this.observationTag = observationTag;
     }
 
     @StartBundle
     public void startBundle() {
       seenNodes.clear();
       seenObs.clear();
+      seenEdges.clear();
     }
 
     @FinishBundle
     public void finishBundle() {
       seenNodes.clear();
       seenObs.clear();
+      seenEdges.clear();
     }
 
     @ProcessElement
-    public void processElement(@Element String row, OutputReceiver<KV<String, Mutation>> out) {
+    public void processElement(@Element String row, MultiOutputReceiver out) {
       if (CacheReader.isArcCacheRow(row) && skipProcessing != SKIP_GRAPH) {
         NodesEdges nodesEdges = cacheReader.parseArcRow(row);
         var kvs = spannerClient.toGraphKVMutations(nodesEdges.getNodes(), nodesEdges.getEdges());
-        var filtered = spannerClient.filterGraphKVMutations(kvs, seenNodes);
-        filtered.forEach(out::output);
-
-        var dups = kvs.size() - filtered.size();
-        if (dups > 0) {
-          DUPLICATE_NODES_COUNTER.inc(dups);
-        }
+        var filtered =
+            spannerClient.filterGraphKVMutations(
+                kvs, seenNodes, seenEdges, DUPLICATE_NODES_COUNTER, DUPLICATE_EDGES_COUNTER);
+        filtered.forEach(out.get(graphTag)::output);
       } else if (CacheReader.isObsTimeSeriesCacheRow(row) && skipProcessing != SKIP_OBS) {
         var obs = cacheReader.parseTimeSeriesRow(row);
         var kvs = spannerClient.toObservationKVMutations(obs);
         var filtered = spannerClient.filterObservationKVMutations(kvs, seenObs);
-        filtered.forEach(out::output);
+        filtered.forEach(out.get(observationTag)::output);
 
         var dups = kvs.size() - filtered.size();
         if (dups > 0) {
@@ -83,6 +93,8 @@ public class Transforms {
         Metrics.counter(ExtractKVMutationsDoFn.class, "dc_duplicate_obs_extraction");
     private static final Counter DUPLICATE_NODES_COUNTER =
         Metrics.counter(ExtractKVMutationsDoFn.class, "dc_duplicate_nodes_extraction");
+    private static final Counter DUPLICATE_EDGES_COUNTER =
+        Metrics.counter(ExtractKVMutationsDoFn.class, "dc_duplicate_edges_extraction");
 
     private final SpannerClient spannerClient;
 
@@ -91,6 +103,7 @@ public class Transforms {
     // These sets are used to detect and remove duplicates in a bundle.
     private final Set<String> seenNodes = new HashSet<>();
     private final Set<String> seenObs = new HashSet<>();
+    private final Set<String> seenEdges = new HashSet<>();
 
     public ExtractKVMutationsDoFn(SpannerClient spannerClient) {
       this.spannerClient = spannerClient;
@@ -100,12 +113,14 @@ public class Transforms {
     public void startBundle() {
       seenNodes.clear();
       seenObs.clear();
+      seenEdges.clear();
     }
 
     @FinishBundle
     public void finishBundle() {
       seenNodes.clear();
       seenObs.clear();
+      seenEdges.clear();
     }
 
     @ProcessElement
@@ -119,6 +134,14 @@ public class Transforms {
             continue;
           }
           seenNodes.add(subjectId);
+        }
+        if (mutation.getTable().equals(spannerClient.getEdgeTableName())) {
+          var edgeKey = SpannerClient.getEdgeKey(mutation);
+          if (seenEdges.contains(edgeKey)) {
+            DUPLICATE_EDGES_COUNTER.inc();
+            continue;
+          }
+          seenEdges.add(edgeKey);
         } else if (mutation.getTable().equals(spannerClient.getObservationTableName())) {
           var key = SpannerClient.getFullObservationKey(mutation);
           if (seenObs.contains(key)) {
@@ -148,18 +171,55 @@ public class Transforms {
     public PCollection<Void> expand(PCollection<String> cacheRows) {
       // While a separate method is not required here, doing so makes it easier to develop and test
       // with other strategies.
-      return groupBy(cacheRows);
+      // return groupBy(cacheRows);
+      return groupByGraphOnly(cacheRows);
     }
 
     private PCollection<Void> groupBy(PCollection<String> cacheRows) {
+      var observationTag = new TupleTag<KV<String, Mutation>>() {};
+      var graphTag = new TupleTag<KV<String, Mutation>>() {};
       var kvs =
           cacheRows.apply(
               "CreateMutations",
-              ParDo.of(new CacheRowKVMutationsDoFn(cacheReader, spannerClient, skipProcessing)));
-      var grouped = kvs.apply("GroupMutations", GroupByKey.create());
+              ParDo.of(
+                      new CacheRowKVMutationsDoFn(
+                          cacheReader, spannerClient, skipProcessing, graphTag, observationTag))
+                  .withOutputTags(graphTag, TupleTagList.of(observationTag)));
+      var merge =
+          PCollectionList.of(kvs.get(graphTag))
+              .and(kvs.get(observationTag))
+              .apply("MergeKVs", Flatten.<KV<String, Mutation>>pCollections());
+      var grouped = merge.apply("GroupMutations", GroupByKey.create());
       var mutations =
           grouped.apply("ExtractMutations", ParDo.of(new ExtractKVMutationsDoFn(spannerClient)));
       var write = mutations.apply("WriteToSpanner", spannerClient.getWriteTransform());
+      return write.getOutput();
+    }
+
+    private PCollection<Void> groupByGraphOnly(PCollection<String> cacheRows) {
+      var observationTag = new TupleTag<KV<String, Mutation>>() {};
+      var graphTag = new TupleTag<KV<String, Mutation>>() {};
+      var kvs =
+          cacheRows.apply(
+              "CreateMutations",
+              ParDo.of(
+                      new CacheRowKVMutationsDoFn(
+                          cacheReader, spannerClient, skipProcessing, graphTag, observationTag))
+                  .withOutputTags(graphTag, TupleTagList.of(observationTag)));
+
+      var observations =
+          kvs.get(observationTag).apply("ExtractObservationMutations", Values.create());
+
+      var graph =
+          kvs.get(graphTag)
+              .apply("GroupGraphMutations", GroupByKey.create())
+              .apply("ExtractGraphMutations", ParDo.of(new ExtractKVMutationsDoFn(spannerClient)));
+
+      var write =
+          PCollectionList.of(graph)
+              .and(observations)
+              .apply("MergeMutations", Flatten.<Mutation>pCollections())
+              .apply("WriteToSpanner", spannerClient.getWriteTransform());
       return write.getOutput();
     }
   }

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/Transforms.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/Transforms.java
@@ -34,6 +34,7 @@ public class Transforms {
     private final SkipProcessing skipProcessing;
     private final TupleTag<KV<String, Mutation>> graphTag;
     private final TupleTag<KV<String, Mutation>> observationTag;
+    // TODO: Explore filtering duplicates across all bundles within a JVM.
     private final Set<String> seenNodes = new HashSet<>();
     private final Set<String> seenEdges = new HashSet<>();
     private final Set<String> seenObs = new HashSet<>();
@@ -209,7 +210,7 @@ public class Transforms {
 
       var observations =
           kvs.get(observationTag).apply("ExtractObservationMutations", Values.create());
-
+      // TODO: Explore emitting protos instead of mutations to reduce shuffle cost.
       var graph =
           kvs.get(graphTag)
               .apply("GroupGraphMutations", GroupByKey.create())


### PR DESCRIPTION
Changes
- Use GBK only for graph mutations. Observations can be written directly.
- Limit default sharding to be 1. This helps in co-locating all rows for a subject-id in same bundle -> same spanner batch -> less splits per batch
- Filter duplicate edges before and after GBK
- Update spanner IO config for better throughput