### PR TITLE
Fix mcf parser error when dealing with lists of quoted strings

### DIFF
--- a/simple/kg_util/mcf_parser.py
+++ b/simple/kg_util/mcf_parser.py
@@ -135,7 +135,7 @@ def _parse_value(prop, value, pc):
 
 def _parse_values(prop, values_str, pc):
   value_pairs = []
-  for values in reader([values_str]):
+  for values in reader([values_str], skipinitialspace=True):
     for value in values:
       value_pairs.append(_parse_value(prop, value.strip(), pc))
     break


### PR DESCRIPTION
This PR introduces a small but important fix to correctly parse CSV-like value lists with leading spaces after commas

`_parse_values` currently uses Python’s `csv.reader` without `skipinitialspace=True`. When values are written as a comma‑separated list of quoted strings with a space after each comma (`, "`), the parser over‑splits on commas that are inside the quoted strings. This change enables `skipinitialspace=True` in `_parse_values` so quoted fields are handled correctly. No other parsing behavior changes.

## Problem
MCF lines can contain lists with multiple values as CSV‑like, quoted strings, for example:

```mcf
searchDescription: "A, A", "B, B", "C, C, C", "D"
```

With the current implementation:

```python
for values in reader([values_str]):  
    ...
```

the leading space after each comma means the next character is a space, not a quote. As a result, the `csv` parser treats the `"` as literal content and splits on every comma, including those inside quotes.

## Proposed Change

Use `skipinitialspace=True` when parsing value lists in `_parse_values`:

```diff
- for values in reader([values_str]):
+ for values in reader([values_str], skipinitialspace=True):
```

## Practical example

**Input (values\_str):**

```
"Grants provided to Mozambique for basic health services, focusing on primary healthcare and universal health coverage", "External financing in the form of grants to Mozambique for basic health infrastructure and primary health care programs", "Data on commitment, grant equivalents, and gross disbursement of external grants for basic health in Mozambique, reported by CRS", "Development assistance grants to Mozambique specifically for basic health and primary healthcare initiatives"
```

### Current behavior (7 items)

```python
[
 "Grants provided to Mozambique for basic health services, focusing on primary healthcare and universal health coverage",
 " "External financing in the form of grants to Mozambique for basic health infrastructure and primary health care programs"",
 " "Data on commitment",
 " grant equivalents",
 " and gross disbursement of external grants for basic health in Mozambique",
 " reported by CRS"",
 " "Development assistance grants to Mozambique specifically for basic health and primary healthcare initiatives""
]
```

### Fixed behavior (4 items, the correct number)

```python
[
 "Grants provided to Mozambique for basic health services, focusing on primary healthcare and universal health coverage",
 "External financing in the form of grants to Mozambique for basic health infrastructure and primary health care programs",
 "Data on commitment, grant equivalents, and gross disbursement of external grants for basic health in Mozambique, reported by CRS",
 "Development assistance grants to Mozambique specifically for basic health and primary healthcare initiatives"
]
```

These then flow through `_parse_value`, which strips surrounding quotes for non‑reference properties and returns four correct `(value, VALUE)` pairs.