### PR TITLE
[DCP] Add a flag to only do DB initialization

### DIFF
--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
@@ -61,6 +61,11 @@ public class GraphIngestionPipeline {
     spannerClient.validateOrInitializeDatabase();
     LOGGER.info("Spanner DDL creation complete.");
 
+    if (options.getInitializeDatabaseOnly()) {
+      LOGGER.info("Skipping Beam data ingestion. Database initialized successfully.");
+      return;
+    }
+
     Pipeline pipeline = Pipeline.create(options);
     buildPipeline(pipeline, options, spannerClient);
     pipeline.run();

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
@@ -88,4 +88,10 @@ public interface IngestionPipelineOptions extends PipelineOptions {
   String getSpannerEdgeTableName();
 
   void setSpannerEdgeTableName(String tableName);
+
+  @Description("Whether to initialize database schema only and skip importing data.")
+  @Default.Boolean(false)
+  boolean getInitializeDatabaseOnly();
+
+  void setInitializeDatabaseOnly(boolean initializeDatabaseOnly);
 }


### PR DESCRIPTION
This will allow us to provide a clean command for DCP customers to run Terraform apply, then trigger the ingestion pipeline with --initializeDatabaseOnly=true to then be in a clean state, and ready to import data.

Note it is somewhat optional, since they dont need the tables created at that point, but it provides for a cleaner story to DCP clients that once you run this you're ready. They could immediately run it with their data as well, but if it's not ready to import, this provides a clean instruction to be done with the setup. 