### PR TITLE
Always generate embeddings for both SVs and topics.

### DIFF
--- a/simple/stats/config.py
+++ b/simple/stats/config.py
@@ -53,7 +53,6 @@ _ROW_ENTITY_TYPE_FIELD = "rowEntityType"
 _ENTITY_COLUMNS = "entityColumns"
 _ENTITIES_FIELD = "entities"
 _GROUP_STAT_VARS_BY_PROPERTY = "groupStatVarsByProperty"
-_GENERATE_TOPICS = "generateTopics"
 _OBSERVATION_PROPERTIES = "observationProperties"
 _INCLUDE_INPUT_SUBDIRS_PROPERTY = "includeInputSubdirs"
 
@@ -187,9 +186,6 @@ class Config:
       if special_file_name:
         special_files[special_file_type] = special_file_name
     return special_files
-
-  def generate_topics(self) -> bool:
-    return self.data.get(_GENERATE_TOPICS) or False
 
   def _per_file_config(self, input_file: File) -> dict:
     """ Looks up the config for a given file.

--- a/simple/stats/runner.py
+++ b/simple/stats/runner.py
@@ -220,22 +220,20 @@ class Runner:
 
   def _generate_nl_artifacts(self):
     triples: list[Triple] = []
-    # Get topic triples if generating topics else get SV triples.
-    generate_topics = self.config.generate_topics()
-    if generate_topics:
-      triples = self.db.select_triples_by_subject_type(sc.TYPE_TOPIC)
-    else:
-      triples = self.db.select_triples_by_subject_type(
-          sc.TYPE_STATISTICAL_VARIABLE)
+    topic_triples = self.db.select_triples_by_subject_type(sc.TYPE_TOPIC)
+    sv_triples = self.db.select_triples_by_subject_type(
+        sc.TYPE_STATISTICAL_VARIABLE)
+    triples = topic_triples + sv_triples
 
     # Generate sentences.
     nl.generate_nl_sentences(triples, self.nl_dir)
 
     # If generating topics, fetch svpg triples as well and generate topic cache
-    if generate_topics:
-      triples = triples + self.db.select_triples_by_subject_type(
+    if topic_triples:
+      sv_peer_group_triples = self.db.select_triples_by_subject_type(
           sc.TYPE_STAT_VAR_PEER_GROUP)
-      nl.generate_topic_cache(triples, self.nl_dir)
+      topic_cache_triples = topic_triples + sv_peer_group_triples
+      nl.generate_topic_cache(topic_cache_triples, self.nl_dir)
 
   def _generate_svg_hierarchy(self):
     if self.mode == RunMode.MAIN_DC:

--- a/simple/tests/stats/test_data/nl/expected/sv_and_topic_triples/custom_catalog.yaml
+++ b/simple/tests/stats/test_data/nl/expected/sv_and_topic_triples/custom_catalog.yaml
@@ -1,0 +1,13 @@
+indexes:
+  user_all_minilm_mem:
+    embeddings_path: //fake/path/embeddings/embeddings.csv
+    model: ft-final-v20230717230459-all-MiniLM-L6-v2
+    source_path: //fake/path
+    store_type: MEMORY
+models:
+  ft-final-v20230717230459-all-MiniLM-L6-v2:
+    gcs_folder: gs://datcom-nl-models/ft_final_v20230717230459.all-MiniLM-L6-v2
+    score_threshold: 0.5
+    type: LOCAL
+    usage: EMBEDDINGS
+version: '1'

--- a/simple/tests/stats/test_data/nl/expected/sv_and_topic_triples/custom_dc_topic_cache.json
+++ b/simple/tests/stats/test_data/nl/expected/sv_and_topic_triples/custom_dc_topic_cache.json
@@ -1,0 +1,65 @@
+{
+ "nodes": [
+  {
+   "dcid": [
+    "topic_with_search_descriptions"
+   ],
+   "typeOf": [
+    "Topic"
+   ],
+   "name": [
+    "Name should NOT be used"
+   ],
+   "relevantVariableList": [
+    "var1",
+    "var2"
+   ]
+  },
+  {
+   "dcid": [
+    "topic_with_name_only"
+   ],
+   "typeOf": [
+    "Topic"
+   ],
+   "name": [
+    "Name should be used"
+   ],
+   "relevantVariableList": [
+    "var3",
+    "var4"
+   ]
+  },
+  {
+   "dcid": [
+    "topic_with_no_sentence_props"
+   ],
+   "typeOf": [
+    "Topic"
+   ],
+   "relevantVariableList": [
+    "var5",
+    "var6",
+    "var7",
+    "var8"
+   ]
+  },
+  {
+   "dcid": [
+    "svpg1"
+   ],
+   "typeOf": [
+    "StatVarPeerGroup"
+   ],
+   "name": [
+    "SVPG 1"
+   ],
+   "memberList": [
+    "var1",
+    "var2",
+    "var3",
+    "var4"
+   ]
+  }
+ ]
+}

--- a/simple/tests/stats/test_data/nl/expected/sv_and_topic_triples/sentences.csv
+++ b/simple/tests/stats/test_data/nl/expected/sv_and_topic_triples/sentences.csv
@@ -1,0 +1,5 @@
+dcid,sentence
+sv_with_search_descriptions,SV search description1;SV search description2
+sv_with_name_only,Name should be used
+topic_with_search_descriptions,Topic search description1;Topic search description2
+topic_with_name_only,Name should be used

--- a/simple/tests/stats/test_data/nl/input/sv_and_topic_triples.csv
+++ b/simple/tests/stats/test_data/nl/input/sv_and_topic_triples.csv
@@ -1,0 +1,28 @@
+subject_id,predicate,object_id,object_value
+sv_with_search_descriptions,typeOf,StatisticalVariable,
+sv_with_search_descriptions,name,,Name should NOT be used
+sv_with_search_descriptions,searchDescription,,SV search description1
+sv_with_search_descriptions,searchDescription,,SV search description2
+sv_with_name_only,typeOf,StatisticalVariable,
+sv_with_name_only,name,,Name should be used
+sv_with_no_sentence_props,typeOf,StatisticalVariable,
+sv_with_no_sentence_props,description,,Descriptions are NOT used for embeddings
+topic_with_search_descriptions,typeOf,Topic,
+topic_with_search_descriptions,name,,Name should NOT be used
+topic_with_search_descriptions,searchDescription,,Topic search description1
+topic_with_search_descriptions,searchDescription,,Topic search description2
+topic_with_search_descriptions,relevantVariable,var1,
+topic_with_search_descriptions,relevantVariable,var2,
+topic_with_name_only,typeOf,Topic,
+topic_with_name_only,name,,Name should be used
+topic_with_name_only,relevantVariableList,,"var3,var4"
+topic_with_no_sentence_props,typeOf,Topic,
+topic_with_no_sentence_props,description,,Descriptions are NOT used for embeddings
+topic_with_no_sentence_props,relevantVariable,var5,
+topic_with_no_sentence_props,relevantVariable,var6,
+topic_with_no_sentence_props,relevantVariableList,,"var7,var8"
+svpg1,typeOf,StatVarPeerGroup,
+svpg1,name,,SVPG 1
+svpg1,member,var1,
+svpg1,member,var2,
+svpg1,memberList,,"var3,var4"

--- a/simple/tests/stats/test_data/runner/expected/sv_nl_sentences/nl/custom_dc_topic_cache.json
+++ b/simple/tests/stats/test_data/runner/expected/sv_nl_sentences/nl/custom_dc_topic_cache.json
@@ -1,0 +1,26 @@
+{
+ "nodes": [
+  {
+   "dcid": [
+    "topic1"
+   ],
+   "typeOf": [
+    "Topic"
+   ],
+   "name": [
+    "Topic1 Name"
+   ]
+  },
+  {
+   "dcid": [
+    "topic2"
+   ],
+   "typeOf": [
+    "Topic"
+   ],
+   "name": [
+    "Topic2 Name"
+   ]
+  }
+ ]
+}

--- a/simple/tests/stats/test_data/runner/expected/sv_nl_sentences/nl/sentences.csv
+++ b/simple/tests/stats/test_data/runner/expected/sv_nl_sentences/nl/sentences.csv
@@ -1,3 +1,5 @@
 dcid,sentence
+topic1,Topic1 Name
+topic2,Topic2 Search Description1;Topic2 Search Description2
 var1,Variable1 Name
 var2,Variable2 Search Description1;Variable2 Search Description2

--- a/simple/tests/stats/test_data/runner/expected/topic_nl_sentences/nl/sentences.csv
+++ b/simple/tests/stats/test_data/runner/expected/topic_nl_sentences/nl/sentences.csv
@@ -1,3 +1,5 @@
 dcid,sentence
 topic1,Topic1 Name
 topic2,Topic2 Search Description1;Topic2 Search Description2
+var1,Variable1 Name
+var2,Variable2 Search Description1;Variable2 Search Description2

--- a/simple/tests/stats/test_data/runner/input/topic_nl_sentences/config.json
+++ b/simple/tests/stats/test_data/runner/input/topic_nl_sentences/config.json
@@ -13,6 +13,5 @@
         "Provenance1": "http://source1.com/provenance1"
       }
     }
-  },
-  "generateTopics": true
+  }
 }


### PR DESCRIPTION
* Always generates embeddings for both SVs and topics if they are present.
* The topic json will be generated only if topics are present.
* Removes the `generateTopics` config field.
   + Existence of it won't cause issues, it will just be ignored.
   + @kmoscoe - if this field is documented, we should remove it.
   + @dwnoble - UN might be specifying this field in their `config.json`. Like I mentioned, it should not be an issue but best to remove it since it will be ignored hereon.