### PR TITLE
Don't write placeholder nodes to spanner

### DIFF
--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/CacheReader.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/data/CacheReader.java
@@ -132,8 +132,11 @@ public class CacheReader implements Serializable {
               }
             }
 
-            // Add node.
-            if (!nodeId.isEmpty()) {
+            // Maybe add node.
+            // Triples with type Thing are from two different import groups.
+            // The corresponding Node is a placeholder and shouldn't be added.
+            // Instead it will be added as part of the import group where its defined.
+            if (!nodeId.isEmpty() && !typeOf.equals(PipelineUtils.TYPE_THING)) {
               result.addNode(
                   Node.builder()
                       .subjectId(nodeId)

--- a/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/CacheReaderTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/ingestion/data/CacheReaderTest.java
@@ -104,6 +104,30 @@ public class CacheReaderTest {
   }
 
   @Test
+  public void testParseArcRowForOutArcWithPlaceholderType() {
+    CacheReader reader = newCacheReader();
+    Counter mockMcfNodesWithoutTypeCounter = Mockito.mock(Counter.class);
+    String row =
+        "d/m/incentive/US_chronicleelectric.com_46d7ab0483fbe0aa^areaServed^Thing^0,H4sIAAAAAAAAAOOyl+JOzi/NKymq1A8NdlQySEnWT0osTtV3z89Pz0mNDy4tLknMzEtMyszJLKl0A7LykjMTczzzklPzSjLLUosFGcDggz0AKTVclkoAAAA=";
+
+    // No Nodes should be added, since they'll be defined in another import group.
+    NodesEdges expected =
+        new NodesEdges()
+            .addEdge(
+                Edge.builder()
+                    .subjectId("incentive/US_chronicleelectric.com_46d7ab0483fbe0aa")
+                    .predicate("areaServed")
+                    .objectId("country/USA")
+                    .provenance("dc/base/Google_SustainabilityFinancialIncentives")
+                    .build());
+
+    NodesEdges actual = reader.parseArcRow(row, mockMcfNodesWithoutTypeCounter);
+
+    assertEquals(expected, actual);
+    Mockito.verify(mockMcfNodesWithoutTypeCounter, Mockito.times(0)).inc();
+  }
+
+  @Test
   public void testParseArcRowForInArc() {
     CacheReader reader = newCacheReader();
     Counter mockMcfNodesWithoutTypeCounter = Mockito.mock(Counter.class);


### PR DESCRIPTION
Skip writing nodes for triples with type = Thing, since these are placeholders from triples spanning two import groups

Instead the nodes will be generated from triples in the import group where the node is defined

Previously updated all nodes so no existing nodes have Thing type and am adding tests to validate this for new schema (eg https://github.com/datacommonsorg/import/pull/432/files) 

Verified with dc_graph_2025_09_12 build that places now have the proper types