### PR TITLE
Populate name fields in nodes

### DIFF
--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphReader.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphReader.java
@@ -43,7 +43,7 @@ public class GraphReader implements Serializable {
         // Generate corresponding node
         Map<String, McfGraph.Values> pv = pvs.getPvsMap();
         Node.Builder node = Node.builder();
-        String dcid = GraphUtils.getPropertyValue(pv, "dcid");
+        String dcid = GraphUtils.getPropVal(pvs, GraphUtils.Property.dcid.name());
         String subjectId = !dcid.isEmpty() ? dcid : McfUtil.stripNamespace(nodeEntry.getKey());
         node.subjectId(subjectId);
 
@@ -54,7 +54,8 @@ public class GraphReader implements Serializable {
           mcfNodesWithoutTypeCounter.inc();
         }
         node.value(subjectId);
-        node.name(GraphUtils.getPropertyValue(pv, "name"));
+        String name = GraphUtils.getPropVal(pvs, GraphUtils.Property.name.name());
+        node.name(!name.isEmpty() ? name : subjectId);
         node.types(types);
         nodes.add(node.build());
 
@@ -92,7 +93,7 @@ public class GraphReader implements Serializable {
       PropertyValues pvs = nodeEntry.getValue();
       if (!GraphUtils.isObservation(pvs)) {
         Map<String, McfGraph.Values> pv = pvs.getPvsMap();
-        String dcid = GraphUtils.getPropertyValue(pv, "dcid");
+        String dcid = GraphUtils.getPropVal(pvs, GraphUtils.Property.dcid.name());
         String subjectId = !dcid.isEmpty() ? dcid : McfUtil.stripNamespace(nodeEntry.getKey());
         for (Map.Entry<String, McfGraph.Values> entry : pv.entrySet()) {
           if (entry.getKey().equals("dcid")) {

--- a/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphReaderTest.java
+++ b/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphReaderTest.java
@@ -117,7 +117,12 @@ public class GraphReaderTest {
                 .name("Node One")
                 .types(List.of("Property"))
                 .build(),
-            Node.builder().subjectId("dcid2").value("dcid2").types(List.of("Thing")).build(),
+            Node.builder()
+                .subjectId("dcid2")
+                .value("dcid2")
+                .name("dcid2")
+                .types(List.of("Thing"))
+                .build(),
             Node.builder()
                 .subjectId("Node Zero:kUyRupzrJkxe/HIOIctxlJX4woEGeOTtlVwqyXYnfDE=")
                 .value("Node Zero")

--- a/util/src/main/java/org/datacommons/util/GraphUtils.java
+++ b/util/src/main/java/org/datacommons/util/GraphUtils.java
@@ -32,6 +32,7 @@ public class GraphUtils {
     measurementMethod,
     unit,
     value,
+    name,
     scalingFactor,
     dcid;
   }
@@ -98,8 +99,7 @@ public class GraphUtils {
    * @return True if the property values indicate a StatVarObservation, false otherwise.
    */
   public static boolean isObservation(PropertyValues pvs) {
-    return GraphUtils.getPropertyValue(pvs.getPvsMap(), GraphUtils.Property.typeOf.name())
-        .contains(GraphUtils.STAT_VAR_OB);
+    return getPropVal(pvs, GraphUtils.Property.typeOf.name()).contains(GraphUtils.STAT_VAR_OB);
   }
 
   /**
@@ -129,11 +129,7 @@ public class GraphUtils {
     McfGraph.Values v = node.getPvsMap().get(prop);
     if (v != null && v.getTypedValuesCount() > 0) {
       String val = v.getTypedValues(0).getValue();
-      if (val.startsWith("dcid:") || val.startsWith("dcs:") || val.startsWith("schema:")) {
-        return val.substring(val.indexOf(':') + 1);
-      } else {
-        return val;
-      }
+      return McfUtil.stripNamespace(val);
     }
     return "";
   }


### PR DESCRIPTION
Population name column in spanner Node table during ingestion. This is done by by updating the name field during Node creation when the source MCF may not have name property added. 
Minor clean up.