### PR TITLE
Add basic ingestion logic for individual imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ target/
 .factorypath
 .project
 .flattened-pom.xml
+dependency-reduced-pom.xml
 
 util/src/main/java/org/datacommons/proto/
 

--- a/pipeline/differ/pom.xml
+++ b/pipeline/differ/pom.xml
@@ -31,10 +31,19 @@
             <artifactId>beam-sdks-java-core</artifactId>
             <version>${beam.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
+            <version>${beam.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-runners-direct-java</artifactId>
+            <version>${beam.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
             <version>${beam.version}</version>
         </dependency>
         <dependency>
@@ -62,55 +71,34 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.6.0</version>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>single</goal>
+                            <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <finalName>${project.artifactId}-bundled-${project.version}</finalName>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>org.datacommons.pipeline.differ.DifferPipeline</mainClass>
-                        </manifest>
-                    </archive>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>direct-runner</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.beam</groupId>
-                    <artifactId>beam-runners-direct-java</artifactId>
-                    <version>${beam.version}</version>
-                    <scope>runtime</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>dataflow-runner</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.beam</groupId>
-                    <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
-                    <version>${beam.version}</version>
-                    <scope>runtime</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
-
 </project>

--- a/pipeline/differ/src/main/java/org/datacommons/pipeline/differ/DifferPipeline.java
+++ b/pipeline/differ/src/main/java/org/datacommons/pipeline/differ/DifferPipeline.java
@@ -1,6 +1,5 @@
 package org.datacommons.pipeline.differ;
 
-import java.nio.file.Paths;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -18,7 +17,7 @@ public class DifferPipeline {
   private static final String DIFF_HEADER =
       "key_combined,value_combined_current,value_combined_previous,diff_type";
 
-  public static void main(String[] args) throws Exception {
+  public static void main(String[] args) {
 
     // Create the pipeline.
     DifferOptions options =
@@ -34,8 +33,8 @@ public class DifferPipeline {
       previousNodes = PipelineUtils.readMcfGraph(options.getPreviousData(), p);
     } else {
       LOGGER.info("Using mcf file format");
-      previousNodes = PipelineUtils.readMcfFile(options.getPreviousData(), p);
-      currentNodes = PipelineUtils.readMcfFile(options.getCurrentData(), p);
+      previousNodes = PipelineUtils.readMcfFiles(options.getPreviousData(), p);
+      currentNodes = PipelineUtils.readMcfFiles(options.getCurrentData(), p);
     }
 
     // Process the input and perform diff operation.
@@ -54,17 +53,17 @@ public class DifferPipeline {
     obsDiff.apply(
         "Write observation diff output",
         TextIO.write()
-            .to(Paths.get(options.getOutputLocation(), "obs-diff").toString())
+            .to(options.getOutputLocation() + "/" + "obs-diff")
             .withSuffix(".csv")
             .withNumShards(1)
             .withHeader(DIFF_HEADER));
     schemaDiff.apply(
         "Write schema diff output",
         TextIO.write()
-            .to(Paths.get(options.getOutputLocation(), "schema-diff").toString())
+            .to(options.getOutputLocation() + "/" + "schema-diff")
             .withSuffix(".csv")
             .withNumShards(1)
             .withHeader(DIFF_HEADER));
-    p.run().waitUntilFinish();
+    p.run();
   }
 }

--- a/pipeline/differ/src/test/java/org/datacommons/pipeline/differ/DifferTest.java
+++ b/pipeline/differ/src/test/java/org/datacommons/pipeline/differ/DifferTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import org.apache.beam.runners.direct.DirectRunner;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
@@ -27,6 +28,7 @@ public class DifferTest {
   @Test
   public void testDiffer() {
     options.setStableUniqueNames(PipelineOptions.CheckEnabled.OFF);
+    options.setRunner(DirectRunner.class);
 
     // Create an input PCollection.
     String currentFile = getClass().getClassLoader().getResource("current").getPath();
@@ -34,9 +36,9 @@ public class DifferTest {
 
     // Process the input.
     PCollection<McfGraph> currentGraph =
-        PipelineUtils.readMcfFile(Paths.get(currentFile, "*.mcf").toString(), p);
+        PipelineUtils.readMcfFiles(Paths.get(currentFile, "*.mcf").toString(), p);
     PCollection<McfGraph> previousGraph =
-        PipelineUtils.readMcfFile(Paths.get(previousFile, "*.mcf").toString(), p);
+        PipelineUtils.readMcfFiles(Paths.get(previousFile, "*.mcf").toString(), p);
     PCollectionTuple currentNodesTuple = DifferUtils.processGraph(currentGraph);
     PCollectionTuple previousNodesTuple = DifferUtils.processGraph(previousGraph);
 

--- a/pipeline/differ/template.sh
+++ b/pipeline/differ/template.sh
@@ -5,19 +5,20 @@ OPERATION=$1
 if [ "$OPERATION" == "deploy" ]; then
     echo "Deploying Dataflow Flex Template..."
     gcloud dataflow flex-template build \
-        "gs://datcom-dataflow/templates/flex/differ.json" \
+        "gs://datcom-templates/templates/flex/differ.json" \
         --image-gcr-path "gcr.io/datcom-ci/dataflow-templates/differ:latest" \
         --sdk-language "JAVA" \
         --flex-template-base-image JAVA17 \
         --metadata-file "metadata.json" \
-        --jar "target/differ-0.1-SNAPSHOT-jar-with-dependencies.jar" \
+        --jar "target/differ-bundled-0.1-SNAPSHOT.jar" \
         --env FLEX_TEMPLATE_JAVA_MAIN_CLASS="org.datacommons.pipeline.differ.DifferPipeline"
 elif [ "$OPERATION" == "run" ]; then
     echo "Running Dataflow Flex Template..."
     gcloud dataflow flex-template run "differ-job" \
-        --template-file-gcs-location "gs://datcom-dataflow/templates/flex/differ.json" \
-        --parameters importList="import_a,import_b" \
-        --parameters spannerDatabaseId="dc_graph_db" \
+        --template-file-gcs-location "gs://datcom-templates/templates/flex/differ.json" \
+        --parameters currentData="gs://datcom-prod-imports/scripts/import-path/*.mcf" \
+        --parameters previousData="gs://datcom-prod-imports/scripts/import-path/*.mcf" \
+        --parameters outputLocation="gs://datcom-dataflow/differ/output" \
         --project=datcom-store \
         --region "us-central1"
 else

--- a/pipeline/ingestion/pom.xml
+++ b/pipeline/ingestion/pom.xml
@@ -49,10 +49,17 @@
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-core</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-runners-direct-java</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -107,53 +114,34 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.6.0</version>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>single</goal>
+                            <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <finalName>${project.artifactId}-bundled-${project.version}</finalName>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>org.datacommons.SpannerIngestion</mainClass>
-                        </manifest>
-                    </archive>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>direct-runner</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.beam</groupId>
-                    <artifactId>beam-runners-direct-java</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>dataflow-runner</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.beam</groupId>
-                    <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
-
 </project>

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/ImportGroupPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/ImportGroupPipeline.java
@@ -1,16 +1,48 @@
 package org.datacommons.ingestion.pipeline;
 
-import static org.datacommons.ingestion.pipeline.Transforms.buildImportGroupPipeline;
-
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerWriteResult;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.datacommons.ingestion.data.CacheReader;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.Values;
+import org.apache.beam.sdk.transforms.Wait;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.datacommons.ingestion.data.GraphReader;
 import org.datacommons.ingestion.spanner.SpannerClient;
+import org.datacommons.pipeline.util.PipelineUtils;
+import org.datacommons.proto.Mcf.McfGraph;
+import org.datacommons.proto.Mcf.McfOptimizedGraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ImportGroupPipeline {
   private static final Logger LOGGER = LoggerFactory.getLogger(ImportGroupPipeline.class);
+  private static final String TABLE_MCF_NODES = "table_mcf_nodes";
+  private static final String INSTANCE_MCF_NODES = "instance_mcf_nodes";
+  private static final String GCS_PREFIX = "gs://";
+  private static final String MCF_SUFFIX = "*.mcf";
+  private static final Counter counter =
+      Metrics.counter(ImportGroupPipeline.class, "mcf_nodes_without_type");
+
+  private static String getGraphPath(String projectId, String bucketId, String importName) {
+    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    String importPath = importName.replace(":", "/");
+    String versionPath = Paths.get(importPath, "latest_version.txt").toString();
+    Blob blob = storage.get(bucketId, versionPath);
+    String version = new String(blob.getContent());
+    String graphPath = Paths.get(bucketId, importPath, version, "*", "validation").toString();
+    return GCS_PREFIX + graphPath;
+  }
 
   public static void main(String[] args) {
     IngestionPipelineOptions options =
@@ -32,12 +64,55 @@ public class ImportGroupPipeline {
     LOGGER.info("Spanner DDL creation complete.");
 
     Pipeline pipeline = Pipeline.create(options);
-    LOGGER.info(
-        "Running import group pipeline for import group: {}", options.getImportGroupVersion());
+    LOGGER.info("Running import pipeline for imports: {}", options.getImportList());
 
-    CacheReader cacheReader = new CacheReader(options.getStorageBucketId());
+    String[] imports = options.getImportList().split(",");
+    List<PCollection<Mutation>> obsMutationList = new ArrayList<>();
+    List<PCollection<Mutation>> edgeMutationList = new ArrayList<>();
+    List<PCollection<Mutation>> nodeMutationList = new ArrayList<>();
+    for (String importName : imports) {
+      String path = getGraphPath(options.getProjectId(), options.getStorageBucketId(), importName);
+      LOGGER.info("Import {} graph path {}", importName, path);
+      // Read schema mcf files and combine MCF nodes, and convert to spanner mutations (Node/Edge).
+      PCollection<McfGraph> schemaNodes =
+          PipelineUtils.readMcfFiles(path + "/" + INSTANCE_MCF_NODES + MCF_SUFFIX, pipeline);
+      PCollection<McfGraph> combinedGraph = PipelineUtils.combineGraphNodes(schemaNodes);
+      PCollection<Mutation> nodeMutations =
+          GraphReader.graphToNodes(combinedGraph, spannerClient, counter)
+              .apply("ExtractNodeMutations", Values.create());
+      PCollection<Mutation> edgeMutations =
+          GraphReader.graphToEdges(combinedGraph, spannerClient, counter)
+              .apply("ExtractEdgeMutations", Values.create());
+      nodeMutationList.add(nodeMutations);
+      edgeMutationList.add(edgeMutations);
 
-    buildImportGroupPipeline(pipeline, options.getImportGroupVersion(), cacheReader, spannerClient);
+      // Read observation mcf files, build optimized graph, and convert to spanner mutations
+      // (Observation).
+      PCollection<McfGraph> observationNodes =
+          PipelineUtils.readMcfFiles(path + "/" + TABLE_MCF_NODES + MCF_SUFFIX, pipeline);
+      PCollection<McfOptimizedGraph> optimizedGraph =
+          PipelineUtils.buildOptimizedMcfGraph(observationNodes);
+      // PCollection<McfOptimizedGraph> optimizedGraph =
+      //     PipelineUtils.readOptimizedMcfGraph(path, pipeline);
+      PCollection<Mutation> observationMutations =
+          GraphReader.graphToObservations(optimizedGraph, spannerClient)
+              .apply("ExtractObsMutations", Values.create());
+      obsMutationList.add(observationMutations);
+    }
+    // Write the mutations to spanner.
+    PCollection<Mutation> obsMutations =
+        PCollectionList.of(obsMutationList).apply(Flatten.pCollections());
+    obsMutations.apply("WriteObsToSpanner", spannerClient.getWriteTransform());
+    PCollection<Mutation> nodeMutations =
+        PCollectionList.of(nodeMutationList).apply(Flatten.pCollections());
+    SpannerWriteResult result =
+        nodeMutations.apply("WriteNodesToSpanner", spannerClient.getWriteTransform());
+    PCollection<Mutation> edgeMutations =
+        PCollectionList.of(edgeMutationList).apply(Flatten.pCollections());
+    // Wait for node mutations to complete before writing edge mutations.
+    edgeMutations
+        .apply(Wait.on(result.getOutput()))
+        .apply("WriteEdgesToSpanner", spannerClient.getWriteTransform());
 
     pipeline.run();
   }

--- a/pipeline/ingestion/template.sh
+++ b/pipeline/ingestion/template.sh
@@ -5,17 +5,17 @@ OPERATION=$1
 if [ "$OPERATION" == "deploy" ]; then
     echo "Deploying Dataflow Flex Template..."
     gcloud dataflow flex-template build \
-        "gs://datcom-dataflow/templates/flex/ingestion.json" \
+        "gs://datcom-templates/templates/flex/ingestion.json" \
         --image-gcr-path "gcr.io/datcom-ci/dataflow-templates/ingestion:latest" \
         --sdk-language "JAVA" \
         --flex-template-base-image JAVA17 \
         --metadata-file "metadata.json" \
-        --jar "target/ingestion-0.1-SNAPSHOT-jar-with-dependencies.jar" \
+        --jar "target/ingestion-bundled-0.1-SNAPSHOT.jar" \
         --env FLEX_TEMPLATE_JAVA_MAIN_CLASS="org.datacommons.ingestion.pipeline.ImportGroupPipeline"
 elif [ "$OPERATION" == "run" ]; then
     echo "Running Dataflow Flex Template..."
     gcloud dataflow flex-template run "ingestion-job" \
-        --template-file-gcs-location "gs://datcom-dataflow/templates/flex/ingestion.json" \
+        --template-file-gcs-location "gs://datcom-templates/templates/flex/ingestion.json" \
         --parameters importList="import_a,import_b" \
         --parameters spannerDatabaseId="dc_graph_db" \
         --project=datcom-store \

--- a/pipeline/util/src/main/java/org/datacommons/pipeline/util/PipelineUtils.java
+++ b/pipeline/util/src/main/java/org/datacommons/pipeline/util/PipelineUtils.java
@@ -22,6 +22,7 @@ import java.util.zip.GZIPOutputStream;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.TFRecordIO;
 import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.io.fs.EmptyMatchTreatment;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
@@ -122,16 +123,22 @@ public class PipelineUtils {
   }
 
   /**
-   * Reads an MCF graph from a text file.
+   * Reads MCF graphs from text files.
    *
-   * @param file Input file.
+   * @param files Input files.
    * @param p Dataflow pipeline.
    * @return PCollection of McfGraph proto.
    */
-  public static PCollection<McfGraph> readMcfFile(String file, Pipeline p) {
+  public static PCollection<McfGraph> readMcfFiles(String files, Pipeline p) {
     String delimiter = "\n\n";
     PCollection<String> nodes =
-        p.apply("ReadMcfFile", TextIO.read().withDelimiter(delimiter.getBytes()).from(file));
+        p.apply(
+            "ReadMcfFile",
+            TextIO.read()
+                .withDelimiter(delimiter.getBytes())
+                .from(files)
+                .withEmptyMatchTreatment(EmptyMatchTreatment.ALLOW));
+
     PCollection<McfGraph> mcf =
         nodes.apply(
             "ProcesGraph",


### PR DESCRIPTION
Updated the import group pipeline to add basic logic to perform ingestion for a given import list (CSV). It reads the corresponding schame/observation mcf files in GCS which are generated by the auto-refresh scripts. 
Also, changed pom.xml to use the shade plugin which is the preferred solution for working with flex templates.
Updated few parameters.
Tested the successful ingestion and differ pipeline runs using flex templates in GCS.
Next steps: refine the ingestion logic to handle other types of imports (tfrecord files), handle deletion of records, and add synchronization with auto-refresh scripts.