### PR TITLE
Create obs series nodes and edges.

### DIFF
--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
@@ -57,6 +57,12 @@ public interface IngestionPipelineOptions extends PipelineOptions {
 
   void setSkipProcessing(SkipProcessing skipProcessing);
 
+  @Description("Whether to write observation graph to Spanner.")
+  @Default.Boolean(false)
+  boolean getWriteObsGraph();
+
+  void setWriteObsGraph(boolean writeObsGraph);
+
   @Description("Spanner Observation table name")
   @Default.String("Observation")
   String getSpannerObservationTableName();

--- a/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/CacheReaderTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/CacheReaderTest.java
@@ -126,9 +126,52 @@ public class CacheReaderTest {
                 .importName("NOAA_GFS_WeatherForecast")
                 .build());
 
+    NodesEdges expectedGraph = new NodesEdges()
+            .addNode(
+                    Node.builder()
+                            .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755143")
+                            .name("Mean Precipitable Water Atmosphere | geoId/sch2915390 | 870755143")
+                            .types(List.of("StatVarObsSeries"))
+                            .build())
+            .addEdge(
+                    Edge.builder()
+                            .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755143")
+                            .predicate("variableMeasured")
+                            .objectId("Mean_PrecipitableWater_Atmosphere")
+                            .objectValue("")
+                            .provenance("dc/base/NOAA_GFS_WeatherForecast")
+                            .build())
+            .addEdge(
+                    Edge.builder()
+                            .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755143")
+                            .predicate("observationAbout")
+                            .objectId("geoId/sch2915390")
+                            .objectValue("")
+                            .provenance("dc/base/NOAA_GFS_WeatherForecast")
+                            .build())
+            .addEdge(
+                    Edge.builder()
+                            .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755143")
+                            .predicate("name")
+                            .objectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755143")
+                            .objectValue("Mean_PrecipitableWater_Atmosphere | geoId/sch2915390 | 870755143")
+                            .provenance("dc/base/NOAA_GFS_WeatherForecast")
+                            .build())
+            .addEdge(
+                    Edge.builder()
+                            .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755143")
+                            .predicate("typeOf")
+                            .objectId("StatVarObsSeries")
+                            .objectValue("")
+                            .provenance("dc/base/NOAA_GFS_WeatherForecast")
+                            .build());
+                    
+
     List<Observation> actual = reader.parseTimeSeriesRow(row);
 
     assertEquals(expected, actual);
+
+    assertEquals(expectedGraph, actual.get(0).getObsGraph());
   }
 
   private static CacheReader newCacheReader() {


### PR DESCRIPTION
* Creates 1 node and 4 edges for each time series.
* Using the type `StatVarObsSeries` for these nodes. We'll need this type to be defined in the schema.
* Currently creates 4 edges for each obs series - name, type, variable measured and observation about.
  + We can add any other edges we need in this PR or later.
*  Currently, the obs series DCID is used for nodes and edges but is not recorded in the Observation table.
   + We can add it later if there's a use case for it.
* This feature is behind a flag (`--writeObsGraph`, `false` by default) until we decide we want to do this or not for sure.