### PR TITLE
Spanner graph ingestion utils

### DIFF
--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/GraphReader.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/GraphReader.java
@@ -1,0 +1,121 @@
+package org.datacommons.ingestion.data;
+
+import com.google.cloud.spanner.Mutation;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.datacommons.ingestion.spanner.SpannerClient;
+import org.datacommons.proto.Mcf.McfGraph;
+import org.datacommons.proto.Mcf.McfGraph.PropertyValues;
+import org.datacommons.proto.Mcf.McfGraph.TypedValue;
+import org.datacommons.proto.Mcf.McfOptimizedGraph;
+import org.datacommons.proto.Mcf.McfStatVarObsSeries.StatVarObs;
+import org.datacommons.proto.Storage.Observations;
+import org.datacommons.util.GraphUtils;
+
+public class GraphReader implements Serializable {
+  public static List<Node> graphToNodes(McfGraph graph) {
+    List<Node> nodes = new ArrayList<>();
+    for (Map.Entry<String, PropertyValues> entry : graph.getNodesMap().entrySet()) {
+      PropertyValues pvs = entry.getValue();
+      if (!GraphUtils.isObservation(pvs)) {
+        Map<String, McfGraph.Values> pv = pvs.getPvsMap();
+        Node.Builder node = Node.builder();
+        node.subjectId(entry.getKey());
+        node.name(GraphUtils.getPropertyValue(pv, "name"));
+        node.types(GraphUtils.getPropertyValues(pv, "typeOf"));
+        nodes.add(node.build());
+      }
+    }
+    return nodes;
+  }
+
+  public static List<Edge> graphToEdges(McfGraph graph) {
+    List<Edge> edges = new ArrayList<>();
+    for (Map.Entry<String, PropertyValues> nodeEntry : graph.getNodesMap().entrySet()) {
+      PropertyValues pvs = nodeEntry.getValue();
+      if (!GraphUtils.isObservation(pvs)) {
+        Map<String, McfGraph.Values> pv = pvs.getPvsMap();
+        String subjectId = nodeEntry.getKey(); // Use the map key as the subjectId
+        for (Map.Entry<String, McfGraph.Values> entry : pv.entrySet()) { // Iterate over properties
+          for (TypedValue val : entry.getValue().getTypedValuesList()) {
+            Edge.Builder edge = Edge.builder();
+            edge.subjectId(subjectId);
+            edge.predicate(entry.getKey());
+            edge.objectId(val.getValue());
+            edges.add(edge.build());
+          }
+        }
+      }
+    }
+    return edges;
+  }
+
+  public static Observation graphToObservations(McfOptimizedGraph graph) {
+    Observation.Builder obs = Observation.builder();
+    obs.observationAbout(graph.getSvObsSeries().getKey().getObservationAbout());
+    obs.observationPeriod(graph.getSvObsSeries().getKey().getObservationPeriod());
+    obs.measurementMethod(graph.getSvObsSeries().getKey().getMeasurementMethod());
+    obs.variableMeasured(graph.getSvObsSeries().getKey().getVariableMeasured());
+    obs.unit(graph.getSvObsSeries().getKey().getUnit());
+    obs.scalingFactor(graph.getSvObsSeries().getKey().getScalingFactor());
+    Observations.Builder ob = Observations.newBuilder();
+    for (StatVarObs svo : graph.getSvObsSeries().getSvObsListList()) {
+      if (svo.hasNumber()) {
+        ob.putValues(svo.getDate(), Double.toString(svo.getNumber()));
+      } else if (svo.hasText()) {
+        ob.putValues(svo.getDate(), svo.getText());
+      }
+    }
+    obs.observations(ob.build());
+    return obs.build();
+  }
+
+  public static PCollection<KV<String, Mutation>> graphToObservations(
+      PCollection<McfOptimizedGraph> graph, SpannerClient spannerClient) {
+    return graph.apply(
+        "GraphToObs",
+        ParDo.of(
+            new DoFn<McfOptimizedGraph, KV<String, Mutation>>() {
+              @ProcessElement
+              public void processElement(
+                  @Element McfOptimizedGraph element,
+                  OutputReceiver<KV<String, Mutation>> receiver) {
+                Observation observations = graphToObservations(element);
+                List<KV<String, Mutation>> obs =
+                    spannerClient.toObservationKVMutations(List.of(observations));
+                obs.stream()
+                    .forEach(
+                        e -> {
+                          receiver.output(e);
+                        });
+              }
+            }));
+  }
+
+  public static PCollection<KV<String, Mutation>> graphToNodeEdges(
+      PCollection<McfGraph> graph, SpannerClient spannerClient) {
+    return graph.apply(
+        "GrapphToNodeEdge",
+        ParDo.of(
+            new DoFn<McfGraph, KV<String, Mutation>>() {
+              @ProcessElement
+              public void processElement(
+                  @Element McfGraph element, OutputReceiver<KV<String, Mutation>> receiver) {
+                List<Edge> edges = graphToEdges(element);
+                List<Node> nodes = graphToNodes(element);
+                List<KV<String, Mutation>> obs = spannerClient.toGraphKVMutations(nodes, edges);
+                obs.stream()
+                    .forEach(
+                        e -> {
+                          receiver.output(e);
+                        });
+              }
+            }));
+  }
+}

--- a/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/GraphReaderTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/GraphReaderTest.java
@@ -174,17 +174,23 @@ public class GraphReaderTest {
                 .subjectId("dcid_subject")
                 .predicate("name")
                 .objectId("Subject Node")
+                .objectValue("Subject Node")
                 .build(),
-            Edge.builder().subjectId("dcid_subject").predicate("typeOf").objectId("Class").build(),
+            Edge.builder()
+                .subjectId("dcid_subject")
+                .predicate("typeOf")
+                .objectId("dcid:Class")
+                .build(),
             Edge.builder()
                 .subjectId("dcid_subject")
                 .predicate("containedInPlace")
-                .objectId("geoId/06")
+                .objectId("dcid:geoId/06")
                 .build(),
             Edge.builder()
                 .subjectId("dcid_subject")
                 .predicate("description")
                 .objectId("A test description")
+                .objectValue("A test description")
                 .build());
 
     List<Edge> actualEdges = GraphReader.graphToEdges(graph);
@@ -193,7 +199,8 @@ public class GraphReaderTest {
     Comparator<Edge> edgeComparator =
         Comparator.comparing(Edge::getSubjectId)
             .thenComparing(Edge::getPredicate)
-            .thenComparing(Edge::getObjectId);
+            .thenComparing(Edge::getObjectId)
+            .thenComparing(Edge::getObjectValue);
     actualEdges.sort(edgeComparator);
     expectedEdges.sort(edgeComparator);
 

--- a/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/GraphReaderTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/GraphReaderTest.java
@@ -1,0 +1,247 @@
+package org.datacommons.ingestion.data;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import org.datacommons.proto.Mcf.McfGraph;
+import org.datacommons.proto.Mcf.McfGraph.PropertyValues;
+import org.datacommons.proto.Mcf.McfGraph.TypedValue;
+import org.datacommons.proto.Mcf.McfOptimizedGraph;
+import org.datacommons.proto.Mcf.McfStatVarObsSeries;
+import org.datacommons.proto.Mcf.McfStatVarObsSeries.StatVarObs;
+import org.datacommons.proto.Mcf.McfType;
+import org.datacommons.proto.Mcf.ValueType;
+import org.datacommons.proto.Storage.Observations;
+import org.junit.Test;
+
+public class GraphReaderTest {
+
+  @Test
+  public void testGraphToNodes() {
+    McfGraph graph =
+        McfGraph.newBuilder()
+            .setType(McfType.INSTANCE_MCF)
+            .putNodes(
+                "dcid0",
+                PropertyValues.newBuilder()
+                    .putPvs(
+                        "name",
+                        McfGraph.Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setType(ValueType.TEXT)
+                                    .setValue("Node Zero"))
+                            .build())
+                    .putPvs(
+                        "typeOf",
+                        McfGraph.Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setType(ValueType.RESOLVED_REF)
+                                    .setValue("Class"))
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setType(ValueType.RESOLVED_REF)
+                                    .setValue("Thing"))
+                            .build())
+                    .build())
+            .putNodes(
+                "dcid1",
+                PropertyValues.newBuilder()
+                    .putPvs(
+                        "name",
+                        McfGraph.Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setType(ValueType.TEXT)
+                                    .setValue("Node One"))
+                            .build())
+                    .putPvs(
+                        "typeOf",
+                        McfGraph.Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setType(ValueType.RESOLVED_REF)
+                                    .setValue("Property"))
+                            .build())
+                    .build())
+            .putNodes(
+                "dcid_obs", // This should be skipped as it's an observation
+                PropertyValues.newBuilder()
+                    .putPvs(
+                        "typeOf",
+                        McfGraph.Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setType(ValueType.RESOLVED_REF)
+                                    .setValue("StatVarObservation"))
+                            .build())
+                    .build())
+            .putNodes(
+                "dcid2", // Node with no name or types
+                PropertyValues.newBuilder().build())
+            .build();
+
+    List<Node> expectedNodes =
+        Arrays.asList(
+            Node.builder()
+                .subjectId("dcid0")
+                .name("Node Zero")
+                .types(List.of("Class", "Thing"))
+                .build(),
+            Node.builder().subjectId("dcid1").name("Node One").types(List.of("Property")).build(),
+            Node.builder().subjectId("dcid2").name("").types(Collections.emptyList()).build());
+
+    List<Node> actualNodes = GraphReader.graphToNodes(graph);
+
+    // Sort both lists for consistent comparison, as map iteration order is not guaranteed.
+    Comparator<Node> nodeComparator = Comparator.comparing(Node::getSubjectId);
+    actualNodes.sort(nodeComparator);
+    expectedNodes.sort(nodeComparator);
+
+    assertEquals(expectedNodes.size(), actualNodes.size());
+    for (int i = 0; i < expectedNodes.size(); i++) {
+      Node expected = expectedNodes.get(i);
+      Node actual = actualNodes.get(i);
+      assertEquals(expected.getSubjectId(), actual.getSubjectId());
+      assertEquals(expected.getName(), actual.getName());
+      assertArrayEquals(expected.getTypes().toArray(), actual.getTypes().toArray());
+    }
+  }
+
+  @Test
+  public void testGraphToEdges() {
+    McfGraph graph =
+        McfGraph.newBuilder()
+            .setType(McfType.INSTANCE_MCF)
+            .putNodes(
+                "dcid_subject",
+                PropertyValues.newBuilder()
+                    .putPvs(
+                        "name",
+                        McfGraph.Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setType(ValueType.TEXT)
+                                    .setValue("Subject Node"))
+                            .build())
+                    .putPvs(
+                        "typeOf",
+                        McfGraph.Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setType(ValueType.RESOLVED_REF)
+                                    .setValue("Class"))
+                            .build())
+                    .putPvs(
+                        "containedInPlace",
+                        McfGraph.Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setType(ValueType.RESOLVED_REF)
+                                    .setValue("geoId/06"))
+                            .build())
+                    .putPvs(
+                        "description",
+                        McfGraph.Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setType(ValueType.TEXT)
+                                    .setValue("A test description"))
+                            .build())
+                    .build())
+            .putNodes(
+                "dcid_obs", // This should be skipped as it's an observation
+                PropertyValues.newBuilder()
+                    .putPvs(
+                        "typeOf",
+                        McfGraph.Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setType(ValueType.RESOLVED_REF)
+                                    .setValue("StatVarObservation"))
+                            .build())
+                    .build())
+            .build();
+
+    List<Edge> expectedEdges =
+        Arrays.asList(
+            Edge.builder()
+                .subjectId("dcid_subject")
+                .predicate("name")
+                .objectId("Subject Node")
+                .build(),
+            Edge.builder().subjectId("dcid_subject").predicate("typeOf").objectId("Class").build(),
+            Edge.builder()
+                .subjectId("dcid_subject")
+                .predicate("containedInPlace")
+                .objectId("geoId/06")
+                .build(),
+            Edge.builder()
+                .subjectId("dcid_subject")
+                .predicate("description")
+                .objectId("A test description")
+                .build());
+
+    List<Edge> actualEdges = GraphReader.graphToEdges(graph);
+
+    // Sort both lists for consistent comparison
+    Comparator<Edge> edgeComparator =
+        Comparator.comparing(Edge::getSubjectId)
+            .thenComparing(Edge::getPredicate)
+            .thenComparing(Edge::getObjectId);
+    actualEdges.sort(edgeComparator);
+    expectedEdges.sort(edgeComparator);
+
+    assertEquals(expectedEdges.size(), actualEdges.size());
+    for (int i = 0; i < expectedEdges.size(); i++) {
+      assertEquals(expectedEdges.get(i), actualEdges.get(i));
+    }
+  }
+
+  @Test
+  public void testGraphToObservations() {
+    McfOptimizedGraph optimizedGraph =
+        McfOptimizedGraph.newBuilder()
+            .setSvObsSeries(
+                McfStatVarObsSeries.newBuilder()
+                    .setKey(
+                        McfStatVarObsSeries.Key.newBuilder()
+                            .setObservationAbout("geoId/testPlace")
+                            .setVariableMeasured("testStatVar")
+                            .setObservationPeriod("P1Y")
+                            .setMeasurementMethod("testMethod")
+                            .setUnit("testUnit")
+                            .setScalingFactor("100"))
+                    .addSvObsList(
+                        StatVarObs.newBuilder().setDcid("obs1").setDate("2020").setNumber(10.0))
+                    .addSvObsList(
+                        StatVarObs.newBuilder()
+                            .setDcid("obs2")
+                            .setDate("2021")
+                            .setText("someText")))
+            .build();
+
+    Observations expectedObsValues =
+        Observations.newBuilder().putValues("2020", "10.0").putValues("2021", "someText").build();
+
+    Observation expectedObservation =
+        Observation.builder()
+            .observationAbout("geoId/testPlace")
+            .variableMeasured("testStatVar")
+            .measurementMethod("testMethod")
+            .observationPeriod("P1Y")
+            .unit("testUnit")
+            .scalingFactor("100")
+            .observations(expectedObsValues)
+            .build();
+
+    Observation actualObservation = GraphReader.graphToObservations(optimizedGraph);
+
+    assertEquals(expectedObservation, actualObservation);
+  }
+}

--- a/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/GraphReaderTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/GraphReaderTest.java
@@ -173,23 +173,19 @@ public class GraphReaderTest {
             Edge.builder()
                 .subjectId("dcid_subject")
                 .predicate("name")
-                .objectId("Subject Node")
+                .objectId("dcid_subject")
                 .objectValue("Subject Node")
                 .build(),
-            Edge.builder()
-                .subjectId("dcid_subject")
-                .predicate("typeOf")
-                .objectId("dcid:Class")
-                .build(),
+            Edge.builder().subjectId("dcid_subject").predicate("typeOf").objectId("Class").build(),
             Edge.builder()
                 .subjectId("dcid_subject")
                 .predicate("containedInPlace")
-                .objectId("dcid:geoId/06")
+                .objectId("geoId/06")
                 .build(),
             Edge.builder()
                 .subjectId("dcid_subject")
                 .predicate("description")
-                .objectId("A test description")
+                .objectId("dcid_subject")
                 .objectValue("A test description")
                 .build());
 
@@ -221,7 +217,7 @@ public class GraphReaderTest {
                             .setObservationAbout("geoId/testPlace")
                             .setVariableMeasured("testStatVar")
                             .setObservationPeriod("P1Y")
-                            .setMeasurementMethod("testMethod")
+                            .setMeasurementMethod("dcAggregate/testMethod")
                             .setUnit("testUnit")
                             .setScalingFactor("100"))
                     .addSvObsList(
@@ -241,6 +237,7 @@ public class GraphReaderTest {
             .observationAbout("geoId/testPlace")
             .variableMeasured("testStatVar")
             .measurementMethod("testMethod")
+            .isDcAggregate(true)
             .observationPeriod("P1Y")
             .unit("testUnit")
             .scalingFactor("100")


### PR DESCRIPTION
This PR adds some helper routines to convert McfGraph and McfOptimizedGraph to Spanner Graph mutations for populating Node/Edge and Observation tables. 