### PR TITLE
feat: support conditional 'dc/base/' prefix during ingestion

### DIFF
--- a/pipeline/data/src/main/java/org/datacommons/ingestion/data/Observation.java
+++ b/pipeline/data/src/main/java/org/datacommons/ingestion/data/Observation.java
@@ -182,7 +182,8 @@ public class Observation {
         && Objects.equals(importName, that.importName)
         && Objects.equals(provenanceUrl, that.provenanceUrl)
         && Objects.equals(facetId, that.facetId)
-        && Objects.equals(isDcAggregate, that.isDcAggregate);
+        && Objects.equals(isDcAggregate, that.isDcAggregate)
+        && Objects.equals(isBaseDc, that.isBaseDc);
   }
 
   @Override
@@ -198,7 +199,8 @@ public class Observation {
         importName,
         provenanceUrl,
         facetId,
-        isDcAggregate);
+        isDcAggregate,
+        isBaseDc);
   }
 
   // Builder for Observation

--- a/pipeline/data/src/main/java/org/datacommons/ingestion/data/Observation.java
+++ b/pipeline/data/src/main/java/org/datacommons/ingestion/data/Observation.java
@@ -18,7 +18,6 @@ public class Observation {
   private static final String VARIABLE_MEASURED_PREDICATE = "variableMeasured";
   private static final String NAME_PREDICATE = "name";
   private static final String TYPE_OF_PREDICATE = "typeOf";
-  private static final String PROVENANCE_DCID_PREFIX = "dc/base/";
 
   private String observationAbout;
   private String variableMeasured;
@@ -31,6 +30,7 @@ public class Observation {
   private String provenanceUrl;
   private String facetId;
   private boolean isDcAggregate;
+  private boolean isBaseDc;
   private NodesEdges obsGraph;
 
   private Observation(Builder builder) {
@@ -45,6 +45,7 @@ public class Observation {
     this.provenanceUrl = builder.provenanceUrl;
     this.facetId = builder.facetId;
     this.isDcAggregate = builder.isDcAggregate;
+    this.isBaseDc = builder.isBaseDc;
     this.obsGraph = toObsGraph();
   }
 
@@ -110,7 +111,7 @@ public class Observation {
                     replaceSlashesWithUnderscores(observationAbout),
                     facetId);
     var seriesName = Joiner.on(" | ").join(variableMeasured, observationAbout, facetId);
-    var provenanceDcid = PROVENANCE_DCID_PREFIX + importName;
+    var provenanceDcid = ProvenanceUtils.getProvenanceDcid(importName, this.isBaseDc);
 
     // Add series node
     graph.addNode(
@@ -213,6 +214,7 @@ public class Observation {
     private String provenanceUrl = "";
     private String facetId = "";
     private boolean isDcAggregate = false;
+    private boolean isBaseDc = true;
 
     public Builder observationAbout(String observationAbout) {
       this.observationAbout = observationAbout;
@@ -251,6 +253,11 @@ public class Observation {
 
     public Builder isDcAggregate(boolean isDcAggregate) {
       this.isDcAggregate = isDcAggregate;
+      return this;
+    }
+
+    public Builder isBaseDc(boolean isBaseDc) {
+      this.isBaseDc = isBaseDc;
       return this;
     }
 

--- a/pipeline/data/src/main/java/org/datacommons/ingestion/data/ProvenanceUtils.java
+++ b/pipeline/data/src/main/java/org/datacommons/ingestion/data/ProvenanceUtils.java
@@ -18,17 +18,4 @@ public class ProvenanceUtils implements Serializable {
     return prefix + importName;
   }
 
-  /**
-   * Strips the 'dc/base/' prefix from the given ID if the run is not base DC.
-   *
-   * @param value The value to strip.
-   * @param isBaseDc Whether the run is base DC.
-   * @return The stripped value if not base DC and starts with prefix; otherwise the original value.
-   */
-  public static String stripPrefix(String value, boolean isBaseDc) {
-    if (!isBaseDc && value != null && value.startsWith(BASE_DC_PREFIX)) {
-      return value.substring(BASE_DC_PREFIX.length());
-    }
-    return value;
-  }
 }

--- a/pipeline/data/src/main/java/org/datacommons/ingestion/data/ProvenanceUtils.java
+++ b/pipeline/data/src/main/java/org/datacommons/ingestion/data/ProvenanceUtils.java
@@ -17,5 +17,4 @@ public class ProvenanceUtils implements Serializable {
     String prefix = isBaseDc ? BASE_DC_PREFIX : "";
     return prefix + importName;
   }
-
 }

--- a/pipeline/data/src/main/java/org/datacommons/ingestion/data/ProvenanceUtils.java
+++ b/pipeline/data/src/main/java/org/datacommons/ingestion/data/ProvenanceUtils.java
@@ -1,0 +1,34 @@
+package org.datacommons.ingestion.data;
+
+import java.io.Serializable;
+
+/** Util functions for managing provenance prefixes. */
+public class ProvenanceUtils implements Serializable {
+  public static final String BASE_DC_PREFIX = "dc/base/";
+
+  /**
+   * Generates the provenance DCID based on import name and whether it is base DC.
+   *
+   * @param importName The name of the import.
+   * @param isBaseDc Whether the run is base DC.
+   * @return The constructed provenance DCID.
+   */
+  public static String getProvenanceDcid(String importName, boolean isBaseDc) {
+    String prefix = isBaseDc ? BASE_DC_PREFIX : "";
+    return prefix + importName;
+  }
+
+  /**
+   * Strips the 'dc/base/' prefix from the given ID if the run is not base DC.
+   *
+   * @param value The value to strip.
+   * @param isBaseDc Whether the run is base DC.
+   * @return The stripped value if not base DC and starts with prefix; otherwise the original value.
+   */
+  public static String stripPrefix(String value, boolean isBaseDc) {
+    if (!isBaseDc && value != null && value.startsWith(BASE_DC_PREFIX)) {
+      return value.substring(BASE_DC_PREFIX.length());
+    }
+    return value;
+  }
+}

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
@@ -16,8 +16,8 @@ import org.apache.beam.sdk.transforms.Wait;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TypeDescriptor;
-import org.datacommons.ingestion.spanner.SpannerClient;
 import org.datacommons.ingestion.data.ProvenanceUtils;
+import org.datacommons.ingestion.spanner.SpannerClient;
 import org.datacommons.ingestion.util.GraphReader;
 import org.datacommons.ingestion.util.PipelineUtils;
 import org.datacommons.proto.Mcf.McfGraph;
@@ -47,7 +47,8 @@ public class GraphIngestionPipeline {
     IngestionPipelineOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(IngestionPipelineOptions.class);
 
-    boolean isBaseDc = System.getenv("IS_BASE_DC") == null || Boolean.parseBoolean(System.getenv("IS_BASE_DC"));
+    boolean isBaseDc =
+        System.getenv("IS_BASE_DC") == null || Boolean.parseBoolean(System.getenv("IS_BASE_DC"));
     options.setIsBaseDc(isBaseDc);
 
     SpannerClient spannerClient =
@@ -215,7 +216,8 @@ public class GraphIngestionPipeline {
     PCollection<McfOptimizedGraph> optimizedGraph =
         PipelineUtils.buildOptimizedMcfGraph(importName, observationNodes);
     PCollection<Mutation> observationMutations =
-        GraphReader.graphToObservations(optimizedGraph, importName, spannerClient, obsCounter, isBaseDc)
+        GraphReader.graphToObservations(
+                optimizedGraph, importName, spannerClient, obsCounter, isBaseDc)
             .apply("ExtractObsMutations-" + importName, Values.create());
     // Write Observations (wait for Obs delete)
     PCollection<Mutation> waitingObs =

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
@@ -47,8 +47,9 @@ public class GraphIngestionPipeline {
     IngestionPipelineOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(IngestionPipelineOptions.class);
 
-    if (System.getenv("IS_BASE_DC") != null) {
-      options.setIsBaseDc(Boolean.parseBoolean(System.getenv("IS_BASE_DC")));
+    String isBaseDcEnv = System.getenv("IS_BASE_DC");
+    if (isBaseDcEnv != null) {
+      options.setIsBaseDc(Boolean.parseBoolean(isBaseDcEnv));
     }
 
     SpannerClient spannerClient =

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
@@ -47,9 +47,9 @@ public class GraphIngestionPipeline {
     IngestionPipelineOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(IngestionPipelineOptions.class);
 
-    boolean isBaseDc =
-        System.getenv("IS_BASE_DC") == null || Boolean.parseBoolean(System.getenv("IS_BASE_DC"));
-    options.setIsBaseDc(isBaseDc);
+    if (System.getenv("IS_BASE_DC") != null) {
+      options.setIsBaseDc(Boolean.parseBoolean(System.getenv("IS_BASE_DC")));
+    }
 
     SpannerClient spannerClient =
         SpannerClient.builder()

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
@@ -17,6 +17,7 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.datacommons.ingestion.spanner.SpannerClient;
+import org.datacommons.ingestion.data.ProvenanceUtils;
 import org.datacommons.ingestion.util.GraphReader;
 import org.datacommons.ingestion.util.PipelineUtils;
 import org.datacommons.proto.Mcf.McfGraph;
@@ -45,6 +46,9 @@ public class GraphIngestionPipeline {
   public static void main(String[] args) {
     IngestionPipelineOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(IngestionPipelineOptions.class);
+
+    boolean isBaseDc = System.getenv("IS_BASE_DC") == null || Boolean.parseBoolean(System.getenv("IS_BASE_DC"));
+    options.setIsBaseDc(isBaseDc);
 
     SpannerClient spannerClient =
         SpannerClient.builder()
@@ -121,7 +125,8 @@ public class GraphIngestionPipeline {
       IngestionPipelineOptions options) {
     LOGGER.info("Import: {} Graph path: {}", importName, graphPath);
 
-    String provenance = "dc/base/" + importName;
+    boolean isBaseDc = options.getIsBaseDc();
+    String provenance = ProvenanceUtils.getProvenanceDcid(importName, isBaseDc);
 
     // 1. Prepare Deletes:
     // Generate mutations to delete existing data for this import/provenance.
@@ -210,7 +215,7 @@ public class GraphIngestionPipeline {
     PCollection<McfOptimizedGraph> optimizedGraph =
         PipelineUtils.buildOptimizedMcfGraph(importName, observationNodes);
     PCollection<Mutation> observationMutations =
-        GraphReader.graphToObservations(optimizedGraph, importName, spannerClient, obsCounter)
+        GraphReader.graphToObservations(optimizedGraph, importName, spannerClient, obsCounter, isBaseDc)
             .apply("ExtractObsMutations-" + importName, Values.create());
     // Write Observations (wait for Obs delete)
     PCollection<Mutation> waitingObs =

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipeline.java
@@ -19,9 +19,9 @@ public class IngestionPipeline {
     IngestionPipelineOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(IngestionPipelineOptions.class);
 
-    boolean isBaseDc =
-        System.getenv("IS_BASE_DC") == null || Boolean.parseBoolean(System.getenv("IS_BASE_DC"));
-    options.setIsBaseDc(isBaseDc);
+    if (System.getenv("IS_BASE_DC") != null) {
+      options.setIsBaseDc(Boolean.parseBoolean(System.getenv("IS_BASE_DC")));
+    }
 
     SpannerClient spannerClient =
         SpannerClient.builder()

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipeline.java
@@ -19,7 +19,8 @@ public class IngestionPipeline {
     IngestionPipelineOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(IngestionPipelineOptions.class);
 
-    boolean isBaseDc = System.getenv("IS_BASE_DC") == null || Boolean.parseBoolean(System.getenv("IS_BASE_DC"));
+    boolean isBaseDc =
+        System.getenv("IS_BASE_DC") == null || Boolean.parseBoolean(System.getenv("IS_BASE_DC"));
     options.setIsBaseDc(isBaseDc);
 
     SpannerClient spannerClient =

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipeline.java
@@ -19,6 +19,9 @@ public class IngestionPipeline {
     IngestionPipelineOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(IngestionPipelineOptions.class);
 
+    boolean isBaseDc = System.getenv("IS_BASE_DC") == null || Boolean.parseBoolean(System.getenv("IS_BASE_DC"));
+    options.setIsBaseDc(isBaseDc);
+
     SpannerClient spannerClient =
         SpannerClient.builder()
             .gcpProjectId(options.getProjectId())
@@ -46,7 +49,7 @@ public class IngestionPipeline {
       importGroupVersions = getImportGroupVersions(options.getVersionEndpoint());
     }
 
-    CacheReader cacheReader = new CacheReader(options.getStorageBucketId());
+    CacheReader cacheReader = new CacheReader(options.getStorageBucketId(), options.getIsBaseDc());
 
     buildIngestionPipeline(pipeline, importGroupVersions, cacheReader, spannerClient);
 

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipeline.java
@@ -19,8 +19,9 @@ public class IngestionPipeline {
     IngestionPipelineOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(IngestionPipelineOptions.class);
 
-    if (System.getenv("IS_BASE_DC") != null) {
-      options.setIsBaseDc(Boolean.parseBoolean(System.getenv("IS_BASE_DC")));
+    String isBaseDcEnv = System.getenv("IS_BASE_DC");
+    if (isBaseDcEnv != null) {
+      options.setIsBaseDc(Boolean.parseBoolean(isBaseDcEnv));
     }
 
     SpannerClient spannerClient =

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
@@ -100,4 +100,10 @@ public interface IngestionPipelineOptions extends PipelineOptions {
   boolean getForceCombineNodes();
 
   void setForceCombineNodes(boolean forceCombineNodes);
+
+  @Description("Whether this is a base Data Commons ingestion run")
+  @Default.Boolean(true)
+  boolean getIsBaseDc();
+
+  void setIsBaseDc(boolean isBaseDc);
 }

--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/CacheReader.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/CacheReader.java
@@ -15,7 +15,7 @@ import org.datacommons.ingestion.data.Edge;
 import org.datacommons.ingestion.data.Node;
 import org.datacommons.ingestion.data.NodesEdges;
 import org.datacommons.ingestion.data.Observation;
-import org.datacommons.ingestion.data.ProvenanceUtils;
+import static org.datacommons.ingestion.data.ProvenanceUtils.stripPrefix;
 import org.datacommons.proto.CacheData.EntityInfo;
 import org.datacommons.proto.CacheData.PagedEntities;
 import org.datacommons.proto.ChartStoreOuterClass.ChartStore;
@@ -143,11 +143,11 @@ public class CacheReader implements Serializable {
             // The corresponding Node is a placeholder and shouldn't be added.
             // Instead it will be added as part of the import group where its defined.
             boolean isReferenceNode = isOutArcCacheRow(row) ? !entity.getDcid().isEmpty() : true;
-            String finalNodeId = stripPrefix(nodeId);
-            String finalNodeValue = isReferenceNode ? stripPrefix(nodeValue) : nodeValue;
-            String finalSubjectId = stripPrefix(subjectId);
-            String finalObjectId = stripPrefix(objectId);
-            String finalProvenance = stripPrefix(entity.getProvenanceId());
+            String finalNodeId = stripPrefix(nodeId, this.isBaseDc);
+            String finalNodeValue = isReferenceNode ? stripPrefix(nodeValue, this.isBaseDc) : nodeValue;
+            String finalSubjectId = stripPrefix(subjectId, this.isBaseDc);
+            String finalObjectId = stripPrefix(objectId, this.isBaseDc);
+            String finalProvenance = stripPrefix(entity.getProvenanceId(), this.isBaseDc);
 
             if (!finalNodeId.isEmpty() && !typeOf.equals(PipelineUtils.TYPE_THING)) {
               result.addNode(
@@ -238,7 +238,4 @@ public class CacheReader implements Serializable {
     return row.startsWith(OBS_TIME_SERIES_CACHE_PREFIX);
   }
 
-  private String stripPrefix(String s) {
-    return ProvenanceUtils.stripPrefix(s, this.isBaseDc);
-  }
 }

--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/CacheReader.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/CacheReader.java
@@ -15,7 +15,7 @@ import org.datacommons.ingestion.data.Edge;
 import org.datacommons.ingestion.data.Node;
 import org.datacommons.ingestion.data.NodesEdges;
 import org.datacommons.ingestion.data.Observation;
-import static org.datacommons.ingestion.data.ProvenanceUtils.stripPrefix;
+
 import org.datacommons.proto.CacheData.EntityInfo;
 import org.datacommons.proto.CacheData.PagedEntities;
 import org.datacommons.proto.ChartStoreOuterClass.ChartStore;
@@ -142,18 +142,11 @@ public class CacheReader implements Serializable {
             // Triples with type Thing are from two different import groups.
             // The corresponding Node is a placeholder and shouldn't be added.
             // Instead it will be added as part of the import group where its defined.
-            boolean isReferenceNode = isOutArcCacheRow(row) ? !entity.getDcid().isEmpty() : true;
-            String finalNodeId = stripPrefix(nodeId, this.isBaseDc);
-            String finalNodeValue = isReferenceNode ? stripPrefix(nodeValue, this.isBaseDc) : nodeValue;
-            String finalSubjectId = stripPrefix(subjectId, this.isBaseDc);
-            String finalObjectId = stripPrefix(objectId, this.isBaseDc);
-            String finalProvenance = stripPrefix(entity.getProvenanceId(), this.isBaseDc);
-
-            if (!finalNodeId.isEmpty() && !typeOf.equals(PipelineUtils.TYPE_THING)) {
+            if (!nodeId.isEmpty() && !typeOf.equals(PipelineUtils.TYPE_THING)) {
               result.addNode(
                   Node.builder()
-                      .subjectId(finalNodeId)
-                      .value(finalNodeValue)
+                      .subjectId(nodeId)
+                      .value(nodeValue)
                       .bytes(bytes)
                       .name(entity.getName())
                       .types(types)
@@ -161,13 +154,13 @@ public class CacheReader implements Serializable {
             }
 
             // Add edge.
-            if (!finalSubjectId.isEmpty() && !finalObjectId.isEmpty()) {
+            if (!subjectId.isEmpty() && !objectId.isEmpty()) {
               result.addEdge(
                   Edge.builder()
-                      .subjectId(finalSubjectId)
+                      .subjectId(subjectId)
                       .predicate(predicate)
-                      .objectId(finalObjectId)
-                      .provenance(finalProvenance)
+                      .objectId(objectId)
+                      .provenance(entity.getProvenanceId())
                       .build());
             }
           }

--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/CacheReader.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/CacheReader.java
@@ -15,6 +15,7 @@ import org.datacommons.ingestion.data.Edge;
 import org.datacommons.ingestion.data.Node;
 import org.datacommons.ingestion.data.NodesEdges;
 import org.datacommons.ingestion.data.Observation;
+import org.datacommons.ingestion.data.ProvenanceUtils;
 import org.datacommons.proto.CacheData.EntityInfo;
 import org.datacommons.proto.CacheData.PagedEntities;
 import org.datacommons.proto.ChartStoreOuterClass.ChartStore;
@@ -33,9 +34,15 @@ public class CacheReader implements Serializable {
   private static final String CACHE_KEY_SEPARATOR_REGEX = "\\^";
 
   private final String gcsBucketId;
+  private final boolean isBaseDc;
 
   public CacheReader(String gcsBucketId) {
+    this(gcsBucketId, true);
+  }
+
+  public CacheReader(String gcsBucketId, boolean isBaseDc) {
     this.gcsBucketId = gcsBucketId;
+    this.isBaseDc = isBaseDc;
   }
 
   /** Returns the GCS cache path for the import group. */
@@ -139,11 +146,18 @@ public class CacheReader implements Serializable {
             // Triples with type Thing are from two different import groups.
             // The corresponding Node is a placeholder and shouldn't be added.
             // Instead it will be added as part of the import group where its defined.
-            if (!nodeId.isEmpty() && !typeOf.equals(PipelineUtils.TYPE_THING)) {
+            boolean isReferenceNode = isOutArcCacheRow(row) ? !entity.getDcid().isEmpty() : true;
+            String finalNodeId = stripPrefix(nodeId);
+            String finalNodeValue = isReferenceNode ? stripPrefix(nodeValue) : nodeValue;
+            String finalSubjectId = stripPrefix(subjectId);
+            String finalObjectId = stripPrefix(objectId);
+            String finalProvenance = stripPrefix(entity.getProvenanceId());
+
+            if (!finalNodeId.isEmpty() && !typeOf.equals(PipelineUtils.TYPE_THING)) {
               result.addNode(
                   Node.builder()
-                      .subjectId(nodeId)
-                      .value(nodeValue)
+                      .subjectId(finalNodeId)
+                      .value(finalNodeValue)
                       .bytes(bytes)
                       .name(entity.getName())
                       .types(types)
@@ -151,13 +165,13 @@ public class CacheReader implements Serializable {
             }
 
             // Add edge.
-            if (!subjectId.isEmpty() && !objectId.isEmpty()) {
+            if (!finalSubjectId.isEmpty() && !finalObjectId.isEmpty()) {
               result.addEdge(
                   Edge.builder()
-                      .subjectId(subjectId)
+                      .subjectId(finalSubjectId)
                       .predicate(predicate)
-                      .objectId(objectId)
-                      .provenance(entity.getProvenanceId())
+                      .objectId(finalObjectId)
+                      .provenance(finalProvenance)
                       .build());
             }
           }
@@ -187,6 +201,7 @@ public class CacheReader implements Serializable {
           for (SourceSeries source : chart.getObsTimeSeries().getSourceSeriesList()) {
             Observation.Builder builder =
                 Observation.builder()
+                    .isBaseDc(this.isBaseDc)
                     .variableMeasured(variableMeasured)
                     .observationAbout(observationAbout)
                     .observationPeriod(source.getObservationPeriod())
@@ -225,5 +240,9 @@ public class CacheReader implements Serializable {
 
   public static final boolean isObsTimeSeriesCacheRow(String row) {
     return row.startsWith(OBS_TIME_SERIES_CACHE_PREFIX);
+  }
+
+  private String stripPrefix(String s) {
+    return ProvenanceUtils.stripPrefix(s, this.isBaseDc);
   }
 }

--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/CacheReader.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/CacheReader.java
@@ -36,10 +36,6 @@ public class CacheReader implements Serializable {
   private final String gcsBucketId;
   private final boolean isBaseDc;
 
-  public CacheReader(String gcsBucketId) {
-    this(gcsBucketId, true);
-  }
-
   public CacheReader(String gcsBucketId, boolean isBaseDc) {
     this.gcsBucketId = gcsBucketId;
     this.isBaseDc = isBaseDc;

--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/CacheReader.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/CacheReader.java
@@ -15,7 +15,6 @@ import org.datacommons.ingestion.data.Edge;
 import org.datacommons.ingestion.data.Node;
 import org.datacommons.ingestion.data.NodesEdges;
 import org.datacommons.ingestion.data.Observation;
-
 import org.datacommons.proto.CacheData.EntityInfo;
 import org.datacommons.proto.CacheData.PagedEntities;
 import org.datacommons.proto.ChartStoreOuterClass.ChartStore;
@@ -230,5 +229,4 @@ public class CacheReader implements Serializable {
   public static final boolean isObsTimeSeriesCacheRow(String row) {
     return row.startsWith(OBS_TIME_SERIES_CACHE_PREFIX);
   }
-
 }

--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphReader.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphReader.java
@@ -127,10 +127,6 @@ public class GraphReader implements Serializable {
     return edges;
   }
 
-  public static Observation graphToObservations(McfOptimizedGraph graph, String importName) {
-    return graphToObservations(graph, importName, true);
-  }
-
   public static Observation graphToObservations(
       McfOptimizedGraph graph, String importName, boolean isBaseDc) {
     Observation.Builder obs = Observation.builder();

--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphReader.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphReader.java
@@ -128,7 +128,13 @@ public class GraphReader implements Serializable {
   }
 
   public static Observation graphToObservations(McfOptimizedGraph graph, String importName) {
+    return graphToObservations(graph, importName, true);
+  }
+
+  public static Observation graphToObservations(
+      McfOptimizedGraph graph, String importName, boolean isBaseDc) {
     Observation.Builder obs = Observation.builder();
+    obs.isBaseDc(isBaseDc);
     String measurementMethod = graph.getSvObsSeries().getKey().getMeasurementMethod();
     obs.observationAbout(graph.getSvObsSeries().getKey().getObservationAbout());
     obs.observationPeriod(graph.getSvObsSeries().getKey().getObservationPeriod());
@@ -162,7 +168,8 @@ public class GraphReader implements Serializable {
       PCollection<McfOptimizedGraph> graph,
       String importName,
       SpannerClient spannerClient,
-      Counter obsCounter) {
+      Counter obsCounter,
+      boolean isBaseDc) {
     return graph.apply(
         "GraphToObs-" + importName,
         ParDo.of(
@@ -171,7 +178,7 @@ public class GraphReader implements Serializable {
               public void processElement(
                   @Element McfOptimizedGraph element,
                   OutputReceiver<KV<String, Mutation>> receiver) {
-                Observation observations = graphToObservations(element, importName);
+                Observation observations = graphToObservations(element, importName, isBaseDc);
                 List<KV<String, Mutation>> obs =
                     spannerClient.toObservationKVMutations(List.of(observations));
                 obs.stream()

--- a/pipeline/util/src/test/java/org/datacommons/ingestion/util/CacheReaderTest.java
+++ b/pipeline/util/src/test/java/org/datacommons/ingestion/util/CacheReaderTest.java
@@ -253,36 +253,6 @@ public class CacheReaderTest {
   }
 
   @Test
-  public void testParseArcRowForInArcWithoutBaseDcPrefix() {
-    CacheReader reader = new CacheReader("datcom-store", false);
-    Counter mockMcfNodesWithoutTypeCounter = Mockito.mock(Counter.class);
-    String row =
-        "d/l/dc/d/UnitedNationsUn_SdgIndicatorsDatabase^isPartOf^Provenance^0,H4sIAAAAAAAAAOPS4GIL9YsPdnGX4ktJ1k9KLE7Vh/CV0PiCDGDwwR4AhMbiaDMAAAA=";
-
-    NodesEdges expected =
-        new NodesEdges()
-            .addNode(
-                Node.builder()
-                    .subjectId("UN_SDG")
-                    .value("UN_SDG")
-                    .name("UN_SDG")
-                    .types(List.of("Provenance"))
-                    .build())
-            .addEdge(
-                Edge.builder()
-                    .subjectId("UN_SDG")
-                    .predicate("isPartOf")
-                    .objectId("dc/d/UnitedNationsUn_SdgIndicatorsDatabase")
-                    .provenance("UN_SDG")
-                    .build());
-
-    NodesEdges actual = reader.parseArcRow(row, mockMcfNodesWithoutTypeCounter);
-
-    assertEquals(expected, actual);
-    Mockito.verify(mockMcfNodesWithoutTypeCounter, Mockito.times(0)).inc();
-  }
-
-  @Test
   public void testParseTimeSeriesRowWithoutBaseDcPrefix() {
     CacheReader reader = new CacheReader("datcom-store", false);
     String row =

--- a/pipeline/util/src/test/java/org/datacommons/ingestion/util/CacheReaderTest.java
+++ b/pipeline/util/src/test/java/org/datacommons/ingestion/util/CacheReaderTest.java
@@ -375,6 +375,6 @@ public class CacheReaderTest {
   }
 
   private static CacheReader newCacheReader() {
-    return new CacheReader("datcom-store");
+    return new CacheReader("datcom-store", true);
   }
 }

--- a/pipeline/util/src/test/java/org/datacommons/ingestion/util/CacheReaderTest.java
+++ b/pipeline/util/src/test/java/org/datacommons/ingestion/util/CacheReaderTest.java
@@ -252,6 +252,128 @@ public class CacheReaderTest {
     assertEquals(expectedGraph, actual.get(0).getObsGraph());
   }
 
+  @Test
+  public void testParseArcRowForInArcWithoutBaseDcPrefix() {
+    CacheReader reader = new CacheReader("datcom-store", false);
+    Counter mockMcfNodesWithoutTypeCounter = Mockito.mock(Counter.class);
+    String row =
+        "d/l/dc/d/UnitedNationsUn_SdgIndicatorsDatabase^isPartOf^Provenance^0,H4sIAAAAAAAAAOPS4GIL9YsPdnGX4ktJ1k9KLE7Vh/CV0PiCDGDwwR4AhMbiaDMAAAA=";
+
+    NodesEdges expected =
+        new NodesEdges()
+            .addNode(
+                Node.builder()
+                    .subjectId("UN_SDG")
+                    .value("UN_SDG")
+                    .name("UN_SDG")
+                    .types(List.of("Provenance"))
+                    .build())
+            .addEdge(
+                Edge.builder()
+                    .subjectId("UN_SDG")
+                    .predicate("isPartOf")
+                    .objectId("dc/d/UnitedNationsUn_SdgIndicatorsDatabase")
+                    .provenance("UN_SDG")
+                    .build());
+
+    NodesEdges actual = reader.parseArcRow(row, mockMcfNodesWithoutTypeCounter);
+
+    assertEquals(expected, actual);
+    Mockito.verify(mockMcfNodesWithoutTypeCounter, Mockito.times(0)).inc();
+  }
+
+  @Test
+  public void testParseTimeSeriesRowWithoutBaseDcPrefix() {
+    CacheReader reader = new CacheReader("datcom-store", false);
+    String row =
+        "d/3/geoId/sch2915390^Mean_PrecipitableWater_Atmosphere,H4sIAAAAAAAAAOPqZpHi8igtykmtVAjS9TT6w8wlysVlZGBkqmtgpGtkIMgQvilZeYOoA4qwkeBcve7Os9OVUIWNBQOzZ5XPaVJBEjbWNTAU3OHQ9Oj4DD1U1aaCIvbH7mx9ookibGguqN6xi98hSwZV2EJQ0Mxmb5CYFqohJoJMszik59WpogobCq49MOHqWjk5VJcYCRac67h074AqqrCxoOOVWoag1QqohlgIpnUkx96ZZoQqbC7IeI+Js2s+mkvMBKub9X2WrdJENdtE0N9BOPHwZkVU71gKGoOBioMUh5+/o2O8u1uwEnOAoYuWBIwbH56aWJKRWuSWX5SanFhcYsSRl5+YqJeeX+bE5ZuZk5OZm1qSWuTBGOSZUVJSUGylr19eXq6Xl5yaqQdTqF9QlJ9SmlxSrF8OMUs3GagtsSRVNzc/JTWnWD89Jz8pMUc3DWoFAAwgwZ8OAgAA";
+
+    Observations series =
+        Observations.newBuilder()
+            .putValues("2025-02-20", "5.42201")
+            .putValues("2025-02-22", "9.29649")
+            .putValues("2025-02-23", "10.2551")
+            .putValues("2025-03-01", "15.2984")
+            .putValues("2025-02-25", "12.9467")
+            .putValues("2025-02-17", "7.10376")
+            .putValues("2025-02-18", "13.0436")
+            .putValues("2025-02-24", "10.7473")
+            .putValues("2025-02-21", "7.52996")
+            .putValues("2025-03-02", "10.8767")
+            .putValues("2025-03-03", "8.33461")
+            .putValues("2025-02-28", "18.5893")
+            .putValues("2025-02-27", "13.3116")
+            .putValues("2025-02-26", "12.8333")
+            .putValues("2025-03-04", "8.8511")
+            .putValues("2025-02-19", "10.1")
+            .build();
+
+    List<Observation> expected =
+        List.of(
+            Observation.builder()
+                .isBaseDc(false)
+                .variableMeasured("Mean_PrecipitableWater_Atmosphere")
+                .observationAbout("geoId/sch2915390")
+                .observations(series)
+                .observationPeriod("P1D")
+                .measurementMethod("NOAA_GFS")
+                .scalingFactor("")
+                .unit("Millimeter")
+                .isDcAggregate(true)
+                .provenanceUrl(
+                    "https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast")
+                .importName("NOAA_GFS_WeatherForecast")
+                .build());
+
+    NodesEdges expectedGraph =
+        new NodesEdges()
+            .addNode(
+                Node.builder()
+                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755137")
+                    .value("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755137")
+                    .name("Mean_PrecipitableWater_Atmosphere | geoId/sch2915390 | 870755137")
+                    .types(List.of("StatVarObsSeries"))
+                    .build())
+            .addNode(
+                Node.builder()
+                    .subjectId("jVWNIHt73yOspqKD0fnvTCH8GCW7m38F3gW+JB+aWms=")
+                    .value("Mean_PrecipitableWater_Atmosphere | geoId/sch2915390 | 870755137")
+                    .build())
+            .addEdge(
+                Edge.builder()
+                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755137")
+                    .predicate("variableMeasured")
+                    .objectId("Mean_PrecipitableWater_Atmosphere")
+                    .provenance("NOAA_GFS_WeatherForecast")
+                    .build())
+            .addEdge(
+                Edge.builder()
+                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755137")
+                    .predicate("observationAbout")
+                    .objectId("geoId/sch2915390")
+                    .provenance("NOAA_GFS_WeatherForecast")
+                    .build())
+            .addEdge(
+                Edge.builder()
+                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755137")
+                    .predicate("name")
+                    .objectId("jVWNIHt73yOspqKD0fnvTCH8GCW7m38F3gW+JB+aWms=")
+                    .provenance("NOAA_GFS_WeatherForecast")
+                    .build())
+            .addEdge(
+                Edge.builder()
+                    .subjectId("dc/os/Mean_PrecipitableWater_Atmosphere_geoId_sch2915390_870755137")
+                    .predicate("typeOf")
+                    .objectId("StatVarObsSeries")
+                    .provenance("NOAA_GFS_WeatherForecast")
+                    .build());
+
+    List<Observation> actual = reader.parseTimeSeriesRow(row);
+
+    assertEquals(expected, actual);
+    assertEquals(expectedGraph, actual.get(0).getObsGraph());
+  }
+
   private static CacheReader newCacheReader() {
     return new CacheReader("datcom-store");
   }

--- a/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphReaderTest.java
+++ b/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphReaderTest.java
@@ -340,7 +340,7 @@ public class GraphReaderTest {
             .observations(expectedObsValues)
             .build();
 
-    Observation actualObservation = GraphReader.graphToObservations(optimizedGraph, "test_import");
+    Observation actualObservation = GraphReader.graphToObservations(optimizedGraph, "test_import", true);
 
     assertEquals(expectedObservation, actualObservation);
   }

--- a/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphReaderTest.java
+++ b/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphReaderTest.java
@@ -344,4 +344,53 @@ public class GraphReaderTest {
 
     assertEquals(expectedObservation, actualObservation);
   }
+
+  @Test
+  public void testGraphToObservationsWithoutBaseDcPrefix() {
+    McfOptimizedGraph optimizedGraph =
+        McfOptimizedGraph.newBuilder()
+            .setSvObsSeries(
+                McfStatVarObsSeries.newBuilder()
+                    .setKey(
+                        McfStatVarObsSeries.Key.newBuilder()
+                            .setObservationAbout("geoId/testPlace")
+                            .setVariableMeasured("testStatVar")
+                            .setObservationPeriod("P1Y")
+                            .setMeasurementMethod("dcAggregate/testMethod")
+                            .setUnit("testUnit")
+                            .setScalingFactor("100")
+                            .setProvenanceUrl("http://example.com"))
+                    .addSvObsList(
+                        StatVarObs.newBuilder().setDcid("obs1").setDate("2020").setNumber(10.0))
+                    .addSvObsList(
+                        StatVarObs.newBuilder()
+                            .setDcid("obs2")
+                            .setDate("2021")
+                            .setText("someText")))
+            .build();
+
+    Observations expectedObsValues =
+        Observations.newBuilder().putValues("2020", "10.0").putValues("2021", "someText").build();
+
+    Observation expectedObservation =
+        Observation.builder()
+            .isBaseDc(false) // Custom DC
+            .observationAbout("geoId/testPlace")
+            .variableMeasured("testStatVar")
+            .measurementMethod("testMethod")
+            .isDcAggregate(true)
+            .importName("test_import")
+            .observationPeriod("P1Y")
+            .unit("testUnit")
+            .scalingFactor("100")
+            .provenanceUrl("http://example.com")
+            .observations(expectedObsValues)
+            .build();
+
+    Observation actualObservation =
+        GraphReader.graphToObservations(optimizedGraph, "test_import", false);
+
+    assertEquals(expectedObservation, actualObservation);
+    assertEquals("test_import", actualObservation.getObsGraph().getEdges().get(0).getProvenance());
+  }
 }

--- a/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphReaderTest.java
+++ b/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphReaderTest.java
@@ -340,7 +340,8 @@ public class GraphReaderTest {
             .observations(expectedObsValues)
             .build();
 
-    Observation actualObservation = GraphReader.graphToObservations(optimizedGraph, "test_import", true);
+    Observation actualObservation =
+        GraphReader.graphToObservations(optimizedGraph, "test_import", true);
 
     assertEquals(expectedObservation, actualObservation);
   }


### PR DESCRIPTION
This PR introduces the `IS_BASE_DC` env to conditionally control `dc/base/` prefixing in the ingestion pipelines. When set to false (applicable for DCP), it dynamically strips this prefix during import.
