### PR TITLE
[DCP - Ingestion]Adds the provenance URL

### DIFF
--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphReader.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphReader.java
@@ -145,6 +145,7 @@ public class GraphReader implements Serializable {
     obs.variableMeasured(graph.getSvObsSeries().getKey().getVariableMeasured());
     obs.unit(graph.getSvObsSeries().getKey().getUnit());
     obs.scalingFactor(graph.getSvObsSeries().getKey().getScalingFactor());
+    obs.provenanceUrl(graph.getSvObsSeries().getKey().getProvenanceUrl());
     Observations.Builder ob = Observations.newBuilder();
     for (StatVarObs svo : graph.getSvObsSeries().getSvObsListList()) {
       if (svo.hasNumber()) {

--- a/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphReaderTest.java
+++ b/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphReaderTest.java
@@ -312,7 +312,8 @@ public class GraphReaderTest {
                             .setObservationPeriod("P1Y")
                             .setMeasurementMethod("dcAggregate/testMethod")
                             .setUnit("testUnit")
-                            .setScalingFactor("100"))
+                            .setScalingFactor("100")
+                            .setProvenanceUrl("http://example.com"))
                     .addSvObsList(
                         StatVarObs.newBuilder().setDcid("obs1").setDate("2020").setNumber(10.0))
                     .addSvObsList(
@@ -335,6 +336,7 @@ public class GraphReaderTest {
             .observationPeriod("P1Y")
             .unit("testUnit")
             .scalingFactor("100")
+            .provenanceUrl("http://example.com")
             .observations(expectedObsValues)
             .build();
 

--- a/simple/stats/jsonld_exporter.py
+++ b/simple/stats/jsonld_exporter.py
@@ -111,7 +111,7 @@ def _add_observation_to_graph(g, row, DCID, prov_urls):
 
   if provenance:
     g.add((subject, DCID["provenance"], expand_id(provenance)))
-    if provenance in prov_urls:
+    if provenance in prov_urls and prov_urls[provenance]:
       g.add((subject, DCID["provenanceUrl"], Literal(prov_urls[provenance])))
   if unit:
     g.add((subject, DCID["unit"], expand_id(unit)))
@@ -139,16 +139,11 @@ def _process_observation_chunk(args):
   This runs in a separate process, so it must establish its own DB connection
   and import necessary modules locally.
   """
-  shard_index, offset, chunk_size, db_path, output_dir_path, ns_map = args
+  shard_index, offset, chunk_size, db_path, output_dir_path, ns_map, prov_urls = args
 
   # Open a new connection for this worker process (SQLite connections cannot be shared across processes)
   conn = sqlite3.connect(db_path)
   cursor = conn.cursor()
-
-  # Fetch all provenance URLs to duplicate onto observations
-  cursor.execute(
-      "SELECT subject_id, object_value FROM triples WHERE predicate = 'url'")
-  prov_urls = {row[0]: row[1] for row in cursor.fetchall()}
 
   # Fetch the specific chunk of observations for this shard
   cursor.execute(
@@ -186,8 +181,12 @@ def process_observations(db, output_dir, ns_map: dict, chunk_size: int):
   total_obs = db.engine.fetch_all("SELECT COUNT(*) FROM observations")[0][0]
   num_chunks = (total_obs + chunk_size - 1) // chunk_size
 
+  # Fetch all provenance URLs once to pass to workers
+  rows = db.engine.fetch_all("SELECT subject_id, object_value FROM triples WHERE predicate = 'url'")
+  prov_urls = {row[0]: row[1] for row in rows}
+
   # Prepare arguments for the worker pool (each chunk gets its own offset and index)
-  args_list = [(i, i * chunk_size, chunk_size, db_path, output_dir_path, ns_map)
+  args_list = [(i, i * chunk_size, chunk_size, db_path, output_dir_path, ns_map, prov_urls)
                for i in range(num_chunks)]
 
   # Cap the number of processes to avoid overloading the machine

--- a/simple/stats/jsonld_exporter.py
+++ b/simple/stats/jsonld_exporter.py
@@ -90,7 +90,7 @@ def process_triples(db, output_dir, ns_map: dict, chunk_size: int):
       break
 
 
-def _add_observation_to_graph(g, row, DCID):
+def _add_observation_to_graph(g, row, DCID, prov_urls):
   """Helper to add an observation row to the graph."""
   entity, variable, date, value, provenance, unit, scaling_factor, mmethod, period, props = row
 
@@ -111,6 +111,8 @@ def _add_observation_to_graph(g, row, DCID):
 
   if provenance:
     g.add((subject, DCID["provenance"], expand_id(provenance)))
+    if provenance in prov_urls:
+      g.add((subject, DCID["provenanceUrl"], Literal(prov_urls[provenance])))
   if unit:
     g.add((subject, DCID["unit"], expand_id(unit)))
   if scaling_factor:
@@ -143,6 +145,10 @@ def _process_observation_chunk(args):
   conn = sqlite3.connect(db_path)
   cursor = conn.cursor()
 
+  # Fetch all provenance URLs to duplicate onto observations
+  cursor.execute("SELECT subject_id, object_value FROM triples WHERE predicate = 'url'")
+  prov_urls = {row[0]: row[1] for row in cursor.fetchall()}
+
   # Fetch the specific chunk of observations for this shard
   cursor.execute(
       "SELECT entity, variable, date, value, provenance, unit, scaling_factor, "
@@ -160,7 +166,7 @@ def _process_observation_chunk(args):
   g.bind("dcid", DCID)
 
   for row in obs_tuples:
-    _add_observation_to_graph(g, row, DCID)
+    _add_observation_to_graph(g, row, DCID, prov_urls)
 
   # Write the graph to a JSON-LD shard file
   with create_store(output_dir_path) as store:

--- a/simple/stats/jsonld_exporter.py
+++ b/simple/stats/jsonld_exporter.py
@@ -182,12 +182,13 @@ def process_observations(db, output_dir, ns_map: dict, chunk_size: int):
   num_chunks = (total_obs + chunk_size - 1) // chunk_size
 
   # Fetch all provenance URLs once to pass to workers
-  rows = db.engine.fetch_all("SELECT subject_id, object_value FROM triples WHERE predicate = 'url'")
+  rows = db.engine.fetch_all(
+      "SELECT subject_id, object_value FROM triples WHERE predicate = 'url'")
   prov_urls = {row[0]: row[1] for row in rows}
 
   # Prepare arguments for the worker pool (each chunk gets its own offset and index)
-  args_list = [(i, i * chunk_size, chunk_size, db_path, output_dir_path, ns_map, prov_urls)
-               for i in range(num_chunks)]
+  args_list = [(i, i * chunk_size, chunk_size, db_path, output_dir_path, ns_map,
+                prov_urls) for i in range(num_chunks)]
 
   # Cap the number of processes to avoid overloading the machine
   num_processes = min(multiprocessing.cpu_count(), 8)

--- a/simple/stats/jsonld_exporter.py
+++ b/simple/stats/jsonld_exporter.py
@@ -27,6 +27,7 @@ from rdflib import URIRef
 from util.filesystem import create_store
 
 DCID_URL = "https://datacommons.org/browser/"
+PREDICATE_URL = "url"
 
 
 def expand_id(item):
@@ -183,7 +184,8 @@ def process_observations(db, output_dir, ns_map: dict, chunk_size: int):
 
   # Fetch all provenance URLs once to pass to workers
   rows = db.engine.fetch_all(
-      "SELECT subject_id, object_value FROM triples WHERE predicate = 'url'")
+      f"SELECT subject_id, object_value FROM triples WHERE predicate = '{PREDICATE_URL}'"
+  )
   prov_urls = {row[0]: row[1] for row in rows}
 
   # Prepare arguments for the worker pool (each chunk gets its own offset and index)

--- a/simple/stats/jsonld_exporter.py
+++ b/simple/stats/jsonld_exporter.py
@@ -146,7 +146,8 @@ def _process_observation_chunk(args):
   cursor = conn.cursor()
 
   # Fetch all provenance URLs to duplicate onto observations
-  cursor.execute("SELECT subject_id, object_value FROM triples WHERE predicate = 'url'")
+  cursor.execute(
+      "SELECT subject_id, object_value FROM triples WHERE predicate = 'url'")
   prov_urls = {row[0]: row[1] for row in cursor.fetchall()}
 
   # Fetch the specific chunk of observations for this shard

--- a/simple/tests/stats/jsonld_exporter_test.py
+++ b/simple/tests/stats/jsonld_exporter_test.py
@@ -43,7 +43,9 @@ class TestJsonLdExporter(unittest.TestCase):
                  predicate="typeOf",
                  object_id="StatisticalVariable"),
           Triple(subject_id="sub1", predicate="name", object_value="Name1"),
-          Triple(subject_id="p1", predicate="url", object_value="http://example.com/p1")
+          Triple(subject_id="p1",
+                 predicate="url",
+                 object_value="http://example.com/p1")
       ])
 
       # Insert some observations
@@ -95,7 +97,8 @@ class TestJsonLdExporter(unittest.TestCase):
             len(obs_nodes) > 0, "No observation node found in shard")
         obs_node_id = obs_nodes[0]
         self.assertEqual(nodes[obs_node_id]['dcid:value'], 100.0)
-        self.assertEqual(nodes[obs_node_id]['dcid:provenanceUrl'], "http://example.com/p1")
+        self.assertEqual(nodes[obs_node_id]['dcid:provenanceUrl'],
+                         "http://example.com/p1")
 
   def test_empty_db(self):
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/simple/tests/stats/jsonld_exporter_test.py
+++ b/simple/tests/stats/jsonld_exporter_test.py
@@ -42,7 +42,8 @@ class TestJsonLdExporter(unittest.TestCase):
           Triple(subject_id="sub1",
                  predicate="typeOf",
                  object_id="StatisticalVariable"),
-          Triple(subject_id="sub1", predicate="name", object_value="Name1")
+          Triple(subject_id="sub1", predicate="name", object_value="Name1"),
+          Triple(subject_id="p1", predicate="url", object_value="http://example.com/p1")
       ])
 
       # Insert some observations
@@ -64,11 +65,12 @@ class TestJsonLdExporter(unittest.TestCase):
       export_to_jsonld(db, output_dir, chunk_size=1)
 
       # Verify files exist
-      # 2 triples with chunk_size=1 -> 2 shards (0 and 1)
-      # 1 observation with chunk_size=1 -> 1 shard (2)
+      # 3 triples with chunk_size=1 -> 3 shards (0, 1 and 2)
+      # 1 observation with chunk_size=1 -> 1 shard (3)
       shard_paths = [
           os.path.join(temp_dir, "node-00000.jsonld"),
           os.path.join(temp_dir, "node-00001.jsonld"),
+          os.path.join(temp_dir, "node-00002.jsonld"),
           os.path.join(temp_dir, "observation-00000.jsonld")
       ]
       for path in shard_paths:
@@ -83,16 +85,17 @@ class TestJsonLdExporter(unittest.TestCase):
         self.assertEqual(nodes['dcid:sub1']['@type'],
                          'dcid:StatisticalVariable')
 
-      # Verify content of shard 2 (should have observations)
-      with open(shard_paths[2], 'r') as f:
-        shard2 = json.load(f)
-        self.assertIn('@graph', shard2)
-        nodes = {node['@id']: node for node in shard2['@graph']}
+      # Verify content of observation shard (should have observations)
+      with open(shard_paths[3], 'r') as f:
+        shard3 = json.load(f)
+        self.assertIn('@graph', shard3)
+        nodes = {node['@id']: node for node in shard3['@graph']}
         obs_nodes = [node for node in nodes if node.startswith('dcid:obs_')]
         self.assertTrue(
             len(obs_nodes) > 0, "No observation node found in shard")
         obs_node_id = obs_nodes[0]
         self.assertEqual(nodes[obs_node_id]['dcid:value'], 100.0)
+        self.assertEqual(nodes[obs_node_id]['dcid:provenanceUrl'], "http://example.com/p1")
 
   def test_empty_db(self):
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/util/src/main/java/org/datacommons/util/GraphUtils.java
+++ b/util/src/main/java/org/datacommons/util/GraphUtils.java
@@ -56,6 +56,9 @@ public class GraphUtils {
     Property.value.name()
   };
 
+  private static final List<String> PROVENANCE_URL_PROPS =
+      List.of("provenanceUrl", "dcid:provenanceUrl");
+
   private static final Set<String> SVOBS_PROTO_PROPS =
       Set.of(
           /** Standard properties expected in StatVarObservation nodes. */
@@ -292,13 +295,11 @@ public class GraphUtils {
     if (!(val = getPropVal(node, "unit")).isEmpty()) {
       key.setUnit(val);
     }
-    if (!(val = getPropVal(node, "provenanceUrl")).isEmpty()) {
-      key.setProvenanceUrl(val);
-    } else if (!(val = getPropVal(node, "dcid:provenanceUrl")).isEmpty()) {
-      key.setProvenanceUrl(val);
-    } else if (!(val = getPropVal(node, "https://datacommons.org/browser/provenanceUrl"))
-        .isEmpty()) {
-      key.setProvenanceUrl(val);
+    for (String prop : PROVENANCE_URL_PROPS) {
+      if (!(val = getPropVal(node, prop)).isEmpty()) {
+        key.setProvenanceUrl(val);
+        break;
+      }
     }
     res.setKey(key.build());
     // Assemble StatVarObs.

--- a/util/src/main/java/org/datacommons/util/GraphUtils.java
+++ b/util/src/main/java/org/datacommons/util/GraphUtils.java
@@ -19,9 +19,13 @@ import org.datacommons.proto.Mcf.McfStatVarObsSeries;
 import org.datacommons.proto.Mcf.McfStatVarObsSeries.StatVarObs;
 import org.datacommons.proto.Mcf.McfType;
 import org.datacommons.proto.Mcf.ValueType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Util functions for processing MCF graphs. */
 public class GraphUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GraphUtils.class);
+
   public enum Property {
     /** Properties for a StatVarObservation. */
     typeOf,
@@ -34,7 +38,8 @@ public class GraphUtils {
     value,
     name,
     scalingFactor,
-    dcid;
+    dcid,
+    provenanceUrl;
   }
 
   public static final String STAT_VAR_OB = "StatVarObservation";
@@ -67,7 +72,8 @@ public class GraphUtils {
           Property.unit.name(),
           Property.value.name(),
           Property.scalingFactor.name(),
-          Property.dcid.name());
+          Property.dcid.name(),
+          Property.provenanceUrl.name());
 
   /**
    * Checks if a given property name is one of the standard SVObs properties.
@@ -289,6 +295,17 @@ public class GraphUtils {
     }
     if (!(val = getPropVal(node, "unit")).isEmpty()) {
       key.setUnit(val);
+    }
+    if (!(val = getPropVal(node, "provenanceUrl")).isEmpty()) {
+      LOGGER.info(">>> Found provenanceUrl: {}", val);
+      key.setProvenanceUrl(val);
+    } else if (!(val = getPropVal(node, "dcid:provenanceUrl")).isEmpty()) {
+      LOGGER.info(">>> Found dcid:provenanceUrl: {}", val);
+      key.setProvenanceUrl(val);
+    } else if (!(val = getPropVal(node, "https://datacommons.org/browser/provenanceUrl"))
+        .isEmpty()) {
+      LOGGER.info(">>> Found full URL provenanceUrl: {}", val);
+      key.setProvenanceUrl(val);
     }
     res.setKey(key.build());
     // Assemble StatVarObs.

--- a/util/src/main/java/org/datacommons/util/GraphUtils.java
+++ b/util/src/main/java/org/datacommons/util/GraphUtils.java
@@ -19,13 +19,9 @@ import org.datacommons.proto.Mcf.McfStatVarObsSeries;
 import org.datacommons.proto.Mcf.McfStatVarObsSeries.StatVarObs;
 import org.datacommons.proto.Mcf.McfType;
 import org.datacommons.proto.Mcf.ValueType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Util functions for processing MCF graphs. */
 public class GraphUtils {
-  private static final Logger LOGGER = LoggerFactory.getLogger(GraphUtils.class);
-
   public enum Property {
     /** Properties for a StatVarObservation. */
     typeOf,
@@ -297,14 +293,11 @@ public class GraphUtils {
       key.setUnit(val);
     }
     if (!(val = getPropVal(node, "provenanceUrl")).isEmpty()) {
-      LOGGER.info(">>> Found provenanceUrl: {}", val);
       key.setProvenanceUrl(val);
     } else if (!(val = getPropVal(node, "dcid:provenanceUrl")).isEmpty()) {
-      LOGGER.info(">>> Found dcid:provenanceUrl: {}", val);
       key.setProvenanceUrl(val);
     } else if (!(val = getPropVal(node, "https://datacommons.org/browser/provenanceUrl"))
         .isEmpty()) {
-      LOGGER.info(">>> Found full URL provenanceUrl: {}", val);
       key.setProvenanceUrl(val);
     }
     res.setKey(key.build());

--- a/util/src/main/proto/Mcf.proto
+++ b/util/src/main/proto/Mcf.proto
@@ -123,6 +123,7 @@ message McfStatVarObsSeries {
     optional string observation_period = 4;
     optional string scaling_factor = 5;
     optional string unit = 6;
+    optional string provenance_url = 7;
   }
 
   required Key key = 1;


### PR DESCRIPTION
This PR modifies the JSONLD exporter to also add the provenance URL on observation nodes, and then reads back the provenance URL from the MCFGraph, to write it in the Spanner Observation Mutation.

I published a new dataflow test template and successfully loaded the undata import in a test spanner DB.