### PR TITLE
Update pom.xml

### DIFF
--- a/pipeline/ingestion/pom.xml
+++ b/pipeline/ingestion/pom.xml
@@ -15,6 +15,18 @@
     <version>${revision}</version>
     <name>Data Commons - Ingestion Pipeline</name>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.beam</groupId>
+                <artifactId>beam-sdks-java-google-cloud-platform-bom</artifactId>
+                <version>${beam.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <artifactId>model</artifactId>
@@ -29,13 +41,11 @@
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-core</artifactId>
-            <version>${beam.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
-            <version>${beam.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -57,6 +67,10 @@
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-spanner</artifactId>
         </dependency>
     </dependencies>
 
@@ -105,7 +119,6 @@
                 <dependency>
                     <groupId>org.apache.beam</groupId>
                     <artifactId>beam-runners-direct-java</artifactId>
-                    <version>${beam.version}</version>
                     <scope>runtime</scope>
                 </dependency>
             </dependencies>
@@ -116,7 +129,6 @@
                 <dependency>
                     <groupId>org.apache.beam</groupId>
                     <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
-                    <version>${beam.version}</version>
                     <scope>runtime</scope>
                 </dependency>
             </dependencies>

--- a/pipeline/pom.xml
+++ b/pipeline/pom.xml
@@ -10,6 +10,13 @@
     <url>https://datacommons.org</url>
     <packaging>pom</packaging>
 
+  <parent>
+      <groupId>org.datacommons</groupId>
+      <artifactId>datacommons-import</artifactId>
+      <version>0.1-alpha.1</version>
+      <relativePath>..</relativePath>
+  </parent>
+
   <modules>
     <module>differ</module>
     <module>ingestion</module>
@@ -32,24 +39,4 @@
         </plugins>
     </pluginManagement>
 </build>
-
-  <properties>
-     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
-    <!-- Dependency versions -->
-    <revision>0.1-SNAPSHOT</revision>
-    <beam.version>2.62.0</beam.version>
-    <os.maven.plugin.version>1.7.1</os.maven.plugin.version>
-    <protobuf.maven.plugin.version>0.6.1</protobuf.maven.plugin.version>
-    <protoc.version>3.21.12</protoc.version>
-    <protobuf.java.version>3.25.3</protobuf.java.version>
-    <junit.version>4.13.1</junit.version>
-    <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-    <maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>
-    <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
-    <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
-    <mockito.version>3.7.7</mockito.version>
-    <slf4j.version>1.7.30</slf4j.version>
-  </properties>
 </project>

--- a/pipeline/pom.xml
+++ b/pipeline/pom.xml
@@ -13,7 +13,7 @@
   <parent>
       <groupId>org.datacommons</groupId>
       <artifactId>datacommons-import</artifactId>
-      <version>0.1-alpha.1</version>
+      <version>${import.version}</version>
       <relativePath>..</relativePath>
   </parent>
 

--- a/pipeline/util/pom.xml
+++ b/pipeline/util/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.datacommons</groupId>
       <artifactId>datacommons-import-util</artifactId>
-      <version>0.1-alpha.1</version>
+      <version>${import.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
                     <version>1</version>
                     <projectId>GCLOUD_CONFIG</projectId>
                 </configuration>
-            </plugin>           
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,21 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <!-- Dependency versions -->
+        <revision>0.1-SNAPSHOT</revision>
+        <beam.version>2.66.0</beam.version>
+        <gson.version>2.10.1</gson.version> 
+        <os.maven.plugin.version>1.7.1</os.maven.plugin.version>
+        <protobuf.maven.plugin.version>0.6.1</protobuf.maven.plugin.version>
+        <protoc.version>3.25.1</protoc.version>
+        <protobuf.java.version>3.25.1</protobuf.java.version>
+        <junit.version>4.13.1</junit.version>
+        <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
+        <maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>
+        <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
+        <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
+        <mockito.version>3.7.7</mockito.version>
+        <slf4j.version>1.7.30</slf4j.version>
     </properties>
 
     <!-- List the sub-dirs so that they all get included in an IntelliJ project -->
@@ -22,7 +37,40 @@
         <module>pipeline</module>
     </modules>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${protobuf.java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java-util</artifactId>
+                <version>${protobuf.java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protoc</artifactId>
+                <version>${protoc.version}</version>
+                <type>pom</type> 
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${gson.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
@@ -54,32 +102,34 @@
                     <!-- By default uses JGit. For git worktree support, use -Pgit-worktree profile -->
                 </configuration>
             </plugin>
-            <plugin>
-                <!-- For protobuf generation -->
-                <groupId>com.github.os72</groupId>
-                <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.4</version>
-                <executions>
-                    <execution>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <protocArtifact>com.google.protobuf:protoc:3.17.3</protocArtifact>
-                            <inputDirectories>
-                                <include>src/main/proto</include>
-                            </inputDirectories>
-                            <outputTargets>
-                                <outputTarget>
-                                    <type>java</type>
-                                    <outputDirectory>src/main/java</outputDirectory>
-                                </outputTarget>
-                            </outputTargets>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+        <plugin>
+            <groupId>org.xolstice.maven.plugins</groupId>
+            <artifactId>protobuf-maven-plugin</artifactId>
+            <version>0.6.1</version> 
+            <configuration>
+                <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                <clearOutputDirectory>false</clearOutputDirectory>
+                <outputTargets>
+                    <outputTarget>
+                        <generator>java</generator>
+                        <outputDirectory>${project.build.directory}/generated-sources/protobuf/java</outputDirectory>
+                        <addSources>true</addSources> 
+                        <filter>false</filter> 
+                    </outputTarget>
+                </outputTargets>
+                <protoSourceRoot>${project.basedir}/src/main/proto</protoSourceRoot>
+            </configuration>
+            <executions>
+                <execution>
+                    <id>compile-protobuf</id>
+                    <goals>
+                        <goal>compile</goal>
+                        <goal>test-compile</goal>
+                    </goals>
+                    <phase>generate-sources</phase>
+                </execution>
+            </executions>
+        </plugin>
             <plugin>
                 <!-- For google-java-format check. Order this after generate-sources since they are in the same phase. -->
                 <groupId>com.spotify.fmt</groupId>
@@ -149,7 +199,7 @@
                     <version>1</version>
                     <projectId>GCLOUD_CONFIG</projectId>
                 </configuration>
-            </plugin>
+            </plugin>           
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.datacommons</groupId>
     <artifactId>datacommons-import</artifactId>
-    <version>0.1-alpha.1</version>
+    <version>${import.version}</version>
     <packaging>pom</packaging>
     <name>Data Commons - Import</name>
     <url>https://datacommons.org</url>
@@ -13,6 +13,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <!-- Dependency versions -->
+        <import.version>0.1-alpha.1</import.version>
         <revision>0.1-SNAPSHOT</revision>
         <beam.version>2.66.0</beam.version>
         <gson.version>2.10.1</gson.version> 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>org.datacommons</groupId>
 		<artifactId>datacommons-import</artifactId>
-		<version>0.1-alpha.1</version>
+		<version>${import.version}</version>
 		<relativePath>..</relativePath>
 	</parent>
 
 	<groupId>org.datacommons</groupId>
 	<artifactId>datacommons-server</artifactId>
-	<version>0.1-alpha.1</version>
+	<version>${import.version}</version>
 	<name>Data Commons - Server</name>
 	<description>API server for private Data Commons</description>
 	<packaging>jar</packaging>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -30,8 +30,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>[3.2.0, 3.10)</version>
-        </dependency>
+            </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
@@ -55,7 +54,6 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
-            <version>3.7.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.datacommons</groupId>
         <artifactId>datacommons-import</artifactId>
-        <version>0.1-alpha.1</version>
+        <version>${import.version}</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            </dependency>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -23,7 +23,15 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>[3.2.0, 3.10)</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -57,6 +65,11 @@
             <groupId>org.jfree</groupId>
             <artifactId>jfreesvg</artifactId>
             <version>3.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>32.1.3-jre</version>
         </dependency>
 
 
@@ -92,12 +105,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java-util</artifactId>
-            <version>3.7.1</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>3.9.0</version>
@@ -117,7 +124,7 @@
                         </manifest>
                     </archive>
                 </configuration>
-            </plugin>
+            </plugin>            
         </plugins>
     </build>
 </project>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.datacommons</groupId>
         <artifactId>datacommons-import</artifactId>
-        <version>0.1-alpha.1</version>
+        <version>${import.version}</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -124,7 +124,7 @@
                         </manifest>
                     </archive>
                 </configuration>
-            </plugin>            
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Updates pom.xml files to fix broken ingestion pipeline ([sample failed run](https://pantheon.corp.google.com/dataflow/jobs/us-central1/2025-07-29_12_32_11-17071637354311084760;graphView=0?project=datcom-store&inv=1&invt=Ab4Gew&pageState=(%22dfTime%22:(%22l%22:%22dfJobMaxTime%22)))). It seemed like a beam error, so I updated the beam SDK to the latest (2.62.0 --> 2.66.0), but then had to update some other dependencies. 

This includes
* Using a BOM to manage beam dependencies
* Explicitly adding the google-cloud-spanner dependency
* Using dependencyManagement for protobuf dependencies in the parent datacommons-import so the same protobuf versions are used throughout, since the protos are shared across modules (and updates the protobuf version to 3.25.1) 
* Switches to use org.xolstice.maven.plugins for protobuf generation
* Adds a few other dependencies needed for the new protobuf version: gson, guava

[Succesful test run](https://pantheon.corp.google.com/dataflow/jobs/us-central1/2025-07-29_19_25_29-8256223821596906265;logsSeverity=ERROR;graphView=0?project=datcom-store&pageState=(%22dfTime%22:(%22l%22:%22dfJobMaxTime%22))&inv=1&invt=Ab4Ekw)