### PR TITLE
This change added the last_update_timestamp to the integration test to reflect the schema change that includes the new field

### DIFF
--- a/pipeline/ingestion/src/test/resources/spanner_schema.sql
+++ b/pipeline/ingestion/src/test/resources/spanner_schema.sql
@@ -6,6 +6,7 @@ CREATE TABLE Node (
   name STRING(MAX),
   types ARRAY<STRING(1024)>,
   name_tokenlist TOKENLIST AS (TOKENIZE_FULLTEXT(name)) HIDDEN,
+  last_update_timestamp TIMESTAMP OPTIONS (allow_commit_timestamp=true),
 ) PRIMARY KEY(subject_id)
 
 CREATE TABLE Edge (


### PR DESCRIPTION
Integration test failed in https://pantheon.corp.google.com/cloud-build/builds;region=global/4ff57037-7aae-4166-ac2d-914809747f75;step=1?e=13803378&mods=-monitoring_api_staging&project=datcom-ci, it dues to the test schema.sql not updated for the integration test.

This PR updated this test schema.sql