### PR TITLE
Create spanner tables in ingestion pipeline

### DIFF
--- a/pipeline/ingestion/pom.xml
+++ b/pipeline/ingestion/pom.xml
@@ -24,6 +24,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>libraries-bom</artifactId>
+                <version>26.62.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -72,6 +79,14 @@
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-spanner</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.api.grpc</groupId>
+            <artifactId>proto-google-cloud-spanner-admin-database-v1</artifactId>
+            </dependency>
+        <dependency>
+            <groupId>com.google.api.grpc</groupId>
+            <artifactId>grpc-google-cloud-spanner-admin-database-v1</artifactId>
+            </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/pipeline/ingestion/pom.xml
+++ b/pipeline/ingestion/pom.xml
@@ -82,11 +82,11 @@
         <dependency>
             <groupId>com.google.api.grpc</groupId>
             <artifactId>proto-google-cloud-spanner-admin-database-v1</artifactId>
-            </dependency>
+        </dependency>
         <dependency>
             <groupId>com.google.api.grpc</groupId>
             <artifactId>grpc-google-cloud-spanner-admin-database-v1</artifactId>
-            </dependency>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/pipeline/ingestion/src/main/resources/spanner_schema.sql
+++ b/pipeline/ingestion/src/main/resources/spanner_schema.sql
@@ -1,0 +1,32 @@
+CREATE PROTO BUNDLE (
+  `org.datacommons.Observations`
+)
+
+CREATE TABLE Node (
+  subject_id STRING(1024) NOT NULL,
+  value STRING(MAX),
+  bytes BYTES(MAX),
+  name STRING(MAX),
+  types ARRAY<STRING(1024)>,
+) PRIMARY KEY(subject_id)
+
+CREATE TABLE Edge (
+  subject_id STRING(1024) NOT NULL,
+  predicate STRING(1024) NOT NULL,
+  object_id STRING(1024) NOT NULL,
+  provenance STRING(1024) NOT NULL,
+) PRIMARY KEY(subject_id, predicate, object_id, provenance)
+
+CREATE TABLE Observation (
+  variable_measured STRING(1024) NOT NULL,
+  observation_about STRING(1024) NOT NULL,
+  facet_id STRING(1024) NOT NULL,
+  observation_period STRING(1024),
+  measurement_method STRING(1024),
+  unit STRING(1024),
+  scaling_factor STRING(1024),
+  observations org.datacommons.Observations,
+  import_name STRING(1024),
+  provenance_url STRING(1024),
+  is_dc_aggregate BOOL,
+) PRIMARY KEY(variable_measured, observation_about, facet_id)

--- a/pipeline/model/pom.xml
+++ b/pipeline/model/pom.xml
@@ -37,25 +37,58 @@
               <goal>detect</goal>
             </goals>
           </execution>
-        </executions>
+        </executions> 
       </plugin>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>${protobuf.maven.plugin.version}</version>
+        <version>${protobuf.maven.plugin.version}</version> 
         <configuration>
-          <protocArtifact>
-            com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}
-          </protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+          <clearOutputDirectory>false</clearOutputDirectory>
+          <protoSourceRoot>${project.basedir}/src/main/proto</protoSourceRoot>
+          <outputDirectory>${project.build.directory}/generated-sources/protobuf</outputDirectory>
+          <includeSourceInfoInDescriptorSet>true</includeSourceInfoInDescriptorSet>
+          <writeDescriptorSet>true</writeDescriptorSet>
+          <descriptorSetFileName>descriptor.proto.bin</descriptorSetFileName>
+          <descriptorSetOutputDirectory>${project.build.directory}/generated-resources/protobuf</descriptorSetOutputDirectory>
+          <attachDescriptorSet>true</attachDescriptorSet>
         </configuration>
         <executions>
           <execution>
-            <goals>
-              <goal>compile</goal>
-              <goal>test-compile</goal>
-            </goals>
+              <id>compile-protobuf</id>
+              <goals>
+                  <goal>compile</goal>
+                  <goal>test-compile</goal>
+              </goals>
+              <phase>generate-sources</phase>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.2.0</version>
+          <executions>
+              <execution>
+                  <id>copy-proto-descriptor</id>
+                  <phase>process-resources</phase>
+                  <goals>
+                      <goal>copy-resources</goal>
+                  </goals>
+                  <configuration>
+                      <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                      <resources>
+                          <resource>
+                              <directory>${project.build.directory}/generated-resources/protobuf</directory>
+                              <includes>
+                                  <include>descriptor.proto.bin</include>
+                              </includes>
+                          </resource>
+                      </resources>
+                  </configuration>
+              </execution>
+          </executions>
       </plugin>
     </plugins>
   </build>

--- a/pipeline/model/pom.xml
+++ b/pipeline/model/pom.xml
@@ -37,12 +37,12 @@
               <goal>detect</goal>
             </goals>
           </execution>
-        </executions> 
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>${protobuf.maven.plugin.version}</version> 
+        <version>${protobuf.maven.plugin.version}</version>
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
           <clearOutputDirectory>false</clearOutputDirectory>

--- a/pipeline/model/src/main/proto/README.md
+++ b/pipeline/model/src/main/proto/README.md
@@ -42,7 +42,7 @@ Reference: https://cloud.google.com/spanner/docs/reference/standard-sql/protocol
 ---
 
 Ensure that the package name and message name used in the DDL
-(e.g. `org.datacommons.proto.Observations`) 
+(e.g. `org.datacommons.Observations`) 
 exactly match what's in `storage.proto` and the generated bundle.
 
 ---

--- a/pipeline/model/src/main/proto/storage.proto
+++ b/pipeline/model/src/main/proto/storage.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package org.datacommons.proto;
+package org.datacommons;
 
 // Includes protos that are used in spanner storage.
 // The protos are typically gzipped and stored in a bytes column.

--- a/pom.xml
+++ b/pom.xml
@@ -107,11 +107,11 @@
             <artifactId>protobuf-maven-plugin</artifactId>
             <version>0.6.1</version> 
             <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
-          <clearOutputDirectory>false</clearOutputDirectory>
-          <protoSourceRoot>${project.basedir}/src/main/proto</protoSourceRoot>
-          <outputDirectory>${project.build.directory}/generated-sources/protobuf</outputDirectory>
-        </configuration>
+                <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                <clearOutputDirectory>false</clearOutputDirectory>
+                <protoSourceRoot>${project.basedir}/src/main/proto</protoSourceRoot>
+                <outputDirectory>${project.build.directory}/generated-sources/protobuf</outputDirectory>
+            </configuration>
             <executions>
                 <execution>
                     <id>compile-protobuf</id>

--- a/pom.xml
+++ b/pom.xml
@@ -107,10 +107,11 @@
             <artifactId>protobuf-maven-plugin</artifactId>
             <version>0.6.1</version> 
             <configuration>
-                <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
-                <clearOutputDirectory>false</clearOutputDirectory>
-                <protoSourceRoot>${project.basedir}/src/main/proto</protoSourceRoot>
-            </configuration>
+          <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+          <clearOutputDirectory>false</clearOutputDirectory>
+          <protoSourceRoot>${project.basedir}/src/main/proto</protoSourceRoot>
+          <outputDirectory>${project.build.directory}/generated-sources/protobuf</outputDirectory>
+        </configuration>
             <executions>
                 <execution>
                     <id>compile-protobuf</id>


### PR DESCRIPTION
The pipeline will create the database and tables if they don't already exist

So we don't have to manually create new tables and can automatically include any ddl changes

Tested with dc_graph_16 and dc_graph_17 