### PR TITLE
Fix misnamed property in nodes.py

### DIFF
--- a/simple/stats/nodes.py
+++ b/simple/stats/nodes.py
@@ -225,7 +225,7 @@ class Nodes:
     if re.fullmatch(_DCID_PATTERN, dcid):
       return dcid
     self._entity_type_generated_id_count += 1
-    return f"{_CUSTOM_ENTITY_TYPE_ID_PREFIX}{self._event_entity_generated_id_count}"
+    return f"{_CUSTOM_ENTITY_TYPE_ID_PREFIX}{self._entity_generated_id_count}"
 
   def group(self, group_path: str) -> StatVarGroup | None:
     if not group_path:


### PR DESCRIPTION
This is one step to fix https://b.corp.google.com/issues/388590765. The custom entity type still fails because of the regex, but at least now custom entities can be created with prefixes.