### PR TITLE
Prevent generated stat var grouping ids from being greater than 255 characters to avoid database column length restrictions

### DIFF
--- a/simple/stats/runner.py
+++ b/simple/stats/runner.py
@@ -45,15 +45,17 @@ class RunMode(StrEnum):
 
 
 class Runner:
-  """Runs and coordinates all imports.
-    """
+  """Runs and coordinates all imports."""
 
-  def __init__(self,
-               config_file_path: str,
-               input_dir_path: str,
-               output_dir_path: str,
-               mode: RunMode = RunMode.CUSTOM_DC) -> None:
-    assert config_file_path or input_dir_path, "One of config_file or input_dir must be specified"
+  def __init__(
+      self,
+      config_file_path: str,
+      input_dir_path: str,
+      output_dir_path: str,
+      mode: RunMode = RunMode.CUSTOM_DC,
+  ) -> None:
+    assert (config_file_path or
+            input_dir_path), "One of config_file or input_dir must be specified"
     assert output_dir_path, "output_dir must be specified"
 
     self.mode = mode
@@ -88,7 +90,8 @@ class Runner:
 
       self._read_config_from_file(
           config_file_path=constants.CONFIG_JSON_FILE_NAME,
-          config_file_dir=input_store.as_dir())
+          config_file_dir=input_store.as_dir(),
+      )
 
     # Get dict of special file type string to special file name.
     # Example entry: verticalSpecsFile -> vertical_specs.json
@@ -117,7 +120,7 @@ class Runner:
 
   def run(self):
     try:
-      if (self.db is None):
+      if self.db is None:
         self.db = create_and_update_db(self._get_db_config())
         self.db_cache = get_db_cache_from_env()
 
@@ -358,11 +361,13 @@ class Runner:
     # locations.
     output_file = output_dir.open_file(input_file.path)
     reporter = self.reporter.get_file_reporter(input_file)
-    return McfImporter(input_file=input_file,
-                       output_file=output_file,
-                       db=self.db,
-                       reporter=reporter,
-                       is_main_dc=is_main_dc)
+    return McfImporter(
+        input_file=input_file,
+        output_file=output_file,
+        db=self.db,
+        reporter=reporter,
+        is_main_dc=is_main_dc,
+    )
 
   def _create_importer(self, input_file: File) -> Importer:
     import_type = self.config.import_type(input_file)
@@ -375,22 +380,28 @@ class Runner:
     if import_type == ImportType.OBSERVATIONS:
       input_file_format = self.config.format(input_file)
       if input_file_format == InputFileFormat.VARIABLE_PER_ROW:
-        return VariablePerRowImporter(input_file=input_file,
-                                      db=self.db,
-                                      reporter=reporter,
-                                      nodes=self.nodes)
-      return ObservationsImporter(input_file=input_file,
-                                  db=self.db,
-                                  debug_resolve_file=debug_resolve_file,
-                                  reporter=reporter,
-                                  nodes=self.nodes)
+        return VariablePerRowImporter(
+            input_file=input_file,
+            db=self.db,
+            reporter=reporter,
+            nodes=self.nodes,
+        )
+      return ObservationsImporter(
+          input_file=input_file,
+          db=self.db,
+          debug_resolve_file=debug_resolve_file,
+          reporter=reporter,
+          nodes=self.nodes,
+      )
 
     if import_type == ImportType.EVENTS:
-      return EventsImporter(input_file=input_file,
-                            db=self.db,
-                            debug_resolve_file=debug_resolve_file,
-                            reporter=reporter,
-                            nodes=self.nodes)
+      return EventsImporter(
+          input_file=input_file,
+          db=self.db,
+          debug_resolve_file=debug_resolve_file,
+          reporter=reporter,
+          nodes=self.nodes,
+      )
 
     if import_type == ImportType.ENTITIES:
       return EntitiesImporter(input_file=input_file,
@@ -405,7 +416,8 @@ class Runner:
 def _check_not_overlapping(input_store: Store, output_store: Store):
   input_path = input_store.full_path()
   output_path = output_store.full_path()
-  if fspath.issamedir(input_path, output_path) or fspath.isparent(
-      input_path, output_path) or fspath.isparent(output_path, input_path):
+  if (fspath.issamedir(input_path, output_path) or
+      fspath.isparent(input_path, output_path) or
+      fspath.isparent(output_path, input_path)):
     raise ValueError(
         f"Input path (${input_path}) overlaps with output dir ({output_path})")

--- a/simple/tests/stats/stat_var_hierarchy_generator_test.py
+++ b/simple/tests/stats/stat_var_hierarchy_generator_test.py
@@ -19,7 +19,6 @@ import tempfile
 import unittest
 
 from kg_util import mcf_parser
-import pandas as pd
 from parameterized import parameterized
 from stats.data import Triple
 from stats.stat_var_hierarchy_generator import *
@@ -232,3 +231,34 @@ class TestStatVarHierarchyGenerator(unittest.TestCase):
   def test_gen_specialized_name(self, parent: SVPropVals, child: SVPropVals,
                                 dcid2name: dict[str, str], expected: str):
     self.assertEqual(child.gen_specialized_name(parent, dcid2name), expected)
+
+  def test_gen_svg_id(self):
+    sv_prop_vals = SVPropVals(
+        sv_id="sv1",
+        population_type="Person",
+        pvs=[PropVal("gender", "Female"),
+             PropVal("race", "Asian")],
+        measured_property="count")
+    svg_id = sv_prop_vals.gen_svg_id()
+    self.assertEqual(svg_id, "c/g/Person_Gender-Female_Race-Asian")
+
+  def test_gen_svg_id_with_long_property_values(self):
+    sv_prop_vals = SVPropVals(
+        sv_id="sv1",
+        population_type="Person",
+        pvs=[
+            PropVal(
+                "propertyWithAReallyLongValue",
+                "HereIsAPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase"
+            ),
+            PropVal(
+                "anotherPropertyWithAReallyLongValue",
+                "HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase1"
+            )
+        ],
+        measured_property="count")
+    svg_id = sv_prop_vals.gen_svg_id()
+    self.assertEqual(
+        svg_id,
+        "c/g/Person_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingA-fafb3dea"
+    )

--- a/simple/tests/stats/test_data/runner/expected/generate_svg_hierarchy/datacommons.sql
+++ b/simple/tests/stats/test_data/runner/expected/generate_svg_hierarchy/datacommons.sql
@@ -9,7 +9,7 @@ CREATE TABLE key_value_store (
     lookup_key varchar(255),
     value longtext
 );
-INSERT INTO "key_value_store" VALUES('StatVarGroups','H4sIAAAAAAAC/32RT0vDQBDFKUiwjwp1UWs2KEvBo5RG8CIepFJPLVKleivbdKyBJBs3W7+EB7+yCdFG88fLzryZYXfeb3GFnjdYD+5JJyoaqU1k5qSN78mACXSnm3BJWqgXEZOKA+IdoBjHDLuZmill2Bjd0SYxKhRzqX25DCjhPRwW0zdr+rma242v4rOF46K3uKNoRfp8TKEMiCVw8rp48s2ryJviWny3H9FOVEiLd6mH/OAhTbfLiKGYypD69VWnXL2lxNN+bPzU5WWDC3aCvVQ20rn4rdgZrDzjDvYrBpmVR9hor7ZMOxwFYXy0cFQlM8mMv8Gu5TIpUXHLVNxaKm4tFfcPlbDOxTNYdQ/e/+dHrTzy00ZvO9n5BeXclHGoAgAA');
+INSERT INTO "key_value_store" VALUES('StatVarGroups','H4sIAAAAAAAC/+1YzWsTQRRnkxjso0Id1NopyphLEYylkbYH8RASqoF+0YZW8BAmm5cP2ezE3U1Lzx4rSFEE8Q/wIOJZEL140IPQ/6A3BdG74EFns5vmo0mzKRWS2Mvuzsybnd+8r3m/gZswqk7mJpfRMIUeE2XdWkPDKqhcIwxGFsvFNBpMZFkJRUlDOgxQE4cVOG23VoSwyByMxMqmJYpsjRsFntbQpKNwviYdzWH113Ss7aqw7YeJ2lhq2RAlObS1XrDy0RXkmrY1L/TcGtfKSPZ8EHbkmD3OqsJOK8oceWZPYJUZ9LUPXigefx++gwYmzOhhMkmRRNOK8bJZ0HPR1XL6PqpWIr60gUZWE5tL2QVhYDLP9cj0dCzPDa5acuH1POrzgmfknIRuiWQe49ziaW4ieaTYq7KEKeF33A5LCmavz1wAUsaFwBIszqoo2FKW2TiYC4TVkDAbCnOxMBuMFEJWhQOPFbhYp67bqGfQCM9hkWtITBiv174zyG4xdzgJQ6YoYmqDG1P03Kr83HcNNsUWeRFDrXvHm3vjaKpGoWQVpM/tBnrcgm/88E7pyiulynrJ6PSnAh/qVRzVhZVH4zAt9p4ZrrqoOysUZtqkKXIJzshm2/T3KTgAenp4Cr41uKtnvV3rP89+5oc/XVqsapSOgsdtmWN2lbCK6kwmE5klO7UjxqOl//058zx4YhjyNAC/fUcKxfo46xWb9l96IE8UCFVLltSmhJHS5OqpkotMdksYJp1orE8qeCsw97dQwWuGPAs2VTw3GiqeV3643l1okF8+mD6SI9H3PnjZL4HYk5nsa6CPFPjWD5+Vgck49LsCHwfiFCFXOlete0p9MUp2FQg6n/Re1/nCe7FMx+HsAUJIgs6bznvn7h52OAZDmf37hWEKtdsG2FbgwkFeumDTzgcw1pKVLjRx0kgzJ4205KSRlpw00pChvwQHxe8kG/ih/E8lCN05oQSzvXbrVGyVY+4CORjXNHTI/VTQedPLbXNFwH7+BZFEBAkEFQAA');
 CREATE TABLE observations (
     entity varchar(255),
     variable varchar(255),
@@ -48,6 +48,13 @@ INSERT INTO "triples" VALUES('PersonCountVertical','typeOf','Thing','');
 INSERT INTO "triples" VALUES('PersonCountVertical','name','','Number of people');
 INSERT INTO "triples" VALUES('PersonAgeVertical','typeOf','Thing','');
 INSERT INTO "triples" VALUES('PersonAgeVertical','name','','Age of people');
+INSERT INTO "triples" VALUES('some_var_with_long_property_values','typeOf','StatisticalVariable','');
+INSERT INTO "triples" VALUES('some_var_with_long_property_values','measuredProperty','count','');
+INSERT INTO "triples" VALUES('some_var_with_long_property_values','name','','Some Variable With Long Property Values');
+INSERT INTO "triples" VALUES('some_var_with_long_property_values','description','','Some Variable 3 Description');
+INSERT INTO "triples" VALUES('some_var_with_long_property_values','populationType','Person','');
+INSERT INTO "triples" VALUES('some_var_with_long_property_values','propertyWithAReallyLongValue','HereIsAPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase','');
+INSERT INTO "triples" VALUES('some_var_with_long_property_values','anotherPropertyWithAReallyLongValue','HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase','');
 INSERT INTO "triples" VALUES('c/s/default','typeOf','Source','');
 INSERT INTO "triples" VALUES('c/s/default','name','','Custom Data Commons');
 INSERT INTO "triples" VALUES('c/s/1','typeOf','Source','');
@@ -75,6 +82,23 @@ INSERT INTO "triples" VALUES('c/g/Person','typeOf','StatVarGroup','');
 INSERT INTO "triples" VALUES('c/g/Person','name','','Person');
 INSERT INTO "triples" VALUES('c/g/Person','specializationOf','c/g/PersonCountVertical','');
 INSERT INTO "triples" VALUES('c/g/Person','specializationOf','c/g/PersonAgeVertical','');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue','typeOf','StatVarGroup','');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue','name','','Person With Another Property With A Really Long Value');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue','specializationOf','c/g/Person','');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase','typeOf','StatVarGroup','');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase','name','','Person With Another Property With A Really Long Value = Here Is Aother Property With A Really Long Value To Test Causing A Subject I D Overflow Of More Than255 Characters When Loading Into The Database');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase','specializationOf','c/g/Person_AnotherPropertyWithAReallyLongValue','');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase_PropertyWithAReallyLongValue','typeOf','StatVarGroup','');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase_PropertyWithAReallyLongValue','name','','Person With Another Property With A Really Long Value = Here Is Aother Property With A Really Long Value To Test Causing A Subject I D Overflow Of More Than255 Characters When Loading Into The Database, Property With A Really Long Value');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase_PropertyWithAReallyLongValue','specializationOf','c/g/Person_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase','');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingA-cec6dd27','typeOf','StatVarGroup','');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingA-cec6dd27','name','','Person With Another Property With A Really Long Value = Here Is Aother Property With A Really Long Value To Test Causing A Subject I D Overflow Of More Than255 Characters When Loading Into The Database, Property With A Really Long Value = Here Is A Property With A Really Long Value To Test Causing A Subject I D Overflow Of More Than255 Characters When Loading Into The Database');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingA-cec6dd27','specializationOf','c/g/Person_AnotherPropertyWithAReallyLongValue_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase','');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingA-cec6dd27','specializationOf','c/g/Person_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase_PropertyWithAReallyLongValue','');
+INSERT INTO "triples" VALUES('some_var_with_long_property_values','memberOf','c/g/Person_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingA-cec6dd27','');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase','typeOf','StatVarGroup','');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase','name','','Person With Another Property With A Really Long Value, Property With A Really Long Value = Here Is A Property With A Really Long Value To Test Causing A Subject I D Overflow Of More Than255 Characters When Loading Into The Database');
+INSERT INTO "triples" VALUES('c/g/Person_AnotherPropertyWithAReallyLongValue_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase','specializationOf','c/g/Person_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase','');
 INSERT INTO "triples" VALUES('c/g/Person_Gender','typeOf','StatVarGroup','');
 INSERT INTO "triples" VALUES('c/g/Person_Gender','name','','Person With Gender');
 INSERT INTO "triples" VALUES('c/g/Person_Gender','specializationOf','c/g/Person','');
@@ -86,6 +110,12 @@ INSERT INTO "triples" VALUES('c/g/Person_Gender-Male','typeOf','StatVarGroup',''
 INSERT INTO "triples" VALUES('c/g/Person_Gender-Male','name','','Person With Gender = Male');
 INSERT INTO "triples" VALUES('c/g/Person_Gender-Male','specializationOf','c/g/Person_Gender','');
 INSERT INTO "triples" VALUES('some_var2','memberOf','c/g/Person_Gender-Male','');
+INSERT INTO "triples" VALUES('c/g/Person_PropertyWithAReallyLongValue','typeOf','StatVarGroup','');
+INSERT INTO "triples" VALUES('c/g/Person_PropertyWithAReallyLongValue','name','','Person With Property With A Really Long Value');
+INSERT INTO "triples" VALUES('c/g/Person_PropertyWithAReallyLongValue','specializationOf','c/g/Person','');
+INSERT INTO "triples" VALUES('c/g/Person_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase','typeOf','StatVarGroup','');
+INSERT INTO "triples" VALUES('c/g/Person_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase','name','','Person With Property With A Really Long Value = Here Is A Property With A Really Long Value To Test Causing A Subject I D Overflow Of More Than255 Characters When Loading Into The Database');
+INSERT INTO "triples" VALUES('c/g/Person_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase','specializationOf','c/g/Person_PropertyWithAReallyLongValue','');
 CREATE INDEX observations_entity_variable on observations (entity, variable);
 CREATE INDEX triples_subject_id on triples (subject_id);
 CREATE INDEX triples_subject_id_predicate on triples (subject_id, predicate);

--- a/simple/tests/stats/test_data/runner/expected/generate_svg_hierarchy/nl/sentences.csv
+++ b/simple/tests/stats/test_data/runner/expected/generate_svg_hierarchy/nl/sentences.csv
@@ -1,3 +1,4 @@
 dcid,sentence
 some_var1,Some Variable 1 Name
 some_var2,Some Variable 2 Name
+some_var_with_long_property_values,Some Variable With Long Property Values

--- a/simple/tests/stats/test_data/runner/input/generate_svg_hierarchy/nodes.mcf
+++ b/simple/tests/stats/test_data/runner/input/generate_svg_hierarchy/nodes.mcf
@@ -22,3 +22,12 @@ name: "Number of people"
 Node: dcid:PersonAgeVertical
 typeOf: dcs:Thing
 name: "Age of people"
+
+Node: dcid:some_var_with_long_property_values
+typeOf: dcs:StatisticalVariable
+measuredProperty: dcs:count
+name: "Some Variable With Long Property Values"
+description: "Some Variable 3 Description"
+populationType: schema:Person
+propertyWithAReallyLongValue: dcs:HereIsAPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase
+anotherPropertyWithAReallyLongValue: dcs:HereIsAotherPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase


### PR DESCRIPTION
Changes:
- Updated stat var grouping generation to keep id lengths <= 255 characters to avoid a databse column length restriction
- Updated unit tests
- Ran linter which formatted a few unrelated files