### PR TITLE
[DCP] Auto create tables when DB is empty

### DIFF
--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
@@ -58,7 +58,7 @@ public class GraphIngestionPipeline {
             .build();
 
     LOGGER.info("Starting Spanner DDL creation...");
-    spannerClient.createDatabase();
+    spannerClient.validateOrInitializeDatabase();
     LOGGER.info("Spanner DDL creation complete.");
 
     Pipeline pipeline = Pipeline.create(options);

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipeline.java
@@ -31,7 +31,7 @@ public class IngestionPipeline {
             .build();
 
     LOGGER.info("Starting Spanner DDL creation...");
-    spannerClient.createDatabase();
+    spannerClient.validateOrInitializeDatabase();
     LOGGER.info("Spanner DDL creation complete.");
 
     Pipeline pipeline = Pipeline.create(options);

--- a/pipeline/ingestion/src/test/java/org/datacommons/ingestion/pipeline/GraphIngestionPipelineIntegrationTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/ingestion/pipeline/GraphIngestionPipelineIntegrationTest.java
@@ -113,7 +113,7 @@ public class GraphIngestionPipelineIntegrationTest {
             .numShards(1)
             .emulatorHost(emulatorHost)
             .build();
-    spannerClient.createDatabase();
+    spannerClient.validateOrInitializeDatabase();
 
     // Clear tables
     DatabaseId dbId = DatabaseId.of(projectId, instanceId, databaseId);

--- a/pipeline/spanner/pom.xml
+++ b/pipeline/spanner/pom.xml
@@ -51,5 +51,29 @@
             <groupId>com.google.api.grpc</groupId>
             <artifactId>grpc-google-cloud-spanner-admin-database-v1</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-runners-direct-java</artifactId>
+            <version>${beam.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pipeline/spanner/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
+++ b/pipeline/spanner/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.beam.sdk.Pipeline;
@@ -127,6 +128,16 @@ public class SpannerClient implements Serializable {
 
       List<String> ddlStatements = readDdlStatements();
 
+      ByteString protoDescriptors;
+      try (InputStream inputStream =
+          getClass().getClassLoader().getResourceAsStream("descriptor.proto.bin")) {
+        if (inputStream == null) {
+          throw new java.io.FileNotFoundException(
+              "Could not find proto descriptor file (descriptor.proto.bin) in resources.");
+        }
+        protoDescriptors = ByteString.copyFrom(inputStream.readAllBytes());
+      }
+
       try {
         dbAdminClient.getDatabase(
             String.format(
@@ -134,52 +145,62 @@ public class SpannerClient implements Serializable {
                 gcpProjectId, spannerInstanceId, spannerDatabaseId));
         LOGGER.info("Spanner database {} already exists.", spannerDatabaseId);
 
-        // Check if tables exist
-        SpannerOptions.Builder builder = SpannerOptions.newBuilder().setProjectId(gcpProjectId);
-        if (emulatorHost != null) {
-          builder.setEmulatorHost(emulatorHost);
-          builder.setCredentials(com.google.cloud.NoCredentials.getInstance());
-        }
-        try (Spanner spanner = builder.build().getService()) {
-          DatabaseClient dbClient =
-              spanner.getDatabaseClient(
-                  DatabaseId.of(gcpProjectId, spannerInstanceId, spannerDatabaseId));
+        // Check if tables exist by fetching current DDL from Spanner once.
+        String databasePath =
+            String.format(
+                "projects/%s/instances/%s/databases/%s",
+                gcpProjectId, spannerInstanceId, spannerDatabaseId);
+        List<String> currentDdlStatements =
+            dbAdminClient.getDatabaseDdl(databasePath).getStatementsList();
 
-          if (!checkTableExists(dbClient, "Node")) {
-            LOGGER.info("Table Node not found. Applying DDL statements to existing database.");
-            try {
-              dbAdminClient
-                  .updateDatabaseDdlAsync(
-                      com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest.newBuilder()
-                          .setDatabase(
-                              String.format(
-                                  "projects/%s/instances/%s/databases/%s",
-                                  gcpProjectId, spannerInstanceId, spannerDatabaseId))
-                          .addAllStatements(ddlStatements)
-                          .build())
-                  .get();
-              LOGGER.info("Successfully applied DDL statements to existing database.");
-            } catch (java.util.concurrent.ExecutionException executionE) {
-              throw SpannerExceptionFactory.newSpannerException(
-                  ErrorCode.UNKNOWN, "An error occurred during DDL update.", executionE);
-            } catch (InterruptedException interruptedE) {
-              LOGGER.error("Operation was interrupted while waiting for DDL update.", interruptedE);
-              throw SpannerExceptionFactory.propagateInterrupt(interruptedE);
-            }
+        boolean nodeExists = checkTableExists(currentDdlStatements, "Node");
+        boolean edgeExists = checkTableExists(currentDdlStatements, "Edge");
+        boolean observationExists = checkTableExists(currentDdlStatements, "Observation");
+
+        if (!nodeExists && !edgeExists && !observationExists) {
+          LOGGER.info("Database is empty. Applying DDL statements to existing database.");
+
+          List<String> statementsToApply = new java.util.ArrayList<>(ddlStatements);
+
+          boolean protoBundleExistsInSpanner =
+              currentDdlStatements.stream()
+                  .anyMatch(s -> s.toUpperCase().contains("CREATE PROTO BUNDLE"));
+
+          if (protoBundleExistsInSpanner) {
+            LOGGER.info("Proto bundle already exists in database. Skipping CREATE PROTO BUNDLE.");
+            statementsToApply.removeIf(s -> s.toUpperCase().contains("CREATE PROTO BUNDLE"));
           }
+
+          try {
+            dbAdminClient
+                .updateDatabaseDdlAsync(
+                    com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest.newBuilder()
+                        .setDatabase(
+                            String.format(
+                                "projects/%s/instances/%s/databases/%s",
+                                gcpProjectId, spannerInstanceId, spannerDatabaseId))
+                        .addAllStatements(statementsToApply)
+                        .setProtoDescriptors(protoDescriptors)
+                        .build())
+                .get();
+            LOGGER.info("Successfully applied DDL statements to existing database.");
+          } catch (java.util.concurrent.ExecutionException executionE) {
+            throw SpannerExceptionFactory.newSpannerException(
+                ErrorCode.UNKNOWN, "An error occurred during DDL update.", executionE);
+          } catch (InterruptedException interruptedE) {
+            LOGGER.error("Operation was interrupted while waiting for DDL update.", interruptedE);
+            throw SpannerExceptionFactory.propagateInterrupt(interruptedE);
+          }
+        } else if (nodeExists && edgeExists && observationExists) {
+          LOGGER.info("Database is fully initialized.");
+        } else {
+          throw new IllegalStateException(
+              String.format(
+                  "Database is in an inconsistent state. Node: %b, Edge: %b, Observation: %b. Please clean up the database manually.",
+                  nodeExists, edgeExists, observationExists));
         }
       } catch (com.google.api.gax.rpc.NotFoundException notFoundE) {
         LOGGER.info("Spanner database {} not found. Creating it now.", spannerDatabaseId);
-
-        ByteString protoDescriptors;
-        try (InputStream inputStream =
-            getClass().getClassLoader().getResourceAsStream("descriptor.proto.bin")) {
-          if (inputStream == null) {
-            throw new java.io.FileNotFoundException(
-                "Could not find proto descriptor file (descriptor.proto.bin) in resources.");
-          }
-          protoDescriptors = ByteString.copyFrom(inputStream.readAllBytes());
-        }
 
         CreateDatabaseRequest request =
             CreateDatabaseRequest.newBuilder()
@@ -220,14 +241,17 @@ public class SpannerClient implements Serializable {
     }
   }
 
-  boolean checkTableExists(DatabaseClient dbClient, String tableName) {
-    String query =
-        "SELECT table_name FROM information_schema.tables WHERE table_schema = '' AND table_name = @tableName";
-    Statement statement = Statement.newBuilder(query).bind("tableName").to(tableName).build();
-    try (com.google.cloud.spanner.ResultSet resultSet =
-        dbClient.singleUse().executeQuery(statement)) {
-      return resultSet.next();
-    }
+  /**
+   * Checks if a table exists in the list of DDL statements.
+   *
+   * @param statements The list of DDL statements retrieved from Spanner.
+   * @param tableName The name of the table to check.
+   * @return true if the table exists, false otherwise.
+   */
+  boolean checkTableExists(List<String> statements, String tableName) {
+    String regex = "^\\s*CREATE\\s+TABLE\\s+[`]?" + tableName + "[`]?\\b";
+    Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+    return statements.stream().anyMatch(s -> pattern.matcher(s).find());
   }
 
   public PCollection<Void> deleteDataForImport(

--- a/pipeline/spanner/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
+++ b/pipeline/spanner/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
@@ -216,10 +216,7 @@ public class SpannerClient implements Serializable {
       dbAdminClient
           .updateDatabaseDdlAsync(
               com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest.newBuilder()
-                  .setDatabase(
-                      String.format(
-                          "projects/%s/instances/%s/databases/%s",
-                          gcpProjectId, spannerInstanceId, spannerDatabaseId))
+                  .setDatabase(databasePath)
                   .addAllStatements(statementsToApply)
                   .setProtoDescriptors(protoDescriptors)
                   .build())

--- a/pipeline/spanner/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
+++ b/pipeline/spanner/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
@@ -125,29 +125,51 @@ public class SpannerClient implements Serializable {
         dbAdminClient = DatabaseAdminClient.create();
       }
 
+      List<String> ddlStatements = readDdlStatements();
+
       try {
         dbAdminClient.getDatabase(
             String.format(
                 "projects/%s/instances/%s/databases/%s",
                 gcpProjectId, spannerInstanceId, spannerDatabaseId));
         LOGGER.info("Spanner database {} already exists.", spannerDatabaseId);
+
+        // Check if tables exist
+        SpannerOptions.Builder builder = SpannerOptions.newBuilder().setProjectId(gcpProjectId);
+        if (emulatorHost != null) {
+          builder.setEmulatorHost(emulatorHost);
+          builder.setCredentials(com.google.cloud.NoCredentials.getInstance());
+        }
+        try (Spanner spanner = builder.build().getService()) {
+          DatabaseClient dbClient =
+              spanner.getDatabaseClient(
+                  DatabaseId.of(gcpProjectId, spannerInstanceId, spannerDatabaseId));
+
+          if (!checkTableExists(dbClient, "Node")) {
+            LOGGER.info("Table Node not found. Applying DDL statements to existing database.");
+            try {
+              dbAdminClient
+                  .updateDatabaseDdlAsync(
+                      com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest.newBuilder()
+                          .setDatabase(
+                              String.format(
+                                  "projects/%s/instances/%s/databases/%s",
+                                  gcpProjectId, spannerInstanceId, spannerDatabaseId))
+                          .addAllStatements(ddlStatements)
+                          .build())
+                  .get();
+              LOGGER.info("Successfully applied DDL statements to existing database.");
+            } catch (java.util.concurrent.ExecutionException executionE) {
+              throw SpannerExceptionFactory.newSpannerException(
+                  ErrorCode.UNKNOWN, "An error occurred during DDL update.", executionE);
+            } catch (InterruptedException interruptedE) {
+              LOGGER.error("Operation was interrupted while waiting for DDL update.", interruptedE);
+              throw SpannerExceptionFactory.propagateInterrupt(interruptedE);
+            }
+          }
+        }
       } catch (com.google.api.gax.rpc.NotFoundException notFoundE) {
         LOGGER.info("Spanner database {} not found. Creating it now.", spannerDatabaseId);
-
-        List<String> ddlStatements;
-        try (InputStream inputStream =
-            getClass().getClassLoader().getResourceAsStream("spanner_schema.sql")) {
-          if (inputStream == null) {
-            throw new java.io.FileNotFoundException(
-                "Could not find spanner_schema.sql in resources.");
-          }
-          try (BufferedReader reader =
-              new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
-            ddlStatements = parseDdlStatements(reader);
-          }
-        } catch (IOException ioE) {
-          throw new IOException("Failed to read DDL file", ioE);
-        }
 
         ByteString protoDescriptors;
         try (InputStream inputStream =
@@ -157,8 +179,6 @@ public class SpannerClient implements Serializable {
                 "Could not find proto descriptor file (descriptor.proto.bin) in resources.");
           }
           protoDescriptors = ByteString.copyFrom(inputStream.readAllBytes());
-        } catch (IOException ioE) {
-          throw new IOException("Failed to read proto descriptor file", ioE);
         }
 
         CreateDatabaseRequest request =
@@ -184,6 +204,29 @@ public class SpannerClient implements Serializable {
       }
     } catch (IOException e) {
       throw new IllegalStateException("Failed to create DatabaseAdminClient.", e);
+    }
+  }
+
+  List<String> readDdlStatements() throws IOException {
+    try (InputStream inputStream =
+        getClass().getClassLoader().getResourceAsStream("spanner_schema.sql")) {
+      if (inputStream == null) {
+        throw new java.io.FileNotFoundException("Could not find spanner_schema.sql in resources.");
+      }
+      try (BufferedReader reader =
+          new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+        return parseDdlStatements(reader);
+      }
+    }
+  }
+
+  boolean checkTableExists(DatabaseClient dbClient, String tableName) {
+    String query =
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = '' AND table_name = @tableName";
+    Statement statement = Statement.newBuilder(query).bind("tableName").to(tableName).build();
+    try (com.google.cloud.spanner.ResultSet resultSet =
+        dbClient.singleUse().executeQuery(statement)) {
+      return resultSet.next();
     }
   }
 

--- a/pipeline/spanner/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
+++ b/pipeline/spanner/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
@@ -102,16 +102,54 @@ public class SpannerClient implements Serializable {
    * Parses DDL statements from a BufferedReader. DDL statements can span multiple lines and are are
    * delimited with a newline.
    */
-  private List<String> parseDdlStatements(BufferedReader reader) throws IOException {
+  private ArrayList<String> parseDdlStatements(BufferedReader reader) throws IOException {
     String fullText = reader.lines().collect(Collectors.joining("\n"));
     String[] blocksArray = fullText.split("\\n\\s*\\n+", 0);
-    return Arrays.asList(blocksArray);
+    return new ArrayList<>(Arrays.asList(blocksArray));
   }
 
-  public void createDatabase() {
+  private ByteString loadProtoDescriptors() {
+    InputStream is = getClass().getClassLoader().getResourceAsStream("descriptor.proto.bin");
+    if (is == null) {
+      throw new IllegalStateException(
+          "Could not find proto descriptor file (descriptor.proto.bin) in resources.");
+    }
     try {
-      DatabaseAdminClient dbAdminClient;
+      return ByteString.copyFrom(is.readAllBytes());
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read proto descriptor file.", e);
+    }
+  }
 
+  /** Initializes the remote Spanner database. */
+  private void initializeRemoteDatabase(DatabaseAdminClient dbAdminClient) {
+    LOGGER.info("Spanner database {} not found. Creating it now.", spannerDatabaseId);
+
+    CreateDatabaseRequest request =
+        CreateDatabaseRequest.newBuilder()
+            .setParent(String.format("projects/%s/instances/%s", gcpProjectId, spannerInstanceId))
+            .setCreateStatement(String.format("CREATE DATABASE `%s`", spannerDatabaseId))
+            .build();
+
+    try {
+      // Block until the database is created.
+      dbAdminClient.createDatabaseAsync(request).get();
+    } catch (java.util.concurrent.ExecutionException executionE) {
+      throw SpannerExceptionFactory.newSpannerException(
+          ErrorCode.UNKNOWN, "An error occurred during database creation.", executionE);
+    } catch (InterruptedException interruptedE) {
+      LOGGER.error("Operation was interrupted while waiting for database creation.", interruptedE);
+      throw SpannerExceptionFactory.propagateInterrupt(interruptedE);
+    }
+    LOGGER.info("Successfully created Spanner database {}.", spannerDatabaseId);
+  }
+
+  /**
+   * Validates that the Spanner database and tables exist. Initializes the database if it doesn't.
+   */
+  public void validateOrInitializeDatabase() {
+    DatabaseAdminClient dbAdminClient;
+    try {
       if (emulatorHost != null) {
         DatabaseAdminSettings.Builder settingsBuilder = DatabaseAdminSettings.newBuilder();
         settingsBuilder.setCredentialsProvider(NoCredentialsProvider.create());
@@ -125,119 +163,88 @@ public class SpannerClient implements Serializable {
       } else {
         dbAdminClient = DatabaseAdminClient.create();
       }
-
-      List<String> ddlStatements = readDdlStatements();
-
-      ByteString protoDescriptors;
-      try (InputStream inputStream =
-          getClass().getClassLoader().getResourceAsStream("descriptor.proto.bin")) {
-        if (inputStream == null) {
-          throw new java.io.FileNotFoundException(
-              "Could not find proto descriptor file (descriptor.proto.bin) in resources.");
-        }
-        protoDescriptors = ByteString.copyFrom(inputStream.readAllBytes());
-      }
-
-      try {
-        dbAdminClient.getDatabase(
-            String.format(
-                "projects/%s/instances/%s/databases/%s",
-                gcpProjectId, spannerInstanceId, spannerDatabaseId));
-        LOGGER.info("Spanner database {} already exists.", spannerDatabaseId);
-
-        // Check if tables exist by fetching current DDL from Spanner once.
-        String databasePath =
-            String.format(
-                "projects/%s/instances/%s/databases/%s",
-                gcpProjectId, spannerInstanceId, spannerDatabaseId);
-        List<String> currentDdlStatements =
-            dbAdminClient.getDatabaseDdl(databasePath).getStatementsList();
-
-        boolean nodeExists = checkTableExists(currentDdlStatements, "Node");
-        boolean edgeExists = checkTableExists(currentDdlStatements, "Edge");
-        boolean observationExists = checkTableExists(currentDdlStatements, "Observation");
-
-        if (!nodeExists && !edgeExists && !observationExists) {
-          LOGGER.info("Database is empty. Applying DDL statements to existing database.");
-
-          List<String> statementsToApply = new java.util.ArrayList<>(ddlStatements);
-
-          boolean protoBundleExistsInSpanner =
-              currentDdlStatements.stream()
-                  .anyMatch(s -> s.toUpperCase().contains("CREATE PROTO BUNDLE"));
-
-          if (protoBundleExistsInSpanner) {
-            LOGGER.info("Proto bundle already exists in database. Skipping CREATE PROTO BUNDLE.");
-            statementsToApply.removeIf(s -> s.toUpperCase().contains("CREATE PROTO BUNDLE"));
-          }
-
-          try {
-            dbAdminClient
-                .updateDatabaseDdlAsync(
-                    com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest.newBuilder()
-                        .setDatabase(
-                            String.format(
-                                "projects/%s/instances/%s/databases/%s",
-                                gcpProjectId, spannerInstanceId, spannerDatabaseId))
-                        .addAllStatements(statementsToApply)
-                        .setProtoDescriptors(protoDescriptors)
-                        .build())
-                .get();
-            LOGGER.info("Successfully applied DDL statements to existing database.");
-          } catch (java.util.concurrent.ExecutionException executionE) {
-            throw SpannerExceptionFactory.newSpannerException(
-                ErrorCode.UNKNOWN, "An error occurred during DDL update.", executionE);
-          } catch (InterruptedException interruptedE) {
-            LOGGER.error("Operation was interrupted while waiting for DDL update.", interruptedE);
-            throw SpannerExceptionFactory.propagateInterrupt(interruptedE);
-          }
-        } else if (nodeExists && edgeExists && observationExists) {
-          LOGGER.info("Database is fully initialized.");
-        } else {
-          throw new IllegalStateException(
-              String.format(
-                  "Database is in an inconsistent state. Node: %b, Edge: %b, Observation: %b. Please clean up the database manually.",
-                  nodeExists, edgeExists, observationExists));
-        }
-      } catch (com.google.api.gax.rpc.NotFoundException notFoundE) {
-        LOGGER.info("Spanner database {} not found. Creating it now.", spannerDatabaseId);
-
-        CreateDatabaseRequest request =
-            CreateDatabaseRequest.newBuilder()
-                .setParent(
-                    String.format("projects/%s/instances/%s", gcpProjectId, spannerInstanceId))
-                .setCreateStatement(String.format("CREATE DATABASE `%s`", spannerDatabaseId))
-                .addAllExtraStatements(ddlStatements)
-                .setProtoDescriptors(protoDescriptors)
-                .build();
-
-        try {
-          dbAdminClient.createDatabaseAsync(request).get();
-        } catch (java.util.concurrent.ExecutionException executionE) {
-          throw SpannerExceptionFactory.newSpannerException(
-              ErrorCode.UNKNOWN, "An error occurred during database creation.", executionE);
-        } catch (InterruptedException interruptedE) {
-          LOGGER.error(
-              "Operation was interrupted while waiting for database creation.", interruptedE);
-          throw SpannerExceptionFactory.propagateInterrupt(interruptedE);
-        }
-        LOGGER.info("Successfully created Spanner database {}.", spannerDatabaseId);
-      }
     } catch (IOException e) {
       throw new IllegalStateException("Failed to create DatabaseAdminClient.", e);
     }
+
+    // Ensure the Database now has the proper Tables and Proto Bundle.
+    String databasePath =
+        String.format(
+            "projects/%s/instances/%s/databases/%s",
+            gcpProjectId, spannerInstanceId, spannerDatabaseId);
+
+    try {
+      dbAdminClient.getDatabase(databasePath);
+      LOGGER.info("Spanner database {} already exists.", spannerDatabaseId);
+    } catch (com.google.api.gax.rpc.NotFoundException notFoundE) {
+      initializeRemoteDatabase(dbAdminClient);
+    }
+
+    // Check if tables exist by fetching current DDL from Spanner once.
+    List<String> currentDdlStatements =
+        dbAdminClient.getDatabaseDdl(databasePath).getStatementsList();
+
+    boolean nodeExists = checkTableExists(currentDdlStatements, "Node");
+    boolean edgeExists = checkTableExists(currentDdlStatements, "Edge");
+    boolean observationExists = checkTableExists(currentDdlStatements, "Observation");
+    boolean protoBundleExists =
+        currentDdlStatements.stream()
+            .anyMatch(s -> s.toUpperCase().contains("CREATE PROTO BUNDLE"));
+
+    if (nodeExists && edgeExists && observationExists && protoBundleExists) {
+      LOGGER.info("Database is fully initialized.");
+      return;
+    }
+
+    if (nodeExists || edgeExists || observationExists) {
+      throw new IllegalStateException(
+          String.format(
+              "Database is in an inconsistent state. Node: %b, Edge: %b, Observation: %b. Please clean up the database manually.",
+              nodeExists, edgeExists, observationExists));
+    }
+
+    LOGGER.info("Database is empty. Applying DDL statements to existing database.");
+    List<String> statementsToApply = readDdlStatements();
+    if (protoBundleExists) {
+      LOGGER.info("Proto bundle already exists in database. Skipping CREATE PROTO BUNDLE.");
+      statementsToApply.removeIf(s -> s.toUpperCase().contains("CREATE PROTO BUNDLE"));
+    }
+
+    ByteString protoDescriptors = loadProtoDescriptors();
+    try {
+      // Update the Schema to include the new tables and proto bundle.
+      dbAdminClient
+          .updateDatabaseDdlAsync(
+              com.google.spanner.admin.database.v1.UpdateDatabaseDdlRequest.newBuilder()
+                  .setDatabase(
+                      String.format(
+                          "projects/%s/instances/%s/databases/%s",
+                          gcpProjectId, spannerInstanceId, spannerDatabaseId))
+                  .addAllStatements(statementsToApply)
+                  .setProtoDescriptors(protoDescriptors)
+                  .build())
+          .get();
+      LOGGER.info("Successfully applied DDL statements to existing database.");
+    } catch (java.util.concurrent.ExecutionException executionE) {
+      throw SpannerExceptionFactory.newSpannerException(
+          ErrorCode.UNKNOWN, "An error occurred during DDL update.", executionE);
+    } catch (InterruptedException interruptedE) {
+      LOGGER.error("Operation was interrupted while waiting for DDL update.", interruptedE);
+      throw SpannerExceptionFactory.propagateInterrupt(interruptedE);
+    }
   }
 
-  List<String> readDdlStatements() throws IOException {
-    try (InputStream inputStream =
-        getClass().getClassLoader().getResourceAsStream("spanner_schema.sql")) {
-      if (inputStream == null) {
-        throw new java.io.FileNotFoundException("Could not find spanner_schema.sql in resources.");
-      }
-      try (BufferedReader reader =
-          new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
-        return parseDdlStatements(reader);
-      }
+  /** Reads DDL statements from the spanner_schema.sql file in the resources directory. */
+  ArrayList<String> readDdlStatements() {
+    InputStream inputStream = getClass().getClassLoader().getResourceAsStream("spanner_schema.sql");
+    if (inputStream == null) {
+      throw new IllegalStateException("Could not find spanner_schema.sql in resources.");
+    }
+    try (BufferedReader reader =
+        new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+      return parseDdlStatements(reader);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read spanner_schema.sql", e);
     }
   }
 
@@ -249,7 +256,7 @@ public class SpannerClient implements Serializable {
    * @return true if the table exists, false otherwise.
    */
   boolean checkTableExists(List<String> statements, String tableName) {
-    String regex = "^\\s*CREATE\\s+TABLE\\s+[`]?" + tableName + "[`]?\\b";
+    String regex = "(?i)\\bCREATE\\s+TABLE\\s+`?" + tableName + "`?\\b";
     Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
     return statements.stream().anyMatch(s -> pattern.matcher(s).find());
   }

--- a/pipeline/spanner/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
+++ b/pipeline/spanner/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
@@ -102,7 +102,7 @@ public class SpannerClient implements Serializable {
    * Parses DDL statements from a BufferedReader. DDL statements can span multiple lines and are are
    * delimited with a newline.
    */
-  private ArrayList<String> parseDdlStatements(BufferedReader reader) throws IOException {
+  private List<String> parseDdlStatements(BufferedReader reader) throws IOException {
     String fullText = reader.lines().collect(Collectors.joining("\n"));
     String[] blocksArray = fullText.split("\\n\\s*\\n+", 0);
     return new ArrayList<>(Arrays.asList(blocksArray));
@@ -189,7 +189,7 @@ public class SpannerClient implements Serializable {
     boolean observationExists = checkTableExists(currentDdlStatements, "Observation");
     boolean protoBundleExists =
         currentDdlStatements.stream()
-            .anyMatch(s -> s.toUpperCase().contains("CREATE PROTO BUNDLE"));
+            .anyMatch(s -> s.trim().toUpperCase().startsWith("CREATE PROTO BUNDLE"));
 
     if (nodeExists && edgeExists && observationExists && protoBundleExists) {
       LOGGER.info("Database is fully initialized.");
@@ -207,7 +207,7 @@ public class SpannerClient implements Serializable {
     List<String> statementsToApply = readDdlStatements();
     if (protoBundleExists) {
       LOGGER.info("Proto bundle already exists in database. Skipping CREATE PROTO BUNDLE.");
-      statementsToApply.removeIf(s -> s.toUpperCase().contains("CREATE PROTO BUNDLE"));
+      statementsToApply.removeIf(s -> s.trim().toUpperCase().startsWith("CREATE PROTO BUNDLE"));
     }
 
     ByteString protoDescriptors = loadProtoDescriptors();
@@ -232,7 +232,7 @@ public class SpannerClient implements Serializable {
   }
 
   /** Reads DDL statements from the spanner_schema.sql file in the resources directory. */
-  ArrayList<String> readDdlStatements() {
+  List<String> readDdlStatements() {
     InputStream inputStream = getClass().getClassLoader().getResourceAsStream("spanner_schema.sql");
     if (inputStream == null) {
       throw new IllegalStateException("Could not find spanner_schema.sql in resources.");

--- a/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
+++ b/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
@@ -3,7 +3,6 @@ package org.datacommons.ingestion.spanner;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import java.io.IOException;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,7 +22,7 @@ public class SpannerClientTest {
   }
 
   @Test
-  public void testReadDdlStatements() throws IOException {
+  public void testReadDdlStatements() {
     List<String> ddlStatements = spannerClient.readDdlStatements();
     assertNotNull(ddlStatements);
     assertFalse(ddlStatements.isEmpty());
@@ -54,6 +53,7 @@ public class SpannerClientTest {
     statements.add("CREATE TABLE Edge");
 
     boolean exists = spannerClient.checkTableExists(statements, "Node");
+    assertFalse(exists);
   }
 
   @Test

--- a/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
+++ b/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
@@ -3,10 +3,6 @@ package org.datacommons.ingestion.spanner;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import com.google.cloud.spanner.DatabaseClient;
-import com.google.cloud.spanner.ReadContext;
-import com.google.cloud.spanner.ResultSet;
-import com.google.cloud.spanner.Statement;
 import java.io.IOException;
 import java.util.List;
 import org.junit.Before;
@@ -45,33 +41,27 @@ public class SpannerClientTest {
 
   @Test
   public void testCheckTableExists_True() {
-    DatabaseClient dbClient = mock(DatabaseClient.class);
-    ReadContext readContext = mock(ReadContext.class);
-    ResultSet resultSet = mock(ResultSet.class);
+    List<String> statements = new java.util.ArrayList<>();
+    statements.add("CREATE TABLE Node");
 
-    when(dbClient.singleUse()).thenReturn(readContext);
-    when(readContext.executeQuery(any(Statement.class))).thenReturn(resultSet);
-    when(resultSet.next()).thenReturn(true);
-
-    boolean exists = spannerClient.checkTableExists(dbClient, "Node");
+    boolean exists = spannerClient.checkTableExists(statements, "Node");
     assertTrue(exists);
-
-    verify(readContext).executeQuery(any(Statement.class));
   }
 
   @Test
   public void testCheckTableExists_False() {
-    DatabaseClient dbClient = mock(DatabaseClient.class);
-    ReadContext readContext = mock(ReadContext.class);
-    ResultSet resultSet = mock(ResultSet.class);
+    List<String> statements = new java.util.ArrayList<>();
+    statements.add("CREATE TABLE Edge");
 
-    when(dbClient.singleUse()).thenReturn(readContext);
-    when(readContext.executeQuery(any(Statement.class))).thenReturn(resultSet);
-    when(resultSet.next()).thenReturn(false);
+    boolean exists = spannerClient.checkTableExists(statements, "Node");
+  }
 
-    boolean exists = spannerClient.checkTableExists(dbClient, "NonExistentTable");
+  @Test
+  public void testCheckTableExists_FalsePositive() {
+    List<String> statements = new java.util.ArrayList<>();
+    statements.add("CREATE TABLE Node_Old");
+
+    boolean exists = spannerClient.checkTableExists(statements, "Node");
     assertFalse(exists);
-
-    verify(readContext).executeQuery(any(Statement.class));
   }
 }

--- a/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
+++ b/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
@@ -1,0 +1,77 @@
+package org.datacommons.ingestion.spanner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.ReadContext;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SpannerClientTest {
+
+  private SpannerClient spannerClient;
+
+  @Before
+  public void setUp() {
+    spannerClient =
+        SpannerClient.builder()
+            .gcpProjectId("test-project")
+            .spannerInstanceId("test-instance")
+            .spannerDatabaseId("test-db")
+            .build();
+  }
+
+  @Test
+  public void testReadDdlStatements() throws IOException {
+    List<String> ddlStatements = spannerClient.readDdlStatements();
+    assertNotNull(ddlStatements);
+    assertFalse(ddlStatements.isEmpty());
+
+    // Verify that we have at least table creation statements
+    boolean hasNodeTable = false;
+    for (String ddl : ddlStatements) {
+      if (ddl.contains("CREATE TABLE Node")) {
+        hasNodeTable = true;
+        break;
+      }
+    }
+    assertTrue("Should contain Node table DDL", hasNodeTable);
+  }
+
+  @Test
+  public void testCheckTableExists_True() {
+    DatabaseClient dbClient = mock(DatabaseClient.class);
+    ReadContext readContext = mock(ReadContext.class);
+    ResultSet resultSet = mock(ResultSet.class);
+
+    when(dbClient.singleUse()).thenReturn(readContext);
+    when(readContext.executeQuery(any(Statement.class))).thenReturn(resultSet);
+    when(resultSet.next()).thenReturn(true);
+
+    boolean exists = spannerClient.checkTableExists(dbClient, "Node");
+    assertTrue(exists);
+
+    verify(readContext).executeQuery(any(Statement.class));
+  }
+
+  @Test
+  public void testCheckTableExists_False() {
+    DatabaseClient dbClient = mock(DatabaseClient.class);
+    ReadContext readContext = mock(ReadContext.class);
+    ResultSet resultSet = mock(ResultSet.class);
+
+    when(dbClient.singleUse()).thenReturn(readContext);
+    when(readContext.executeQuery(any(Statement.class))).thenReturn(resultSet);
+    when(resultSet.next()).thenReturn(false);
+
+    boolean exists = spannerClient.checkTableExists(dbClient, "NonExistentTable");
+    assertFalse(exists);
+
+    verify(readContext).executeQuery(any(Statement.class));
+  }
+}


### PR DESCRIPTION
Modify the ingestion pipeline's logic for DB creation to be a bit more flexible. Before this change, it just checks whether the DB exists, and if not it creates it with the appropriate scheme and protodescriptor.

With this change, we retain the ability to create the DB and initialize it properly, but we also allow customers to provide an empty DB, and have it be initialized with the proper schema and proto descriptor.
This is important for DCP, where the DB should be created via Terraform at setup time in order to also connect the DCP service to the DB, however the schema is not necessary at that point, and so we can expect the ingestion pipeline to validate the schema and create it when necessary.

I've tested this on all the following scenarios:
- DB exists and is properly initialized
- DB exists but has no tables or proto descriptor
- DB exists but has no tables only
- DB does not exist.