### PR TITLE
fix: Handle pre-1900 dates gracefully

### DIFF
--- a/util/src/main/java/org/datacommons/util/PlaceSeriesSummary.java
+++ b/util/src/main/java/org/datacommons/util/PlaceSeriesSummary.java
@@ -79,6 +79,11 @@ public class PlaceSeriesSummary {
         LocalDateTime localDateTime = StringUtil.getValidISO8601Date(timeSeriesDataPoint.getKey());
         if (localDateTime == null) continue;
 
+        // The JFreeChart library we are using does not support years before 1900.
+        if (localDateTime.getYear() < 1900) {
+          return "<b>Charts for years before 1900 are not supported yet</b>";
+        }
+
         DataPoint dp = timeSeriesDataPoint.getValue();
         if (SeriesSummary.getTypeOfDataPoint(dp) != ValueType.NUMBER) continue;
 

--- a/util/src/test/java/org/datacommons/util/PlaceSeriesSummaryTest.java
+++ b/util/src/test/java/org/datacommons/util/PlaceSeriesSummaryTest.java
@@ -55,7 +55,7 @@ public class PlaceSeriesSummaryTest {
   }
 
   @Test
-  public void testGetTimeSeriesSVGChart_pre1900() throws IOException {
+  public void testGetTimeSeriesSVGChartPre1900() throws IOException {
     String mcfPath = this.getClass().getResource("Pre1900PlaceSeriesSummaryTest.mcf").getPath();
     Mcf.McfGraph graph = McfParser.parseInstanceMcfFile(mcfPath, false, TestUtil.newLogCtx());
     PlaceSeriesSummary placeSeriesSummary = new PlaceSeriesSummary();

--- a/util/src/test/java/org/datacommons/util/PlaceSeriesSummaryTest.java
+++ b/util/src/test/java/org/datacommons/util/PlaceSeriesSummaryTest.java
@@ -53,4 +53,25 @@ public class PlaceSeriesSummaryTest {
       assertEquals(expectedEntry.getValue().seriesValues, actualEntry.seriesValues);
     }
   }
+
+  @Test
+  public void testGetTimeSeriesSVGChart_pre1900() throws IOException {
+    String mcfPath = this.getClass().getResource("Pre1900PlaceSeriesSummaryTest.mcf").getPath();
+    Mcf.McfGraph graph = McfParser.parseInstanceMcfFile(mcfPath, false, TestUtil.newLogCtx());
+    PlaceSeriesSummary placeSeriesSummary = new PlaceSeriesSummary();
+    for (Map.Entry<String, McfGraph.PropertyValues> node : graph.getNodesMap().entrySet()) {
+      placeSeriesSummary.extractSeriesFromNode(node.getValue());
+    }
+    Map<String, Map<Long, PlaceSeriesSummary.SeriesSummary>> svSeriesSummaryMap =
+        placeSeriesSummary.getSvSeriesSummaryMap();
+    assertFalse(svSeriesSummaryMap.isEmpty());
+    for (Map<Long, PlaceSeriesSummary.SeriesSummary> seriesSummaryMap :
+        svSeriesSummaryMap.values()) {
+      for (PlaceSeriesSummary.SeriesSummary summary : seriesSummaryMap.values()) {
+        assertEquals(
+            "<b>Charts for years before 1900 are not supported yet</b>",
+            summary.getTimeSeriesSVGChart());
+      }
+    }
+  }
 }

--- a/util/src/test/resources/org/datacommons/util/Pre1900PlaceSeriesSummaryTest.mcf
+++ b/util/src/test/resources/org/datacommons/util/Pre1900PlaceSeriesSummaryTest.mcf
@@ -1,0 +1,7 @@
+Node: SVTest/E0/1
+typeOf: dcid:StatVarObservation
+observationDate: 1871
+observationAbout: dcid:geoId/06
+variableMeasured: dcid:Count_Person
+measurementMethod: dcid:CensusACS5YrSurvey
+value: 1000100


### PR DESCRIPTION
The JFreeChart library throws an `IllegalArgumentException` when handling dates before 1900. This was causing the import process to crash (see b/424329091).

This fix adds a check to the `getTimeSeriesSVGChart` method to handle dates before 1900 gracefully. Instead of crashing, the method now returns a user-friendly message. A regression test has been added to ensure this bug does not recur.