### PR TITLE
Add the upsert logic for updating the recent update timestamp for spanner Node table

### DIFF
--- a/pipeline/spanner/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
+++ b/pipeline/spanner/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
@@ -333,6 +333,8 @@ public class SpannerClient implements Serializable {
       return Mutation.newInsertOrUpdateBuilder(nodeTableName)
           .set("subject_id")
           .to(node.getSubjectId())
+          .set("last_update_timestamp")
+          .to(Value.COMMIT_TIMESTAMP)
           .build();
     }
     return Mutation.newInsertOrUpdateBuilder(nodeTableName)
@@ -346,6 +348,8 @@ public class SpannerClient implements Serializable {
         .to(node.getName())
         .set("types")
         .toStringArray(node.getTypes())
+        .set("last_update_timestamp")
+        .to(Value.COMMIT_TIMESTAMP)
         .build();
   }
 

--- a/pipeline/spanner/src/main/resources/spanner_schema.sql
+++ b/pipeline/spanner/src/main/resources/spanner_schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE Node (
   name STRING(MAX),
   types ARRAY<STRING(1024)>,
   name_tokenlist TOKENLIST AS (TOKENIZE_FULLTEXT(name)) HIDDEN,
+  last_update_timestamp TIMESTAMP OPTIONS (allow_commit_timestamp=true),
 ) PRIMARY KEY(subject_id)
 
 CREATE TABLE Edge (

--- a/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
+++ b/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
@@ -79,14 +79,14 @@ public class SpannerClientTest {
 
     Mutation mutation = spannerClient.toNodeMutation(node);
     assertNotNull(mutation);
-    assertEquals("Node", mutation.getTable());
+    assertEquals(mutation.getTable(), "Node");
 
     var mutationMap = mutation.asMap();
-    assertEquals("dcid:123", mutationMap.get("subject_id").getString());
-    assertEquals("value123", mutationMap.get("value").getString());
-    assertEquals("Node Name", mutationMap.get("name").getString());
-    assertEquals(List.of("Type1", "Type2"), mutationMap.get("types").getStringArray());
-    assertEquals("spanner.commit_timestamp()", mutationMap.get("last_update_timestamp").toString());
+    assertEquals(mutationMap.get("subject_id").getString(), "dcid:123");
+    assertEquals(mutationMap.get("value").getString(), "value123");
+    assertEquals(mutationMap.get("name").getString(), "Node Name");
+    assertEquals(mutationMap.get("types").getStringArray(), List.of("Type1", "Type2"));
+    assertEquals(mutationMap.get("last_update_timestamp").toString(), "spanner.commit_timestamp()");
   }
 
   @Test
@@ -95,11 +95,11 @@ public class SpannerClientTest {
 
     Mutation mutation = spannerClient.toNodeMutation(node);
     assertNotNull(mutation);
-    assertEquals("Node", mutation.getTable());
+    assertEquals(mutation.getTable(), "Node");
 
     var mutationMap = mutation.asMap();
-    assertEquals("dcid:456", mutationMap.get("subject_id").getString());
+    assertEquals(mutationMap.get("subject_id").getString(), "dcid:456");
     assertFalse(mutationMap.containsKey("value"));
-    assertEquals("spanner.commit_timestamp()", mutationMap.get("last_update_timestamp").toString());
+    assertEquals(mutationMap.get("last_update_timestamp").toString(), "spanner.commit_timestamp()");
   }
 }

--- a/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
+++ b/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
@@ -87,7 +87,7 @@ public class SpannerClientTest {
     assertEquals("value123", mutationMap.get("value").getString());
     assertEquals("Node Name", mutationMap.get("name").getString());
     assertEquals(List.of("Type1", "Type2"), mutationMap.get("types").getStringArray());
-    assertEquals(Value.COMMIT_TIMESTAMP, mutationMap.get("last_update_timestamp"));
+    assertEquals(Value.COMMIT_TIMESTAMP.toString(), mutationMap.get("last_update_timestamp").toString());
   }
 
   @Test
@@ -101,6 +101,6 @@ public class SpannerClientTest {
     var mutationMap = mutation.asMap();
     assertEquals("dcid:456", mutationMap.get("subject_id").getString());
     assertFalse(mutationMap.containsKey("value"));
-    assertEquals(Value.COMMIT_TIMESTAMP, mutationMap.get("last_update_timestamp"));
+    assertEquals(Value.COMMIT_TIMESTAMP.toString(), mutationMap.get("last_update_timestamp").toString());
   }
 }

--- a/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
+++ b/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import com.google.cloud.spanner.Mutation;
-import com.google.cloud.spanner.Value;
 import java.util.List;
 import org.datacommons.ingestion.data.Node;
 import org.junit.Before;
@@ -87,8 +86,7 @@ public class SpannerClientTest {
     assertEquals("value123", mutationMap.get("value").getString());
     assertEquals("Node Name", mutationMap.get("name").getString());
     assertEquals(List.of("Type1", "Type2"), mutationMap.get("types").getStringArray());
-    assertEquals(
-        Value.COMMIT_TIMESTAMP.toString(), mutationMap.get("last_update_timestamp").toString());
+    assertEquals("spanner.commit_timestamp()", mutationMap.get("last_update_timestamp").toString());
   }
 
   @Test
@@ -102,7 +100,6 @@ public class SpannerClientTest {
     var mutationMap = mutation.asMap();
     assertEquals("dcid:456", mutationMap.get("subject_id").getString());
     assertFalse(mutationMap.containsKey("value"));
-    assertEquals(
-        Value.COMMIT_TIMESTAMP.toString(), mutationMap.get("last_update_timestamp").toString());
+    assertEquals("spanner.commit_timestamp()", mutationMap.get("last_update_timestamp").toString());
   }
 }

--- a/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
+++ b/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
@@ -87,7 +87,8 @@ public class SpannerClientTest {
     assertEquals("value123", mutationMap.get("value").getString());
     assertEquals("Node Name", mutationMap.get("name").getString());
     assertEquals(List.of("Type1", "Type2"), mutationMap.get("types").getStringArray());
-    assertEquals(Value.COMMIT_TIMESTAMP.toString(), mutationMap.get("last_update_timestamp").toString());
+    assertEquals(
+        Value.COMMIT_TIMESTAMP.toString(), mutationMap.get("last_update_timestamp").toString());
   }
 
   @Test
@@ -101,6 +102,7 @@ public class SpannerClientTest {
     var mutationMap = mutation.asMap();
     assertEquals("dcid:456", mutationMap.get("subject_id").getString());
     assertFalse(mutationMap.containsKey("value"));
-    assertEquals(Value.COMMIT_TIMESTAMP.toString(), mutationMap.get("last_update_timestamp").toString());
+    assertEquals(
+        Value.COMMIT_TIMESTAMP.toString(), mutationMap.get("last_update_timestamp").toString());
   }
 }

--- a/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
+++ b/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
@@ -3,7 +3,10 @@ package org.datacommons.ingestion.spanner;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Value;
 import java.util.List;
+import org.datacommons.ingestion.data.Node;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -63,5 +66,43 @@ public class SpannerClientTest {
 
     boolean exists = spannerClient.checkTableExists(statements, "Node");
     assertFalse(exists);
+  }
+
+  @Test
+  public void testToNodeMutation_RegularNode() {
+    Node node = Node.builder()
+        .subjectId("dcid:123")
+        .value("value123")
+        .name("Node Name")
+        .types(List.of("Type1", "Type2"))
+        .build();
+
+    Mutation mutation = spannerClient.toNodeMutation(node);
+    assertNotNull(mutation);
+    assertEquals("Node", mutation.getTable());
+    
+    var mutationMap = mutation.asMap();
+    assertEquals("dcid:123", mutationMap.get("subject_id").getString());
+    assertEquals("value123", mutationMap.get("value").getString());
+    assertEquals("Node Name", mutationMap.get("name").getString());
+    assertEquals(List.of("Type1", "Type2"), mutationMap.get("types").getStringArray());
+    assertEquals(Value.COMMIT_TIMESTAMP, mutationMap.get("last_update_timestamp"));
+  }
+
+  @Test
+  public void testToNodeMutation_ProvisionalNode() {
+    Node node = Node.builder()
+        .subjectId("dcid:456")
+        .types(List.of("ProvisionalNode"))
+        .build();
+
+    Mutation mutation = spannerClient.toNodeMutation(node);
+    assertNotNull(mutation);
+    assertEquals("Node", mutation.getTable());
+    
+    var mutationMap = mutation.asMap();
+    assertEquals("dcid:456", mutationMap.get("subject_id").getString());
+    assertFalse(mutationMap.containsKey("value"));
+    assertEquals(Value.COMMIT_TIMESTAMP, mutationMap.get("last_update_timestamp"));
   }
 }

--- a/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
+++ b/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
@@ -70,17 +70,18 @@ public class SpannerClientTest {
 
   @Test
   public void testToNodeMutation_RegularNode() {
-    Node node = Node.builder()
-        .subjectId("dcid:123")
-        .value("value123")
-        .name("Node Name")
-        .types(List.of("Type1", "Type2"))
-        .build();
+    Node node =
+        Node.builder()
+            .subjectId("dcid:123")
+            .value("value123")
+            .name("Node Name")
+            .types(List.of("Type1", "Type2"))
+            .build();
 
     Mutation mutation = spannerClient.toNodeMutation(node);
     assertNotNull(mutation);
     assertEquals("Node", mutation.getTable());
-    
+
     var mutationMap = mutation.asMap();
     assertEquals("dcid:123", mutationMap.get("subject_id").getString());
     assertEquals("value123", mutationMap.get("value").getString());
@@ -91,15 +92,12 @@ public class SpannerClientTest {
 
   @Test
   public void testToNodeMutation_ProvisionalNode() {
-    Node node = Node.builder()
-        .subjectId("dcid:456")
-        .types(List.of("ProvisionalNode"))
-        .build();
+    Node node = Node.builder().subjectId("dcid:456").types(List.of("ProvisionalNode")).build();
 
     Mutation mutation = spannerClient.toNodeMutation(node);
     assertNotNull(mutation);
     assertEquals("Node", mutation.getTable());
-    
+
     var mutationMap = mutation.asMap();
     assertEquals("dcid:456", mutationMap.get("subject_id").getString());
     assertFalse(mutationMap.containsKey("value"));


### PR DESCRIPTION
This PR added the mutation logic to update the timestamp based on the insert/update logic from spanner table instruction https://docs.cloud.google.com/spanner/docs/commit-timestamp-postgresql#update-row

