### PR TITLE
Support custom ID namespace, SVG prefix, root SVG name

### DIFF
--- a/simple/stats/config.md
+++ b/simple/stats/config.md
@@ -195,24 +195,24 @@ If `true`, auto generates a hierarchy of groups based on properties of variables
 
 These optional top-level fields customize how the StatVarGroup hierarchy is generated and labeled. All are optional; defaults match the built-in values.
 
-- `svHierarchyPropsBlocklist`: Array of additional property dcids to exclude from hierarchy generation. These are added to the internal blocklist used by Data Commons.
-  - Example: `["DevelopmentFinanceRecipient", "DACCode", "CustomProperty"]`
-- `customSvgPrefix`: String prefix for generated custom StatVarGroup ids.
-  - If not set, and `customIdNamespace` is provided, it defaults to `<customIdNamespace>/g/`.
-  - Otherwise defaults to `"c/g/"`.
-  - Affects ids like `c/g/Person_Gender-Female`.
 - `defaultCustomRootStatVarGroupName`: Display name for the custom root StatVarGroup. Default: `"Custom Variables"`.
 - `customIdNamespace`: Namespace token for generated ids for SVs and manual groups. Default: `"custom"`.
   - Generated SV ids: `<namespace>/statvar_<n>` (e.g., `custom/statvar_1`).
   - Manual group ids: `<namespace>/g/group_<n>` (e.g., `custom/g/group_1`).
+- `customSvgPrefix`: String prefix for generated custom StatVarGroup ids.
+  - If not set, and `customIdNamespace` is provided, it defaults to `<customIdNamespace>/g/`.
+  - Otherwise defaults to `"c/g/"`.
+  - Affects ids like `c/g/Person_Gender-Female`.
+- `svHierarchyPropsBlocklist`: Array of additional property dcids to exclude from hierarchy generation. These are added to the internal blocklist used by Data Commons.
+  - Example: `["DevelopmentFinanceRecipient", "DACCode", "CustomProperty"]`
 
 Example fragment:
 
 ```json
 {
   "groupStatVarsByProperty": true,
-  "svHierarchyPropsBlocklist": ["DevelopmentFinanceRecipients", "DACCode"],
-  "customSvgPrefix": "ONE/g/",
   "defaultCustomRootStatVarGroupName": "ONE Data",
   "customIdNamespace": "ONE"
+  "customSvgPrefix": "OD/g/",
+  "svHierarchyPropsBlocklist": ["DevelopmentFinanceRecipients", "DACCode"],
 }

--- a/simple/stats/config.md
+++ b/simple/stats/config.md
@@ -190,3 +190,29 @@ Local directory:
 If `true`, auto generates a hierarchy of groups based on properties of variables in the dataset. Default is `false`.
 
 > TODO: Add more details.
+
+## Hierarchy and Group Customization
+
+These optional top-level fields customize how the StatVarGroup hierarchy is generated and labeled. All are optional; defaults match the built-in values.
+
+- `svHierarchyPropsBlocklist`: Array of additional property dcids to exclude from hierarchy generation. These are added to the internal blocklist used by Data Commons.
+  - Example: `["DevelopmentFinanceRecipient", "DACCode", "CustomProperty"]`
+- `customSvgPrefix`: String prefix for generated custom StatVarGroup ids. Must always include `/g/`
+  - If not set, and `customIdNamespace` is provided, it defaults to `<customIdNamespace>/g/`.
+  - Otherwise defaults to `"c/g/"`.
+  - Affects ids like `c/g/Person_Gender-Female`.
+- `defaultCustomRootStatVarGroupName`: Display name for the custom root StatVarGroup. Default: `"Custom Variables"`.
+- `customIdNamespace`: Namespace token for generated ids for SVs and manual groups. Default: `"custom"`.
+  - Generated SV ids: `<namespace>/statvar_<n>` (e.g., `custom/statvar_1`).
+  - Manual group ids: `<namespace>/g/group_<n>` (e.g., `custom/g/group_1`).
+
+Example fragment:
+
+```json
+{
+  "groupStatVarsByProperty": true,
+  "svHierarchyPropsBlocklist": ["DevelopmentFinanceRecipients", "DACCode"],
+  "customSvgPrefix": "ONE/g/",
+  "defaultCustomRootStatVarGroupName": "ONE Data",
+  "customIdNamespace": "ONE"
+}

--- a/simple/stats/config.md
+++ b/simple/stats/config.md
@@ -197,7 +197,7 @@ These optional top-level fields customize how the StatVarGroup hierarchy is gene
 
 - `svHierarchyPropsBlocklist`: Array of additional property dcids to exclude from hierarchy generation. These are added to the internal blocklist used by Data Commons.
   - Example: `["DevelopmentFinanceRecipient", "DACCode", "CustomProperty"]`
-- `customSvgPrefix`: String prefix for generated custom StatVarGroup ids. Must always include `/g/`
+- `customSvgPrefix`: String prefix for generated custom StatVarGroup ids.
   - If not set, and `customIdNamespace` is provided, it defaults to `<customIdNamespace>/g/`.
   - Otherwise defaults to `"c/g/"`.
   - Affects ids like `c/g/Person_Gender-Female`.

--- a/simple/stats/nodes.py
+++ b/simple/stats/nodes.py
@@ -56,6 +56,8 @@ class Nodes:
 
   def __init__(self, config: Config) -> None:
     self.config = config
+    # Custom namespace
+    self._custom_id_namespace = self.config.custom_id_namespace()
     # Dictionary of SVs from column name to SV
     self.variables: dict[str, StatVar] = {}
     # Dictionary of SVGs from SVG path to SVG
@@ -187,7 +189,7 @@ class Nodes:
     if re.fullmatch(_DCID_PATTERN, dcid):
       return dcid
     self._sv_generated_id_count += 1
-    return f"{_CUSTOM_SV_ID_PREFIX}{self._sv_generated_id_count}"
+    return f"{self._custom_id_namespace}/statvar_{self._sv_generated_id_count}"
 
   def _property_id(self, property_column_name: str) -> str:
     dcid = property_column_name
@@ -238,8 +240,9 @@ class Nodes:
         parent_path = "" if "/" not in path else path[:path.rindex("/")]
         parent_id = (self.groups[parent_path].id
                      if parent_path in self.groups else sc.ROOT_SVG_ID)
-        svg = StatVarGroup(f"{_CUSTOM_GROUP_ID_PREFIX}{len(self.groups) + 1}",
-                           tokens[index], parent_id)
+        svg = StatVarGroup(
+            f"{self._custom_id_namespace}/g/group_{len(self.groups) + 1}",
+            tokens[index], parent_id)
         self.groups[path] = svg
         self.ids_to_groups[svg.id] = svg
 
@@ -247,7 +250,11 @@ class Nodes:
 
   def _default_custom_group(self) -> StatVarGroup:
     if _DEFAULT_CUSTOM_GROUP_PATH not in self.groups:
-      self.groups[_DEFAULT_CUSTOM_GROUP_PATH] = _DEFAULT_CUSTOM_GROUP
+      # Compute id and name using config (falls back to schema constants).
+      root_id = sc.DEFAULT_CUSTOM_ROOT_SVG_ID
+      root_name = self.config.default_custom_root_svg_name()
+      svg = StatVarGroup(root_id, root_name, sc.ROOT_SVG_ID)
+      self.groups[_DEFAULT_CUSTOM_GROUP_PATH] = svg
     return self.groups[_DEFAULT_CUSTOM_GROUP_PATH]
 
   def entity_with_type(self, entity_dcid: str, entity_type: str):

--- a/simple/stats/runner.py
+++ b/simple/stats/runner.py
@@ -269,7 +269,11 @@ class Runner:
     dcid2name = schema.get_schema_names(schema_dcids, self.db)
 
     sv_hierarchy_result = stat_var_hierarchy_generator.generate(
-        triples=sv_triples, vertical_specs=vertical_specs, dcid2name=dcid2name)
+        triples=sv_triples,
+        vertical_specs=vertical_specs,
+        dcid2name=dcid2name,
+        custom_svg_prefix=self.config.custom_svg_prefix(),
+        sv_hierarchy_props_blocklist=self.config.sv_hierarchy_props_blocklist())
     self.svg_specialized_names = sv_hierarchy_result.svg_specialized_names
     logging.info("Inserting %s SVG triples into DB.",
                  len(sv_hierarchy_result.svg_triples))

--- a/simple/stats/stat_var_hierarchy_generator.py
+++ b/simple/stats/stat_var_hierarchy_generator.py
@@ -70,14 +70,19 @@ def _generate_internal(
     triples: list[Triple],
     vertical_specs: list[VerticalSpec],
     dcid2name: dict[str, str],
-    custom_svg_prefix: str = sc.CUSTOM_SVG_PREFIX,
-    default_custom_root_svg_id: str = sc.DEFAULT_CUSTOM_ROOT_SVG_ID,
-    sv_hierarchy_props_blocklist: set[str] = sc.SV_HIERARCHY_PROPS_BLOCKLIST
-) -> "StatVarHierarchy":
+    custom_svg_prefix: str | None = None,
+    default_custom_root_svg_id: str | None = None,
+    sv_hierarchy_props_blocklist: set[str] | None = None) -> "StatVarHierarchy":
   """Given a list of input triples (including stat vars), 
 generates a SV hierarchy and returns a list of output triples
 representing the hierarchy.
 """
+  if not custom_svg_prefix:
+    custom_svg_prefix = sc.CUSTOM_SVG_PREFIX
+  if not default_custom_root_svg_id:
+    default_custom_root_svg_id = sc.DEFAULT_CUSTOM_ROOT_SVG_ID
+  if not sv_hierarchy_props_blocklist:
+    sv_hierarchy_props_blocklist = sc.SV_HIERARCHY_PROPS_BLOCKLIST
 
   # Extract SVs.
   svs = _extract_svs(triples, sv_hierarchy_props_blocklist)

--- a/simple/stats/stat_var_hierarchy_generator.py
+++ b/simple/stats/stat_var_hierarchy_generator.py
@@ -480,8 +480,7 @@ def _to_dcid_token(token: str) -> str:
 
 def _extract_svs(
     triples: list[Triple],
-    sv_hierarchy_props_blocklist: set[str] = sc.SV_HIERARCHY_PROPS_BLOCKLIST
-) -> list[SVPropVals]:
+    sv_hierarchy_props_blocklist: set[str] | None = None) -> list[SVPropVals]:
   """Extracts SVs from the input triples.
   The following SV properties used for generating the SV hierarchy are extracted:
   - dcid
@@ -489,6 +488,9 @@ def _extract_svs(
   - PVs not in `sv_hierarchy_props_blocklist` (SV_HIERARCHY_PROPS_BLOCKLIST plus any custom blocklist)
   - measured property
   """
+
+  if not sv_hierarchy_props_blocklist:
+    sv_hierarchy_props_blocklist = sc.SV_HIERARCHY_PROPS_BLOCKLIST
 
   # Using dict instead of set to maintain order.
   # Maintaining order maintains results consistency and helps with tests.

--- a/simple/tests/stats/config_test.py
+++ b/simple/tests/stats/config_test.py
@@ -384,10 +384,8 @@ class TestConfig(unittest.TestCase):
         }).custom_id_namespace(), "ONE")
 
   def test_custom_svg_prefix_resolution(self):
-    from stats import schema_constants as sc
-
     # Default prefix falls back to schema constant
-    self.assertEqual(Config({}).custom_svg_prefix(), sc.CUSTOM_SVG_PREFIX)
+    self.assertEqual(Config({}).custom_svg_prefix(), "c/g/")
     # Explicit override takes precedence
     self.assertEqual(
         Config({
@@ -430,4 +428,52 @@ class TestConfig(unittest.TestCase):
     with self.assertRaisesRegex(ValueError, "must be a list of strings"):
       Config({
           "svHierarchyPropsBlocklist": "gender"
+      }).sv_hierarchy_props_blocklist()
+
+  def test_custom_id_namespace_validation(self):
+    # Valid overrides
+    self.assertEqual(
+        Config({
+            "customIdNamespace": "ONE"
+        }).custom_id_namespace(), "ONE")
+    self.assertEqual(
+        Config({
+            "customIdNamespace": "ACME_123"
+        }).custom_id_namespace(), "ACME_123")
+    # Invalid: contains slash
+    with self.assertRaises(ValueError):
+      Config({"customIdNamespace": "acme/ns"}).custom_id_namespace()
+    # Invalid: starts with slash
+    with self.assertRaises(ValueError):
+      Config({"customIdNamespace": "/acme"}).custom_id_namespace()
+    # Invalid: contains dash
+    with self.assertRaises(ValueError):
+      Config({"customIdNamespace": "ACME-123"}).custom_id_namespace()
+    # Invalid: empty string
+    with self.assertRaises(ValueError):
+      Config({"customIdNamespace": ""}).custom_id_namespace()
+
+  def test_custom_svg_prefix_validation(self):
+    from stats import schema_constants as sc
+
+    # Valid explicit
+    self.assertEqual(
+        Config({
+            "customSvgPrefix": "ONE/g/"
+        }).custom_svg_prefix(), "ONE/g/")
+    # Invalid: starts with '/'
+    with self.assertRaises(ValueError):
+      Config({"customSvgPrefix": "/ONE/g/"}).custom_svg_prefix()
+    # Invalid: missing trailing '/'
+    with self.assertRaises(ValueError):
+      Config({"customSvgPrefix": "ONE/g"}).custom_svg_prefix()
+    # Invalid: contains space
+    with self.assertRaises(ValueError):
+      Config({"customSvgPrefix": "ONE g/"}).custom_svg_prefix()
+
+  def test_sv_hierarchy_props_blocklist_string_items(self):
+    # Mixed type should raise
+    with self.assertRaisesRegex(ValueError, "must be a list of strings"):
+      Config({
+          "svHierarchyPropsBlocklist": ["gender", 123]
       }).sv_hierarchy_props_blocklist()

--- a/simple/tests/stats/config_test.py
+++ b/simple/tests/stats/config_test.py
@@ -373,3 +373,61 @@ class TestConfig(unittest.TestCase):
 
     config = Config({"includeInputSubdirs": True})
     self.assertTrue(config.include_input_subdirs())
+
+  def test_custom_id_namespace_default_and_override(self):
+    # Default namespace is "custom"
+    self.assertEqual(Config({}).custom_id_namespace(), "custom")
+    # Override via config
+    self.assertEqual(
+        Config({
+            "customIdNamespace": "ONE"
+        }).custom_id_namespace(), "ONE")
+
+  def test_custom_svg_prefix_resolution(self):
+    from stats import schema_constants as sc
+
+    # Default prefix falls back to schema constant
+    self.assertEqual(Config({}).custom_svg_prefix(), sc.CUSTOM_SVG_PREFIX)
+    # Explicit override takes precedence
+    self.assertEqual(
+        Config({
+            "customSvgPrefix": "ONE/g/"
+        }).custom_svg_prefix(), "ONE/g/")
+    # Derive from non-default customIdNamespace when prefix is not set
+    self.assertEqual(
+        Config({
+            "customIdNamespace": "ONE"
+        }).custom_svg_prefix(), "ONE/g/")
+
+  def test_default_custom_root_svg_name(self):
+    from stats import schema_constants as sc
+
+    # Default name from schema constants
+    self.assertEqual(
+        Config({}).default_custom_root_svg_name(),
+        sc.DEFAULT_CUSTOM_ROOT_SVG_NAME)
+    # Override via config
+    self.assertEqual(
+        Config({
+            "defaultCustomRootStatVarGroupName": "ONE Data"
+        }).default_custom_root_svg_name(), "ONE Data")
+
+  def test_sv_hierarchy_props_blocklist_merge_and_validation(self):
+    from stats import schema_constants as sc
+
+    # Default equals schema constant
+    self.assertSetEqual(
+        Config({}).sv_hierarchy_props_blocklist(),
+        sc.SV_HIERARCHY_PROPS_BLOCKLIST)
+    # Merge user-provided list with default
+    merged = Config({
+        "svHierarchyPropsBlocklist": ["gender", "customProp"]
+    }).sv_hierarchy_props_blocklist()
+    self.assertTrue("gender" in merged and "customProp" in merged)
+    for p in sc.SV_HIERARCHY_PROPS_BLOCKLIST:
+      self.assertIn(p, merged)
+    # Invalid type raises ValueError
+    with self.assertRaisesRegex(ValueError, "must be a list of strings"):
+      Config({
+          "svHierarchyPropsBlocklist": "gender"
+      }).sv_hierarchy_props_blocklist()

--- a/simple/tests/stats/config_test.py
+++ b/simple/tests/stats/config_test.py
@@ -454,8 +454,6 @@ class TestConfig(unittest.TestCase):
       Config({"customIdNamespace": ""}).custom_id_namespace()
 
   def test_custom_svg_prefix_validation(self):
-    from stats import schema_constants as sc
-
     # Valid explicit
     self.assertEqual(
         Config({

--- a/simple/tests/stats/stat_var_hierarchy_generator_test.py
+++ b/simple/tests/stats/stat_var_hierarchy_generator_test.py
@@ -262,3 +262,31 @@ class TestStatVarHierarchyGenerator(unittest.TestCase):
         svg_id,
         "c/g/Person_PropertyWithAReallyLongValue-HereIsAPropertyWithAReallyLongValueToTestCausingASubjectIDOverflowOfMoreThan255CharactersWhenLoadingIntoTheDatabase_AnotherPropertyWithAReallyLongValue-HereIsAotherPropertyWithAReallyLongValueToTestCausingA-fafb3dea"
     )
+
+  def test_gen_svg_id_with_custom_prefix(self):
+    sv_prop_vals = SVPropVals(
+        sv_id="sv1",
+        population_type="Person",
+        pvs=[PropVal("gender", "Female"),
+             PropVal("race", "Asian")],
+        measured_property="count")
+    svg_id = sv_prop_vals.gen_svg_id(custom_svg_prefix="acme/g/")
+    self.assertEqual(svg_id, "acme/g/Person_Gender-Female_Race-Asian")
+
+  def test_extract_svs_with_custom_blocklist(self):
+    # gender should be excluded when added to the custom blocklist
+    input_triples: list[Triple] = [
+        Triple("sv1", "typeOf", "StatisticalVariable", ""),
+        Triple("sv1", "populationType", "Person", ""),
+        Triple("sv1", "race", "Asian", ""),
+        Triple("sv1", "gender", "Female", ""),
+    ]
+    custom_blocklist = set(["gender"
+                           ])  # pass custom blocklist to exclude 'gender'
+    svs = _extract_svs(input_triples, custom_blocklist)
+    self.assertListEqual(svs, [
+        SVPropVals(sv_id="sv1",
+                   population_type="Person",
+                   pvs=[PropVal("race", "Asian")],
+                   measured_property="")
+    ])

--- a/simple/tests/stats/stat_var_hierarchy_generator_test.py
+++ b/simple/tests/stats/stat_var_hierarchy_generator_test.py
@@ -24,6 +24,8 @@ from stats.data import Triple
 from stats.stat_var_hierarchy_generator import *
 from stats.stat_var_hierarchy_generator import _extract_svs
 from stats.stat_var_hierarchy_generator import _generate_internal
+from stats.stat_var_hierarchy_generator import PropVal
+from stats.stat_var_hierarchy_generator import SVPropVals
 from tests.stats.test_util import compare_files
 from tests.stats.test_util import is_write_mode
 from tests.stats.test_util import read_triples_csv


### PR DESCRIPTION
This PR adds config-driven customisation for a number of settings which are currently hardcoded (ID namespace, SVG prefix, root statvar group name, hierarchy properties blocklist).  

It's the first in a small series of PRs which will focus on improving how statvar and groups Ids are generated to improve the front-end experience and make IDs deterministic.


## Problem
Given hardcoded constants in the code, with no overrides possible:
 - Generated IDs for SVs and manual groups were fixed to a default namespace .
 - The StatVarGroup hierarchy always used a fixed custom prefix and root name .
 - No way to extend the SV property blocklist used during hierarchy generation. This means potentially messy hierarchies if additional properties are used for StatVar nodes.

## Proposed Solution
- Config
      - `customIdNamespace`: controls generated SV IDs as <namespace>/statvar_<n> and manual group IDs as <namespace>/g/group_<n>.
      - `customSvgPrefix`: controls the prefix for generated custom SVG IDs (e.g., c/g/). Resolution order: explicit value; else if
  non-default customIdNamespace is set, derive as <namespace>/g/; else default to c/g/.
      - `defaultCustomRootStatVarGroupName`: sets the display name of the default custom root SVG; ID remains the default.
      - `svHierarchyPropsBlocklist`: extends the built-in blocklist used for grouping in the hierarchy.

- Pipeline
      - Nodes uses customIdNamespace for generated SV and group IDs; default root SVG name respects
  defaultCustomRootStatVarGroupName.
      - Runner passes customSvgPrefix and the merged blocklist into the hierarchy generator.
      - Hierarchy generator accepts and applies these overrides.


## Note

- This PR is fully backwards compatible and changes nothing in the current, default behaviour. 
- The root SVG ID remains the constant default. Only the display name is configurable to avoid destabilising other references.
- All tests are passing and I've added targeted tests for the proposed overrides. 
