### PR TITLE
Chore: Update protobuf version to 3.21.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <protocArtifact>com.google.protobuf:protoc:3.17.3</protocArtifact>
+                            <protocArtifact>com.google.protobuf:protoc:3.21.12</protocArtifact>
                             <inputDirectories>
                                 <include>src/main/proto</include>
                             </inputDirectories>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>[3.2.0, 3.10)</version>
+            <version>3.21.12</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
-            <version>3.7.1</version>
+            <version>3.21.12</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>[3.2.0, 3.10)</version>
+            <version>3.21.12</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
-            <version>3.7.1</version>
+            <version>3.21.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This upgrade is necessary to fix test failures on Mac Silicon devices caused by an incompatible `protoc` version.