### PR TITLE
Generate leaf nodes in spanner ingestion

### DIFF
--- a/pipeline/ingestion/README.md
+++ b/pipeline/ingestion/README.md
@@ -64,7 +64,7 @@ mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.d
 
 ```shell
 mvn -Pdataflow-runner compile exec:java -pl ingestion -am -Dexec.mainClass=org.datacommons.ingestion.pipeline.IngestionPipeline \
--Dexec.args="--skipProcessing=SKIP_OBS --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=30 --maxNumWorkers=40 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
+-Dexec.args="--skipProcessing=SKIP_OBS --project=datcom-store --gcpTempLocation=gs://keyurs-dataflow/temp --runner=DataflowRunner --region=us-central1  --numWorkers=30 --maxNumWorkers=100 --dataflowServiceOptions=enable_google_cloud_profiler --workerMachineType=e2-highmem-16"
 ```
 
 ### Import specific import group

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Edge.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Edge.java
@@ -1,9 +1,6 @@
 package org.datacommons.ingestion.data;
 
-import com.google.common.hash.Hashing;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Objects;
 import org.apache.beam.sdk.coders.DefaultCoder;
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
@@ -15,18 +12,14 @@ public class Edge implements Serializable {
   private String subjectId;
   private String predicate;
   private String objectId;
-  private String objectValue;
   private String provenance;
-  private String objectHash;
 
   // Private constructor to enforce use of Builder
   private Edge(Builder builder) {
     this.subjectId = builder.subjectId;
     this.predicate = builder.predicate;
     this.objectId = builder.objectId;
-    this.objectValue = builder.objectValue;
     this.provenance = builder.provenance;
-    this.objectHash = builder.objectHash;
   }
 
   public static Builder builder() {
@@ -45,16 +38,8 @@ public class Edge implements Serializable {
     return objectId;
   }
 
-  public String getObjectValue() {
-    return objectValue;
-  }
-
   public String getProvenance() {
     return provenance;
-  }
-
-  public String getObjectHash() {
-    return objectHash;
   }
 
   @Override
@@ -65,28 +50,26 @@ public class Edge implements Serializable {
     return subjectId.equals(edge.subjectId)
         && predicate.equals(edge.predicate)
         && objectId.equals(edge.objectId)
-        && Objects.equals(objectHash, edge.objectHash);
+        && provenance.equals(edge.provenance);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(subjectId, predicate, objectId, objectHash);
+    return Objects.hash(subjectId, predicate, objectId, provenance);
   }
 
   @Override
   public String toString() {
     return String.format(
-        "Edge{subjectId='%s', predicate='%s', objectId='%s', objectValue='%s', provenance='%s', objectHash='%s'}",
-        subjectId, predicate, objectId, objectValue, provenance, objectHash);
+        "Edge{subjectId='%s', predicate='%s', objectId='%s', provenance='%s'}",
+        subjectId, predicate, objectId, provenance);
   }
 
   public static class Builder {
     private String subjectId = "";
     private String predicate = "";
     private String objectId = "";
-    private String objectValue = "";
     private String provenance = "";
-    private String objectHash = "";
 
     private Builder() {}
 
@@ -105,19 +88,8 @@ public class Edge implements Serializable {
       return this;
     }
 
-    public Builder objectValue(String objectValue) {
-      this.objectValue = objectValue;
-      this.objectHash = generateSha256(objectValue);
-      return this;
-    }
-
     public Builder provenance(String provenance) {
       this.provenance = provenance;
-      return this;
-    }
-
-    public Builder objectHash(String objectHash) {
-      this.objectHash = objectHash;
       return this;
     }
 
@@ -132,14 +104,6 @@ public class Edge implements Serializable {
         throw new IllegalArgumentException("objectId cannot be null or empty");
       }
       return new Edge(this);
-    }
-
-    private String generateSha256(String input) {
-      if (input == null || input.isEmpty()) {
-        return "";
-      }
-      return Base64.getEncoder()
-          .encodeToString(Hashing.sha256().hashString(input, StandardCharsets.UTF_8).asBytes());
     }
   }
 

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Node.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Node.java
@@ -1,5 +1,6 @@
 package org.datacommons.ingestion.data;
 
+import com.google.cloud.ByteArray;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
@@ -14,12 +15,18 @@ import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 public class Node implements Serializable {
 
   private String subjectId;
+  private String value;
+  private ByteArray bytes;
+  private boolean reference;
   private String name;
   private List<String> types;
 
   // Private constructor to enforce use of Builder
   private Node(Builder builder) {
     this.subjectId = builder.subjectId;
+    this.value = builder.value;
+    this.bytes = builder.bytes;
+    this.reference = builder.reference;
     this.name = builder.name;
     this.types = builder.types;
   }
@@ -30,6 +37,18 @@ public class Node implements Serializable {
 
   public String getSubjectId() {
     return subjectId;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public ByteArray getBytes() {
+    return bytes;
+  }
+
+  public boolean getReference() {
+    return reference;
   }
 
   public String getName() {
@@ -55,11 +74,16 @@ public class Node implements Serializable {
 
   @Override
   public String toString() {
-    return String.format("Node{subjectId='%s', name='%s', types=%s}", subjectId, name, types);
+    return String.format(
+        "Node{subjectId='%s', value='%s', bytes='%s', reference='%s', name='%s', types=%s}",
+        subjectId, value, bytes, reference, name, types);
   }
 
   public static class Builder {
     private String subjectId = "";
+    private String value = "";
+    private ByteArray bytes = null;
+    private boolean reference = false;
     private String name = "";
     private List<String> types = List.of();
 
@@ -67,6 +91,21 @@ public class Node implements Serializable {
 
     public Builder subjectId(String subjectId) {
       this.subjectId = subjectId;
+      return this;
+    }
+
+    public Builder value(String value) {
+      this.value = value;
+      return this;
+    }
+
+    public Builder bytes(ByteArray bytes) {
+      this.bytes = bytes;
+      return this;
+    }
+
+    public Builder reference(boolean reference) {
+      this.reference = reference;
       return this;
     }
 

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Observation.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/Observation.java
@@ -3,6 +3,7 @@ package org.datacommons.ingestion.data;
 import com.google.common.base.Joiner;
 import java.util.List;
 import java.util.Objects;
+import org.datacommons.pipeline.util.GraphUtils;
 import org.datacommons.proto.Storage.Observations;
 
 /**
@@ -92,7 +93,7 @@ public class Observation {
     return facetId;
   }
 
-  public boolean isDcAggregate() {
+  public boolean getIsDcAggregate() {
     return isDcAggregate;
   }
 
@@ -116,9 +117,15 @@ public class Observation {
     graph.addNode(
         Node.builder()
             .subjectId(seriesDcid)
+            .value(seriesDcid)
+            .reference(true)
             .name(seriesName)
             .types(List.of(OBS_SERIES_TYPE))
             .build());
+
+    // Add leaf node
+    graph.addNode(
+        Node.builder().subjectId(GraphUtils.generateSha256(seriesName)).value(seriesName).build());
 
     // Add variableMeasured edge
     graph.addEdge(
@@ -141,8 +148,7 @@ public class Observation {
         Edge.builder()
             .subjectId(seriesDcid)
             .predicate(NAME_PREDICATE)
-            .objectId(seriesDcid)
-            .objectValue(seriesName)
+            .objectId(GraphUtils.generateSha256(seriesName))
             .provenance(provenanceDcid)
             .build());
     // Add typeOf edge

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
@@ -1,22 +1,14 @@
 package org.datacommons.ingestion.spanner;
 
-import com.google.cloud.ByteArray;
 import com.google.cloud.spanner.Mutation;
-import com.google.cloud.spanner.Mutation.WriteBuilder;
 import com.google.cloud.spanner.Value;
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSet;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Stream;
-import java.util.zip.GZIPOutputStream;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO.Write;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO.WriteGrouped;
@@ -39,15 +31,6 @@ public class SpannerClient implements Serializable {
   private static final int SPANNER_GROUPING_FACTOR = 3000;
   // Commit deadline for spanner writes. Use large value for bigger batches.
   private static final int SPANNER_COMMIT_DEADLINE_SECONDS = 120;
-
-  // Predicates for which the object value should be stored as bytes in Spanner.
-  private static final Set<String> STORE_VALUE_AS_BYTES_PREDICATES =
-      ImmutableSet.of(
-          "geoJsonCoordinates",
-          "geoJsonCoordinatesDP1",
-          "geoJsonCoordinatesDP2",
-          "geoJsonCoordinatesDP3",
-          "kmlCoordinates");
 
   private final String gcpProjectId;
   private final String spannerInstanceId;
@@ -87,6 +70,10 @@ public class SpannerClient implements Serializable {
     return Mutation.newInsertOrUpdateBuilder(nodeTableName)
         .set("subject_id")
         .to(node.getSubjectId())
+        .set("value")
+        .to(node.getValue())
+        .set("bytes")
+        .to(node.getBytes())
         .set("name")
         .to(node.getName())
         .set("types")
@@ -95,45 +82,16 @@ public class SpannerClient implements Serializable {
   }
 
   public Mutation toEdgeMutation(Edge edge) {
-    WriteBuilder builder =
-        Mutation.newInsertOrUpdateBuilder(edgeTableName)
-            .set("subject_id")
-            .to(edge.getSubjectId())
-            .set("predicate")
-            .to(edge.getPredicate())
-            .set("object_id")
-            .to(edge.getObjectId())
-            .set("provenance")
-            .to(edge.getProvenance())
-            .set("object_hash")
-            .to(edge.getObjectHash());
-    if (storeValueAsBytes(edge.getPredicate())) {
-      builder.set("object_bytes").to(ByteArray.copyFrom(compressString(edge.getObjectValue())));
-    } else {
-      builder.set("object_value").to(edge.getObjectValue());
-    }
-    return builder.build();
-  }
-
-  /**
-   * Returns true if the object value for the given predicate should be stored as bytes in Spanner,
-   * false otherwise.
-   */
-  private boolean storeValueAsBytes(String predicate) {
-    return STORE_VALUE_AS_BYTES_PREDICATES.contains(predicate);
-  }
-
-  public static byte[] compressString(String data) {
-    try {
-      var out = new ByteArrayOutputStream();
-      try (GZIPOutputStream gout = new GZIPOutputStream(out)) {
-        // Default charset can differ across platforms. Using UTF-8 here.
-        gout.write(data.getBytes(StandardCharsets.UTF_8));
-      }
-      return out.toByteArray();
-    } catch (IOException e) {
-      throw new RuntimeException("Error serializing string: " + data, e);
-    }
+    return Mutation.newInsertOrUpdateBuilder(edgeTableName)
+        .set("subject_id")
+        .to(edge.getSubjectId())
+        .set("predicate")
+        .to(edge.getPredicate())
+        .set("object_id")
+        .to(edge.getObjectId())
+        .set("provenance")
+        .to(edge.getProvenance())
+        .build();
   }
 
   public Mutation toObservationMutation(Observation observation) {
@@ -159,7 +117,7 @@ public class SpannerClient implements Serializable {
         .set("provenance_url")
         .to(observation.getProvenanceUrl())
         .set("is_dc_aggregate")
-        .to(observation.isDcAggregate())
+        .to(observation.getIsDcAggregate())
         .build();
   }
 
@@ -259,7 +217,6 @@ public class SpannerClient implements Serializable {
             getMutationValue(mutationMap, "subject_id"),
             getMutationValue(mutationMap, "predicate"),
             getMutationValue(mutationMap, "object_id"),
-            getMutationValue(mutationMap, "object_hash"),
             getMutationValue(mutationMap, "provenance"));
   }
 
@@ -277,8 +234,7 @@ public class SpannerClient implements Serializable {
     }
 
     String objectId = getMutationValue(mutationMap, "object_id");
-    String objectHash = getMutationValue(mutationMap, "object_hash");
-    int shard = Math.abs(Objects.hash(objectId, objectHash)) % numShards;
+    int shard = Math.abs(Objects.hash(objectId)) % numShards;
 
     return Joiner.on("::").join(subjectId, shard);
   }
@@ -306,11 +262,7 @@ public class SpannerClient implements Serializable {
         new String[] {
           getMutationValue(mutationMap, "variable_measured"),
           getMutationValue(mutationMap, "observation_about"),
-          getMutationValue(mutationMap, "import_name"),
-          getMutationValue(mutationMap, "observation_period"),
-          getMutationValue(mutationMap, "measurement_method"),
-          getMutationValue(mutationMap, "unit"),
-          getMutationValue(mutationMap, "scaling_factor")
+          getMutationValue(mutationMap, "facet_id")
         };
 
     return Joiner.on("::").join(parts);

--- a/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/CacheReaderTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/CacheReaderTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 
 public class CacheReaderTest {
   @Test
-  public void testParseArcRow_outArcwithNode() {
+  public void testParseArcRow_outArcWithReferenceNode() {
     CacheReader reader = newCacheReader();
     String row =
         "d/m/Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person^measuredProperty^Property^0,H4sIAAAAAAAAAOPS5WJNzi/NK5GCUEqyKcn6SYnFqfoepbmJeUGpiSmJSTmpwSWJJWGJRcWCDGDwwR4AejAnwDgAAAA=";
@@ -16,14 +16,19 @@ public class CacheReaderTest {
     NodesEdges expected =
         new NodesEdges()
             .addNode(
-                Node.builder().subjectId("count").name("count").types(List.of("Property")).build())
+                Node.builder()
+                    .subjectId("count")
+                    .value("count")
+                    .reference(true)
+                    .name("count")
+                    .types(List.of("Property"))
+                    .build())
             .addEdge(
                 Edge.builder()
                     .subjectId(
                         "Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person")
                     .predicate("measuredProperty")
                     .objectId("count")
-                    .objectValue("")
                     .provenance("dc/base/HumanReadableStatVars")
                     .build());
 
@@ -33,22 +38,25 @@ public class CacheReaderTest {
   }
 
   @Test
-  public void testParseArcRow_outArcwithoutNode() {
+  public void testParseArcRow_outArcWithValueNode() {
     CacheReader reader = newCacheReader();
     String row =
         "d/m/Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person^name^^0,H4sIAAAAAAAAAONqYFSSTUnWT0osTtX3KM1NzAtKTUxJTMpJDS5JLAlLLCrWig9ILUpOzStJTE9VCM8vylYISs1JLElNUQjIqCzOTE7MUXBMLsksyyyp1FHwzU9JLQJKwoUU/IsUPFITyyoRIo65+XnpCgH5BaVAYzLz8wQZwOCDPQA1JajOjAAAAA==";
 
     NodesEdges expected =
         new NodesEdges()
+            .addNode(
+                Node.builder()
+                    .subjectId("c6CV18sK/njghkqgkS/mMaTkKP+oWup0pgYkS6iFpvY=")
+                    .value(
+                        "Percentage Work Related Physical Activity, Moderate Activity Or Heavy Activity Among Population")
+                    .build())
             .addEdge(
                 Edge.builder()
                     .subjectId(
                         "Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person")
                     .predicate("name")
-                    .objectId(
-                        "Percent_WorkRelatedPhysicalActivity_ModerateActivityOrHeavyActivity_In_Count_Person")
-                    .objectValue(
-                        "Percentage Work Related Physical Activity, Moderate Activity Or Heavy Activity Among Population")
+                    .objectId("c6CV18sK/njghkqgkS/mMaTkKP+oWup0pgYkS6iFpvY=")
                     .provenance("dc/base/HumanReadableStatVars")
                     .build());
 
@@ -68,6 +76,8 @@ public class CacheReaderTest {
             .addNode(
                 Node.builder()
                     .subjectId("dc/base/UN_SDG")
+                    .value("dc/base/UN_SDG")
+                    .reference(true)
                     .name("UN_SDG")
                     .types(List.of("Provenance"))
                     .build())
@@ -76,7 +86,6 @@ public class CacheReaderTest {
                     .subjectId("dc/base/UN_SDG")
                     .predicate("isPartOf")
                     .objectId("dc/d/UnitedNationsUn_SdgIndicatorsDatabase")
-                    .objectValue("")
                     .provenance("dc/base/UN_SDG")
                     .build());
 
@@ -121,6 +130,7 @@ public class CacheReaderTest {
                 .measurementMethod("NOAA_GFS")
                 .scalingFactor("")
                 .unit("Millimeter")
+                .isDcAggregate(true)
                 .provenanceUrl(
                     "https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast")
                 .importName("NOAA_GFS_WeatherForecast")
@@ -130,40 +140,43 @@ public class CacheReaderTest {
         new NodesEdges()
             .addNode(
                 Node.builder()
-                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755143")
-                    .name("Mean Precipitable Water Atmosphere | geoId/sch2915390 | 870755143")
+                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755137")
+                    .value("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755137")
+                    .reference(true)
+                    .name("Mean_PrecipitableWater_Atmosphere | geoId/sch2915390 | 870755137")
                     .types(List.of("StatVarObsSeries"))
                     .build())
+            .addNode(
+                Node.builder()
+                    .subjectId("jVWNIHt73yOspqKD0fnvTCH8GCW7m38F3gW+JB+aWms=")
+                    .value("Mean_PrecipitableWater_Atmosphere | geoId/sch2915390 | 870755137")
+                    .build())
             .addEdge(
                 Edge.builder()
-                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755143")
+                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755137")
                     .predicate("variableMeasured")
                     .objectId("Mean_PrecipitableWater_Atmosphere")
-                    .objectValue("")
                     .provenance("dc/base/NOAA_GFS_WeatherForecast")
                     .build())
             .addEdge(
                 Edge.builder()
-                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755143")
+                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755137")
                     .predicate("observationAbout")
                     .objectId("geoId/sch2915390")
-                    .objectValue("")
                     .provenance("dc/base/NOAA_GFS_WeatherForecast")
                     .build())
             .addEdge(
                 Edge.builder()
-                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755143")
+                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755137")
                     .predicate("name")
-                    .objectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755143")
-                    .objectValue("Mean_PrecipitableWater_Atmosphere | geoId/sch2915390 | 870755143")
+                    .objectId("jVWNIHt73yOspqKD0fnvTCH8GCW7m38F3gW+JB+aWms=")
                     .provenance("dc/base/NOAA_GFS_WeatherForecast")
                     .build())
             .addEdge(
                 Edge.builder()
-                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755143")
+                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755137")
                     .predicate("typeOf")
                     .objectId("StatVarObsSeries")
-                    .objectValue("")
                     .provenance("dc/base/NOAA_GFS_WeatherForecast")
                     .build());
 

--- a/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/GraphReaderTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/GraphReaderTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import org.datacommons.proto.Mcf.McfGraph;
@@ -90,11 +89,27 @@ public class GraphReaderTest {
         Arrays.asList(
             Node.builder()
                 .subjectId("dcid0")
+                .value("dcid0")
+                .reference(true)
                 .name("Node Zero")
                 .types(List.of("Class", "Thing"))
                 .build(),
-            Node.builder().subjectId("dcid1").name("Node One").types(List.of("Property")).build(),
-            Node.builder().subjectId("dcid2").name("").types(Collections.emptyList()).build());
+            Node.builder()
+                .subjectId("dcid1")
+                .value("dcid1")
+                .reference(true)
+                .name("Node One")
+                .types(List.of("Property"))
+                .build(),
+            Node.builder().subjectId("dcid2").value("dcid2").reference(true).build(),
+            Node.builder()
+                .subjectId("kUyRupzrJkxe/HIOIctxlJX4woEGeOTtlVwqyXYnfDE=")
+                .value("Node Zero")
+                .build(),
+            Node.builder()
+                .subjectId("J7we8EV8ssChRxBgWot6zDSbHl4xGY7I6mQosc89hFk=")
+                .value("Node One")
+                .build());
 
     List<Node> actualNodes = GraphReader.graphToNodes(graph);
 
@@ -108,6 +123,9 @@ public class GraphReaderTest {
       Node expected = expectedNodes.get(i);
       Node actual = actualNodes.get(i);
       assertEquals(expected.getSubjectId(), actual.getSubjectId());
+      assertEquals(expected.getValue(), actual.getValue());
+      assertEquals(expected.getBytes(), actual.getBytes());
+      assertEquals(expected.getReference(), actual.getReference());
       assertEquals(expected.getName(), actual.getName());
       assertArrayEquals(expected.getTypes().toArray(), actual.getTypes().toArray());
     }
@@ -153,6 +171,14 @@ public class GraphReaderTest {
                                     .setType(ValueType.TEXT)
                                     .setValue("A test description"))
                             .build())
+                    .putPvs(
+                        "provenance",
+                        McfGraph.Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setType(ValueType.RESOLVED_REF)
+                                    .setValue("dc/base/Test"))
+                            .build())
                     .build())
             .putNodes(
                 "dcid_obs", // This should be skipped as it's an observation
@@ -173,20 +199,32 @@ public class GraphReaderTest {
             Edge.builder()
                 .subjectId("dcid_subject")
                 .predicate("name")
-                .objectId("dcid_subject")
-                .objectValue("Subject Node")
+                .objectId("mccrOBZqQNkHnRh1HpDlRRCFk+0dKKdYJFwWqrIw71s=")
+                .provenance("dc/base/Test")
                 .build(),
-            Edge.builder().subjectId("dcid_subject").predicate("typeOf").objectId("Class").build(),
+            Edge.builder()
+                .subjectId("dcid_subject")
+                .predicate("typeOf")
+                .objectId("Class")
+                .provenance("dc/base/Test")
+                .build(),
             Edge.builder()
                 .subjectId("dcid_subject")
                 .predicate("containedInPlace")
                 .objectId("geoId/06")
+                .provenance("dc/base/Test")
                 .build(),
             Edge.builder()
                 .subjectId("dcid_subject")
                 .predicate("description")
-                .objectId("dcid_subject")
-                .objectValue("A test description")
+                .objectId("Qa4HqNXvAF/E5uwL1wf1QtUS1qKwulUzF/F1HtAY6fk=")
+                .provenance("dc/base/Test")
+                .build(),
+            Edge.builder()
+                .subjectId("dcid_subject")
+                .predicate("provenance")
+                .objectId("dc/base/Test")
+                .provenance("dc/base/Test")
                 .build());
 
     List<Edge> actualEdges = GraphReader.graphToEdges(graph);
@@ -195,8 +233,7 @@ public class GraphReaderTest {
     Comparator<Edge> edgeComparator =
         Comparator.comparing(Edge::getSubjectId)
             .thenComparing(Edge::getPredicate)
-            .thenComparing(Edge::getObjectId)
-            .thenComparing(Edge::getObjectValue);
+            .thenComparing(Edge::getObjectId);
     actualEdges.sort(edgeComparator);
     expectedEdges.sort(edgeComparator);
 


### PR DESCRIPTION
Updates ingestion pipelines to use revised schema with generated nodes

Tested with unit tests and dc_graph_13 instance

Also, for Observation table
* Adds facet_id field
* Fixes setting is_dc_aggregate field