### PR TITLE
Fix tests by incorporating the new indexes.

### DIFF
--- a/simple/tests/stats/db_test.py
+++ b/simple/tests/stats/db_test.py
@@ -81,6 +81,11 @@ _CURRENT_IMPORT_TUPLE = ("2023-01-01 00:00:00", "SUCCESS",
 
 _KEY_VALUE = ("k1", "v1")
 
+_INDEXES = [('observations_entity_variable', 'observations'),
+            ('triples_subject_id', 'triples'),
+            ('triples_subject_id_predicate', 'triples'),
+            ('observations_variable', 'observations')]
+
 
 class TestDb(unittest.TestCase):
 
@@ -108,7 +113,7 @@ class TestDb(unittest.TestCase):
     actual_indexes = db.execute(
         "select name, tbl_name from sqlite_master where type = 'index'"
     ).fetchall()
-    self.assertListEqual(actual_indexes, indexes)
+    self.assertListEqual(sorted(actual_indexes), sorted(indexes))
 
     db.close()
 
@@ -147,8 +152,7 @@ class TestDb(unittest.TestCase):
           observations=list(map(lambda x: x.db_tuple(), _OBSERVATIONS)),
           key_values=[_KEY_VALUE],
           imports=[_CURRENT_IMPORT_TUPLE],
-          indexes=[('observations_entity_variable', 'observations'),
-                   ('triples_subject_id', 'triples')])
+          indexes=_INDEXES)
 
   @freeze_time("2023-01-01")
   def test_sql_db_schema_update(self):
@@ -171,8 +175,7 @@ class TestDb(unittest.TestCase):
           observations=_OLD_OBSERVATION_TUPLES_AFTER_UPDATE,
           key_values=[_KEY_VALUE],
           imports=[_OLD_IMPORT_TUPLE],
-          indexes=[('observations_entity_variable', 'observations'),
-                   ('triples_subject_id', 'triples')])
+          indexes=_INDEXES)
 
   @freeze_time("2023-01-01")
   def test_sql_db_reimport_with_schema_update(self):
@@ -204,8 +207,7 @@ class TestDb(unittest.TestCase):
           observations=list(map(lambda x: x.db_tuple(), _OBSERVATIONS)),
           key_values=[_KEY_VALUE],
           imports=[_OLD_IMPORT_TUPLE, _CURRENT_IMPORT_TUPLE],
-          indexes=[('observations_entity_variable', 'observations'),
-                   ('triples_subject_id', 'triples')])
+          indexes=_INDEXES)
 
   @freeze_time("2023-01-01")
   def test_sql_db_reimport_without_schema_update(self):
@@ -238,8 +240,7 @@ class TestDb(unittest.TestCase):
           observations=list(map(lambda x: x.db_tuple(), _OBSERVATIONS)),
           key_values=[_KEY_VALUE],
           imports=[_DIFFERENT_IMPORT_TUPLE, _CURRENT_IMPORT_TUPLE],
-          indexes=[('observations_entity_variable', 'observations'),
-                   ('triples_subject_id', 'triples')])
+          indexes=_INDEXES)
 
   @freeze_time("2023-01-01")
   def test_main_dc_db(self):

--- a/simple/tests/stats/test_data/runner/expected/config_driven/datacommons.sql
+++ b/simple/tests/stats/test_data/runner/expected/config_driven/datacommons.sql
@@ -160,4 +160,6 @@ INSERT INTO "triples" VALUES('country/USA','typeOf','Country','');
 INSERT INTO "triples" VALUES('country/IND','typeOf','Country','');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
+CREATE INDEX observations_variable on observations (variable);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/expected/config_with_wildcards/datacommons.sql
+++ b/simple/tests/stats/test_data/runner/expected/config_with_wildcards/datacommons.sql
@@ -108,4 +108,6 @@ INSERT INTO "triples" VALUES('country/USA','typeOf','Country','');
 INSERT INTO "triples" VALUES('country/IND','typeOf','Country','');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
+CREATE INDEX observations_variable on observations (variable);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/expected/empty_initialized_db/datacommons.sql
+++ b/simple/tests/stats/test_data/runner/expected/empty_initialized_db/datacommons.sql
@@ -28,4 +28,6 @@ CREATE TABLE triples (
 );
 CREATE INDEX observations_entity_variable on observations (entity, variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
+CREATE INDEX observations_variable on observations (variable);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/expected/generate_svg_hierarchy/datacommons.sql
+++ b/simple/tests/stats/test_data/runner/expected/generate_svg_hierarchy/datacommons.sql
@@ -88,4 +88,6 @@ INSERT INTO "triples" VALUES('c/g/Person_Gender-Male','specializationOf','c/g/Pe
 INSERT INTO "triples" VALUES('some_var2','memberOf','c/g/Person_Gender-Male','');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
+CREATE INDEX observations_variable on observations (variable);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/expected/input_dir_driven/datacommons.sql
+++ b/simple/tests/stats/test_data/runner/expected/input_dir_driven/datacommons.sql
@@ -168,4 +168,6 @@ INSERT INTO "triples" VALUES('country/USA','typeOf','Country','');
 INSERT INTO "triples" VALUES('country/IND','typeOf','Country','');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
+CREATE INDEX observations_variable on observations (variable);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/expected/input_dir_driven_with_existing_old_schema_data/datacommons.sql
+++ b/simple/tests/stats/test_data/runner/expected/input_dir_driven_with_existing_old_schema_data/datacommons.sql
@@ -163,5 +163,7 @@ INSERT INTO "triples" VALUES('country/ESH','typeOf','Country','');
 INSERT INTO "triples" VALUES('country/USA','typeOf','Country','');
 INSERT INTO "triples" VALUES('country/IND','typeOf','Country','');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
+CREATE INDEX observations_variable on observations (variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/expected/namespace_prefixes/datacommons.sql
+++ b/simple/tests/stats/test_data/runner/expected/namespace_prefixes/datacommons.sql
@@ -61,4 +61,6 @@ INSERT INTO "triples" VALUES('country/FAKE2','typeOf','FakeType2','');
 INSERT INTO "triples" VALUES('country/FAKE3','typeOf','FakeType2','');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
+CREATE INDEX observations_variable on observations (variable);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/expected/remote_entity_types/datacommons.sql
+++ b/simple/tests/stats/test_data/runner/expected/remote_entity_types/datacommons.sql
@@ -75,4 +75,6 @@ INSERT INTO "triples" VALUES('country/FAKE3','typeOf','FakeType2','');
 INSERT INTO "triples" VALUES('country/FAKE4','typeOf','FakeType1','');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
+CREATE INDEX observations_variable on observations (variable);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/expected/schema_update_only/datacommons.sql
+++ b/simple/tests/stats/test_data/runner/expected/schema_update_only/datacommons.sql
@@ -32,5 +32,7 @@ INSERT INTO "triples" VALUES('sub1','name','','name1');
 INSERT INTO "triples" VALUES('sub2','typeOf','StatisticalVariable','');
 INSERT INTO "triples" VALUES('sub2','name','','name2');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
+CREATE INDEX observations_variable on observations (variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/expected/sv_nl_sentences/datacommons.sql
+++ b/simple/tests/stats/test_data/runner/expected/sv_nl_sentences/datacommons.sql
@@ -62,4 +62,6 @@ INSERT INTO "triples" VALUES('c/p/1','source','c/s/1','');
 INSERT INTO "triples" VALUES('c/p/1','url','','http://source1.com/provenance1');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
+CREATE INDEX observations_variable on observations (variable);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/expected/topic_nl_sentences/datacommons.sql
+++ b/simple/tests/stats/test_data/runner/expected/topic_nl_sentences/datacommons.sql
@@ -69,4 +69,6 @@ INSERT INTO "triples" VALUES('c/p/1','source','c/s/1','');
 INSERT INTO "triples" VALUES('c/p/1','url','','http://source1.com/provenance1');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
+CREATE INDEX observations_variable on observations (variable);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/expected/with_subdirs_excluded/datacommons.sql
+++ b/simple/tests/stats/test_data/runner/expected/with_subdirs_excluded/datacommons.sql
@@ -102,4 +102,6 @@ INSERT INTO "triples" VALUES('country/USA','typeOf','Country','');
 INSERT INTO "triples" VALUES('country/IND','typeOf','Country','');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
+CREATE INDEX observations_variable on observations (variable);
 COMMIT;

--- a/simple/tests/stats/test_data/runner/expected/with_subdirs_included/datacommons.sql
+++ b/simple/tests/stats/test_data/runner/expected/with_subdirs_included/datacommons.sql
@@ -168,4 +168,6 @@ INSERT INTO "triples" VALUES('country/USA','typeOf','Country','');
 INSERT INTO "triples" VALUES('country/IND','typeOf','Country','');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
+CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);
+CREATE INDEX observations_variable on observations (variable);
 COMMIT;


### PR DESCRIPTION
* I was looking into the [test failures](https://pantheon.corp.google.com/cloud-build/builds/989579a7-8b01-4727-9ac2-6429d0596bda?project=datcom-ci&pli=1&e=13803378&mods=-monitoring_api_staging&invt=Abyoyg&inv=1) in @kmoscoe's PR and found that the goldens didn't include the new indexes that are now created.
* This fix is to incorporate those indexes in our tests. 