### PR TITLE
[DCP Ingestion] Adds a ForceCombine option to the dataflow 

### DIFF
--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
@@ -100,7 +100,7 @@ public class GraphIngestionPipeline {
       }
 
       // Process the individual import.
-      processImport(pipeline, spannerClient, importName, graphPath, options.getSkipDelete());
+      processImport(pipeline, spannerClient, importName, graphPath, options);
     }
   }
 
@@ -118,7 +118,7 @@ public class GraphIngestionPipeline {
       SpannerClient spannerClient,
       String importName,
       String graphPath,
-      boolean skipDelete) {
+      IngestionPipelineOptions options) {
     LOGGER.info("Import: {} Graph path: {}", importName, graphPath);
 
     String provenance = "dc/base/" + importName;
@@ -129,7 +129,7 @@ public class GraphIngestionPipeline {
     // immediately.
     PCollection<Void> deleteObsWait;
     PCollection<Void> deleteEdgesWait;
-    if (!skipDelete) {
+    if (!options.getSkipDelete()) {
       deleteObsWait =
           spannerClient.deleteDataForImport(
               pipeline, importName, spannerClient.getObservationTableName(), "import_name");
@@ -168,7 +168,7 @@ public class GraphIngestionPipeline {
     // 3. Process Schema Nodes:
     // Combine nodes if required.
     PCollection<McfGraph> combinedGraph = schemaNodes;
-    if (IMPORTS_TO_COMBINE.contains(importName)) {
+    if (options.getForceCombineNodes() || IMPORTS_TO_COMBINE.contains(importName)) {
       combinedGraph = PipelineUtils.combineGraphNodes(importName, schemaNodes);
     }
 

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
@@ -111,7 +111,7 @@ public class GraphIngestionPipeline {
    * @param spannerClient The Spanner client.
    * @param importName The name of the import.
    * @param graphPath The full path to the graph data.
-   * @param skipDelete Whether to skip delete operations.
+   * @param options The ingestion pipeline options.
    */
   private static void processImport(
       Pipeline pipeline,

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
@@ -169,6 +169,10 @@ public class GraphIngestionPipeline {
     // Combine nodes if required.
     PCollection<McfGraph> combinedGraph = schemaNodes;
     if (options.getForceCombineNodes() || IMPORTS_TO_COMBINE.contains(importName)) {
+      LOGGER.info(
+          ">>> Combining nodes for import: {} (ForceCombine: {})",
+          importName,
+          options.getForceCombineNodes());
       combinedGraph = PipelineUtils.combineGraphNodes(importName, schemaNodes);
     }
 

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
@@ -94,4 +94,10 @@ public interface IngestionPipelineOptions extends PipelineOptions {
   boolean getInitializeDatabaseOnly();
 
   void setInitializeDatabaseOnly(boolean initializeDatabaseOnly);
+
+  @Description("Whether to force combination of schema nodes across shards.")
+  @Default.Boolean(false)
+  boolean getForceCombineNodes();
+
+  void setForceCombineNodes(boolean forceCombineNodes);
 }

--- a/pipeline/ingestion/src/test/java/org/datacommons/ingestion/pipeline/GraphIngestionPipelineTest.java
+++ b/pipeline/ingestion/src/test/java/org/datacommons/ingestion/pipeline/GraphIngestionPipelineTest.java
@@ -104,6 +104,62 @@ public class GraphIngestionPipelineTest implements Serializable {
     assertTrue("Edge mutation for name not found", foundNameEdge);
   }
 
+  @Test
+  public void testBuildPipelineWithForceCombineNodes() throws Exception {
+    // 1. Setup Test Data (Two MCF files with same node ID)
+    File mcfFile1 = tmpFolder.newFile("test1.mcf");
+    Files.writeString(
+        Path.of(mcfFile1.getPath()),
+        "Node: dcid:geoId/06\n" + "typeOf: dcs:Place\n" + "name: \"California\"\n\n");
+
+    File mcfFile2 = tmpFolder.newFile("test2.mcf");
+    Files.writeString(
+        Path.of(mcfFile2.getPath()),
+        "Node: dcid:geoId/06\n" + "typeOf: dcs:Place\n" + "containedInPlace: dcid:country/USA\n\n");
+
+    // 2. Setup Options
+    IngestionPipelineOptions options = PipelineOptionsFactory.as(IngestionPipelineOptions.class);
+    // Point to the folder containing both files
+    String importListJson =
+        String.format(
+            "[{\"importName\": \"customImport\", \"graphPath\": \"%s/*\"}]",
+            tmpFolder.getRoot().getPath());
+    options.setImportList(importListJson);
+    options.setProjectId("test-project");
+    options.setSpannerInstanceId("test-instance");
+    options.setSpannerDatabaseId("test-database");
+    options.setForceCombineNodes(true); // Enable the new flag!
+
+    // 3. Setup Mock SpannerClient
+    PCollection<Void> emptySignal =
+        pipeline.apply("CreateEmptySignal_Combine", Create.empty(TypeDescriptor.of(Void.class)));
+
+    SpannerWriteResult mockWriteResult =
+        mock(SpannerWriteResult.class, withSettings().serializable());
+    PCollection<Void> mockWriteOutput =
+        pipeline.apply("CreateWriteSignal_Combine", Create.empty(TypeDescriptor.of(Void.class)));
+    when(mockWriteResult.getOutput()).thenReturn(mockWriteOutput);
+
+    SpannerClient mockSpannerClient = new MockSpannerClient(emptySignal, mockWriteResult);
+
+    // 4. Build Pipeline
+    GraphIngestionPipeline.buildPipeline(pipeline, options, mockSpannerClient);
+
+    // 5. Run Pipeline
+    pipeline.run().waitUntilFinish();
+
+    // 6. Assertions
+    // If combined, we should see only 1 Node mutation for geoId/06!
+    int nodeMutationCount = 0;
+    for (com.google.cloud.spanner.Mutation m : capturedMutations) {
+      if (m.getTable().equals("Node")
+          && m.asMap().get("subject_id").getString().equals("geoId/06")) {
+        nodeMutationCount++;
+      }
+    }
+    assertTrue("Node mutations should be combined into 1", nodeMutationCount == 1);
+  }
+
   static class MockSpannerClient extends SpannerClient {
     private final transient PCollection<Void> deleteSignal;
     private final transient SpannerWriteResult mockWriteResult;


### PR DESCRIPTION
ForceCombine is required on all schema imports to ensure the references exist, otherwise the sharded graph creates nodes of type Thing, instead of the true node.

This change will keep the hardcoded list for Schema and Place imports for base DC, and will also add a flag that will be set by default to true on all DCP-initiated Ingestion workflows. See https://github.com/datacommonsorg/datacommons/pull/47