### PR TITLE
Fix parent versions in pom.xml

### DIFF
--- a/pipeline/pom.xml
+++ b/pipeline/pom.xml
@@ -13,7 +13,7 @@
   <parent>
       <groupId>org.datacommons</groupId>
       <artifactId>datacommons-import</artifactId>
-      <version>${import.version}</version>
+      <version>0.1-alpha.1</version>
       <relativePath>..</relativePath>
   </parent>
 

--- a/pipeline/util/pom.xml
+++ b/pipeline/util/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.datacommons</groupId>
       <artifactId>datacommons-import-util</artifactId>
-      <version>${import.version}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.datacommons</groupId>
     <artifactId>datacommons-import</artifactId>
-    <version>${import.version}</version>
+    <version>0.1-alpha.1</version>
     <packaging>pom</packaging>
     <name>Data Commons - Import</name>
     <url>https://datacommons.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <!-- Dependency versions -->
-        <import.version>0.1-alpha.1</import.version>
-        <revision>0.1-SNAPSHOT</revision>
+        <revision>0.1-alpha.1</revision>
         <beam.version>2.66.0</beam.version>
         <gson.version>2.10.1</gson.version> 
         <os.maven.plugin.version>1.7.1</os.maven.plugin.version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.datacommons</groupId>
 		<artifactId>datacommons-import</artifactId>
-		<version>${import.version}</version>
+		<version>0.1-alpha.1</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.datacommons</groupId>
 	<artifactId>datacommons-server</artifactId>
-	<version>${import.version}</version>
+	<version>${revision}</version>
 	<name>Data Commons - Server</name>
 	<description>API server for private Data Commons</description>
 	<packaging>jar</packaging>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.datacommons</groupId>
         <artifactId>datacommons-import</artifactId>
-        <version>${import.version}</version>
+        <version>0.1-alpha.1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.datacommons</groupId>
         <artifactId>datacommons-import</artifactId>
-        <version>${import.version}</version>
+        <version>0.1-alpha.1</version>
         <relativePath>..</relativePath>
     </parent>
 


### PR DESCRIPTION
Follow up to https://github.com/datacommonsorg/import/commit/4c2964f0c1961c084d8ec1ca0952ce08dd15cede 

It looks like parent versions need to be explicitly set to compile the ingestion module to run the ingestion pipeline. (Apparently revision is a special property that allows this, but custom properties do not) 

To keep the stable modules (0.1-alpha.1) separate from the development modules (0.1-SNAPSHOT, which is currently set for revision), I have to set the parent versions directly. 

Tested by running ingestion pipeline 