### PR TITLE
[dc-import] Optimize memory usage in data processing pipeline through immediate observation extraction

### DIFF
--- a/util/src/main/java/org/datacommons/util/GraphUtils.java
+++ b/util/src/main/java/org/datacommons/util/GraphUtils.java
@@ -391,6 +391,19 @@ public class GraphUtils {
       }
     }
 
+    return buildOptimizedMcfGraphFromSeries(svoList);
+  }
+
+  /**
+   * Builds an OptimizedMcfGraph proto from a list of McfStatVarObsSeries. This function groups
+   * StatVarObservations by their key. This is a memory-efficient version that works with
+   * pre-extracted observation series instead of full graphs.
+   *
+   * @param svoList A list of McfStatVarObsSeries protos.
+   * @return A list of McfOptimizedGraph protos containing the grouped StatVarObservations.
+   */
+  public static List<McfOptimizedGraph> buildOptimizedMcfGraphFromSeries(
+      List<McfStatVarObsSeries> svoList) {
     Map<McfStatVarObsSeries.Key, List<McfStatVarObsSeries>> svoByKey =
         svoList.stream().collect(Collectors.groupingBy(McfStatVarObsSeries::getKey));
     List<McfOptimizedGraph> res = new ArrayList<>();


### PR DESCRIPTION
Replaces full graph storage with pre-extracted observation series to reduce memory footprint during large data processing.

- Did some test on a csv file sized 900MiB
- Without mcf graph object list - ~ 3Gib
- With mcf graph object list > 32Gib (oom after 32Gib ). The progress was slow because of aggressive GC cycles, which were not able to free any ram.
- Made some improvement in this PR, memory consumption down to 16Gib. The task completed too in 7-8 mins. GC cycles do show cleanup.