### PR TITLE
Populate facet_id and is_dc_aggregate fields.

### DIFF
--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Observation.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Observation.java
@@ -1,14 +1,17 @@
 package org.datacommons.ingestion.data;
 
-import java.io.Serializable;
 import java.util.Objects;
-import org.apache.beam.sdk.coders.DefaultCoder;
-import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
+
 import org.datacommons.proto.Storage.Observations;
 
-/** Models a statvar observation time series. */
-@DefaultCoder(AvroCoder.class)
-public class Observation implements Serializable {
+/**
+ * Models a statvar observation time series.
+ * 
+ * This class is used to store the result of
+ * parsing a time series row in memory. It is not inserted into the pipeline.
+ * 
+ */
+public class Observation {
 
   private String variableMeasured;
   private String observationAbout;
@@ -19,6 +22,8 @@ public class Observation implements Serializable {
   private String scalingFactor;
   private String importName;
   private String provenanceUrl;
+  private String facetId;
+  private boolean isDcAggregate;
 
   private Observation(Builder builder) {
     this.variableMeasured = builder.variableMeasured;
@@ -30,6 +35,8 @@ public class Observation implements Serializable {
     this.scalingFactor = builder.scalingFactor;
     this.importName = builder.importName;
     this.provenanceUrl = builder.provenanceUrl;
+    this.facetId = builder.facetId;
+    this.isDcAggregate = builder.isDcAggregate;
   }
 
   public static Builder builder() {
@@ -72,59 +79,12 @@ public class Observation implements Serializable {
     return provenanceUrl;
   }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    Observation that = (Observation) o;
-    return Objects.equals(variableMeasured, that.variableMeasured)
-        && Objects.equals(observationAbout, that.observationAbout)
-        && Objects.equals(observations, that.observations)
-        && Objects.equals(observationPeriod, that.observationPeriod)
-        && Objects.equals(measurementMethod, that.measurementMethod)
-        && Objects.equals(unit, that.unit)
-        && Objects.equals(scalingFactor, that.scalingFactor)
-        && Objects.equals(importName, that.importName)
-        && Objects.equals(provenanceUrl, that.provenanceUrl);
+  public String getFacetId() {
+    return facetId;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        variableMeasured,
-        observationAbout,
-        observations,
-        observationPeriod,
-        measurementMethod,
-        unit,
-        scalingFactor,
-        importName,
-        provenanceUrl);
-  }
-
-  @Override
-  public String toString() {
-    return String.format(
-        "Observation{"
-            + "variableMeasured='%s', "
-            + "observationAbout='%s', "
-            + "observations=%s, "
-            + "observationPeriod='%s', "
-            + "measurementMethod='%s', "
-            + "unit='%s', "
-            + "scalingFactor='%s', "
-            + "importName='%s', "
-            + "provenanceUrl='%s'"
-            + "}",
-        variableMeasured,
-        observationAbout,
-        observations,
-        observationPeriod,
-        measurementMethod,
-        unit,
-        scalingFactor,
-        importName,
-        provenanceUrl);
+  public boolean isDcAggregate() {
+    return isDcAggregate;
   }
 
   // Builder for Observation
@@ -138,6 +98,8 @@ public class Observation implements Serializable {
     private String scalingFactor = "";
     private String importName = "";
     private String provenanceUrl = "";
+    private String facetId = "";
+    private boolean isDcAggregate = false;
 
     public Builder variableMeasured(String variableMeasured) {
       this.variableMeasured = variableMeasured;
@@ -174,6 +136,11 @@ public class Observation implements Serializable {
       return this;
     }
 
+    public Builder isDcAggregate(boolean isDcAggregate) {
+      this.isDcAggregate = isDcAggregate;
+      return this;
+    }
+
     public Builder scalingFactor(String scalingFactor) {
       this.scalingFactor = scalingFactor;
       return this;
@@ -190,6 +157,14 @@ public class Observation implements Serializable {
     }
 
     public Observation build() {
+      this.facetId = String
+          .valueOf(
+              Objects.hash(
+                  importName,
+                  measurementMethod,
+                  observationPeriod,
+                  scalingFactor,
+                  unit));
       return new Observation(this);
     }
   }

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
@@ -3,6 +3,7 @@ package org.datacommons.ingestion.spanner;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
+import org.datacommons.ingestion.data.Observation;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +21,6 @@ import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.values.KV;
 import org.datacommons.ingestion.data.Edge;
 import org.datacommons.ingestion.data.Node;
-import org.datacommons.ingestion.data.Observation;
 import org.joda.time.Duration;
 
 import com.google.cloud.ByteArray;

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
@@ -1,19 +1,17 @@
 package org.datacommons.ingestion.spanner;
 
-import com.google.cloud.ByteArray;
-import com.google.cloud.spanner.Mutation;
-import com.google.cloud.spanner.Mutation.WriteBuilder;
-import com.google.cloud.spanner.Value;
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
+
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO.Write;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO.WriteGrouped;
@@ -24,6 +22,13 @@ import org.datacommons.ingestion.data.Edge;
 import org.datacommons.ingestion.data.Node;
 import org.datacommons.ingestion.data.Observation;
 import org.joda.time.Duration;
+
+import com.google.cloud.ByteArray;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Mutation.WriteBuilder;
+import com.google.cloud.spanner.Value;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
 
 public class SpannerClient implements Serializable {
   // Decrease batch size for observations (bigger rows)
@@ -139,6 +144,8 @@ public class SpannerClient implements Serializable {
         .to(observation.getVariableMeasured())
         .set("observation_about")
         .to(observation.getObservationAbout())
+        .set("facet_id")
+        .to(observation.getFacetId())
         .set("observation_period")
         .to(observation.getObservationPeriod())
         .set("measurement_method")
@@ -153,6 +160,8 @@ public class SpannerClient implements Serializable {
         .to(observation.getImportName())
         .set("provenance_url")
         .to(observation.getProvenanceUrl())
+        .set("is_dc_aggregate")
+        .to(observation.isDcAggregate())
         .build();
   }
 

--- a/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/CacheReaderTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/CacheReaderTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 import org.datacommons.proto.Storage.Observations;
+import org.datacommons.ingestion.data.Observation;
 import org.junit.Test;
 
 public class CacheReaderTest {

--- a/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/CacheReaderTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/CacheReaderTest.java
@@ -86,19 +86,6 @@ public class CacheReaderTest {
   }
 
   @Test
-  public void testParseArcRow_skipPredicate() {
-    CacheReader reader = newCacheReader(List.of("measuredProperty"));
-    String row =
-        "d/m/Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person^measuredProperty^Property^0,H4sIAAAAAAAAAOPS5WJNzi/NK5GCUEqyKcn6SYnFqfoepbmJeUGpiSmJSTmpwSWJJWGJRcWCDGDwwR4AejAnwDgAAAA=";
-
-    NodesEdges expected = new NodesEdges();
-
-    NodesEdges actual = reader.parseArcRow(row);
-
-    assertEquals(expected, actual);
-  }
-
-  @Test
   public void testParseTimeSeriesRow() {
     CacheReader reader = newCacheReader();
     String row =
@@ -145,10 +132,6 @@ public class CacheReaderTest {
   }
 
   private static CacheReader newCacheReader() {
-    return newCacheReader(List.of());
-  }
-
-  private static CacheReader newCacheReader(List<String> skipPredicatePrefixes) {
-    return new CacheReader("datcom-store", skipPredicatePrefixes);
+      return new CacheReader("datcom-store");
   }
 }


### PR DESCRIPTION
* Adds the 2 fields.
* Does not add edge rows yet. Will do that in a follow-on once we've agreed on the schema.
* The new observation table schema looks like this:

```
CREATE TABLE
  Observation ( variable_measured STRING(1024) NOT NULL,
    observation_about STRING(1024) NOT NULL,
    observations `org.datacommons.proto.Observations` NOT NULL,
    facet_id STRING(64),
    import_name STRING(1024) NOT NULL,
    observation_period STRING(1024),
    measurement_method STRING(1024),
    unit STRING(1024),
    scaling_factor STRING(1024),
    provenance_url STRING(1024) NOT NULL,
    is_dc_aggregate BOOL DEFAULT (FALSE),
    )
PRIMARY KEY
  (variable_measured,
    observation_about,
    facet_id);
```