### PR TITLE
Add initial SVG generation

### DIFF
--- a/pipeline/workflow/ingestion-helper/aggregation/__init__.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/__init__.py
@@ -22,6 +22,7 @@ from .linked_edge_generator import LinkedEdgeGenerator
 from .provenance_summary_generator import ProvenanceSummaryGenerator
 from .stat_var_aggregator import StatVarAggregator
 from .place_aggregation_generator import PlaceAggregationGenerator
+from .stat_var_group_generator import StatVarGroupGenerator
 
 __all__ = [
     'BigQueryExecutor',
@@ -29,4 +30,5 @@ __all__ = [
     'ProvenanceSummaryGenerator',
     'StatVarAggregator',
     'PlaceAggregationGenerator',
+    'StatVarGroupGenerator'
 ]

--- a/pipeline/workflow/ingestion-helper/aggregation/e2e_tests/aggregation_e2e_test.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/e2e_tests/aggregation_e2e_test.py
@@ -17,6 +17,7 @@ Covers:
 - LinkedEdgeGenerator (Linked Edges)
 - ProvenanceSummaryGenerator (Provenance Summaries)
 - StatVarAggregator (Statistical Variable Aggregations)
+- StatVarGroupGenerator (Statistical Variable Group / Vertical generation)
 
 NOTE: This script is intended for local testing purposes only and is NOT
 currently part of the CI pipeline.
@@ -48,7 +49,7 @@ from google.cloud import bigquery
 import sys
 # Add ingestion-helper to sys.path (two levels up from this file)
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-from aggregation import BigQueryExecutor, LinkedEdgeGenerator, ProvenanceSummaryGenerator, StatVarAggregator, PlaceAggregationGenerator
+from aggregation import BigQueryExecutor, LinkedEdgeGenerator, ProvenanceSummaryGenerator, StatVarAggregator, PlaceAggregationGenerator, StatVarGroupGenerator
 
 # Configuration
 PROJECT_ID = os.environ.get('PROJECT_ID', 'datcom-ci')
@@ -105,9 +106,9 @@ class AggregationIntegrationTestBase(unittest.TestCase):
         self.database.run_in_transaction(_clear)
         logging.info("Tables cleared successfully.")
 
-    def add_node(self, subject_id, name=None, types=None):
+    def add_node(self, subject_id, name=None, value=None, types=None):
         """Adds a node to mock list."""
-        self.mock_nodes.append((subject_id, name or subject_id, None, None, types or []))
+        self.mock_nodes.append((subject_id, name or subject_id, value, None, types or []))
 
     def add_edge(self, subject_id, predicate, object_id, import_name):
         """Adds an edge to mock list."""
@@ -205,9 +206,9 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
         import_name = 'USFed_ConstantMaturityRates_Test'
         
         # 1. Setup mock data
-        self.add_node('geoId/06075', 'San Francisco County', ['County'])
-        self.add_node('geoId/06', 'California', ['State'])
-        self.add_node('country/USA', 'United States', ['Country'])
+        self.add_node('geoId/06075', 'San Francisco County', types=['County'])
+        self.add_node('geoId/06', 'California', types=['State'])
+        self.add_node('country/USA', 'United States', types=['Country'])
         
         self.add_edge('geoId/06075', 'containedInPlace', 'geoId/06', import_name)
         self.add_edge('geoId/06', 'containedInPlace', 'country/USA', import_name)
@@ -235,42 +236,6 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
             self.assertEqual(tuple(results[1]), ('geoId/06075', 'country/USA', expected_provenance))
             self.assertEqual(tuple(results[2]), ('geoId/06075', 'geoId/06', expected_provenance))
 
-    def test_linked_member_of(self):
-        """Tests run_linked_member_of.
-        
-        Hierarchy: Instance_A -> memberOf -> Class_B -> specializationOf -> Class_C
-        """
-        import_name = 'Schema_Import_Test'
-        
-        # 1. Setup mock data
-        self.add_node('Instance_A', 'Instance A', ['Class_B'])
-        self.add_node('Class_B', 'Class B', ['Class'])
-        self.add_node('Class_C', 'Class C', ['Class'])
-        
-        self.add_edge('Instance_A', 'memberOf', 'Class_B', import_name)
-        self.add_edge('Class_B', 'specializationOf', 'Class_C', import_name)
-        
-        self.flush_to_spanner()
-        
-        # 2. Run generator
-        generator = self.get_generator()
-        job = generator.run_linked_member_of([import_name])
-        self.assertIsNotNone(job)
-        
-        # 3. Verify results
-        with self.database.snapshot() as snapshot:
-            query = """
-                SELECT subject_id, object_id, provenance 
-                FROM Edge 
-                WHERE predicate = 'linkedMemberOf'
-                ORDER BY subject_id, object_id
-            """
-            results = list(snapshot.execute_sql(query))
-            
-            expected_provenance = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
-            self.assertEqual(len(results), 2)
-            self.assertEqual(tuple(results[0]), ('Instance_A', 'Class_B', expected_provenance))
-            self.assertEqual(tuple(results[1]), ('Instance_A', 'Class_C', expected_provenance))
 
     def test_linked_member(self):
         """Tests run_linked_member.
@@ -280,9 +245,9 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
         import_name = 'Topic_Import_Test'
         
         # 1. Setup mock data
-        self.add_node('dc/topic/TestTopic', 'Test Topic', ['Topic'])
-        self.add_node('dc/svpg/TestSvpg', 'Test SVPG', ['StatVarPeerGroup'])
-        self.add_node('TestVariable', 'Test Variable', ['StatisticalVariable'])
+        self.add_node('dc/topic/TestTopic', 'Test Topic', types=['Topic'])
+        self.add_node('dc/svpg/TestSvpg', 'Test SVPG', types=['StatVarPeerGroup'])
+        self.add_node('TestVariable', 'Test Variable', types=['StatisticalVariable'])
         
         self.add_edge('dc/topic/TestTopic', 'member', 'dc/svpg/TestSvpg', import_name)
         self.add_edge('dc/svpg/TestSvpg', 'relevantVariable', 'TestVariable', import_name)
@@ -316,8 +281,8 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
         import_name = 'Cyclic_Import_Test'
         
         # 1. Setup mock data (cycle)
-        self.add_node('geoId/06', 'California', ['State'])
-        self.add_node('geoId/36', 'New York', ['State'])
+        self.add_node('geoId/06', 'California', types=['State'])
+        self.add_node('geoId/36', 'New York', types=['State'])
         
         self.add_edge('geoId/06', 'containedInPlace', 'geoId/36', import_name)
         self.add_edge('geoId/36', 'containedInPlace', 'geoId/06', import_name)
@@ -352,8 +317,8 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
         import_name = 'Idempotency_Import_Test'
         
         # 1. Setup mock base data
-        self.add_node('geoId/06075', 'San Francisco County', ['County'])
-        self.add_node('geoId/06', 'California', ['State'])
+        self.add_node('geoId/06075', 'San Francisco County', types=['County'])
+        self.add_node('geoId/06', 'California', types=['State'])
         self.add_edge('geoId/06075', 'containedInPlace', 'geoId/06', import_name)
         
         # 2. Pre-insert the expected generated edge (simulating a previous run)
@@ -413,9 +378,9 @@ class ProvenanceSummaryGeneratorIntegrationTest(AggregationIntegrationTestBase):
         import_name = 'USFed_ConstantMaturityRates_Test'
         
         # 1. Setup mock data
-        self.add_node('geoId/06', 'California', ['State'])
-        self.add_node('geoId/36', 'New York', ['State'])
-        self.add_node('State', 'State Class', ['Class'])
+        self.add_node('geoId/06', 'California', types=['State'])
+        self.add_node('geoId/36', 'New York', types=['State'])
+        self.add_node('State', 'State Class', types=['Class'])
         
         self.add_edge('geoId/06', 'typeOf', 'State', import_name)
         self.add_edge('geoId/36', 'typeOf', 'State', import_name)
@@ -508,9 +473,9 @@ class ProvenanceSummaryGeneratorIntegrationTest(AggregationIntegrationTestBase):
         """
         import_name = 'USFed_ConstantMaturityRates_Test'
         
-        self.add_node('geoId/06', 'California', ['State'])
-        self.add_node('geoId/36', 'New York', ['State'])
-        self.add_node('State', 'State Class', ['Class'])
+        self.add_node('geoId/06', 'California', types=['State'])
+        self.add_node('geoId/36', 'New York', types=['State'])
+        self.add_node('State', 'State Class', types=['Class'])
         
         self.add_edge('geoId/06', 'typeOf', 'State', import_name)
         self.add_edge('geoId/36', 'typeOf', 'State', import_name)
@@ -579,16 +544,16 @@ class ProvenanceSummaryGeneratorIntegrationTest(AggregationIntegrationTestBase):
         import_name = 'USFed_ConstantMaturityRates_Test'
         
         # 1. Normal Node
-        self.add_node('geoId/06', 'California', ['State'])
+        self.add_node('geoId/06', 'California', types=['State'])
         self.add_edge('geoId/06', 'typeOf', 'State', import_name)
         
         # 2. Dangling 1: We only add typeOf edge, NO node
         self.add_edge('geoId/99', 'typeOf', 'State', import_name)
         
         # 3. Dangling 2: We only add node, NO typeOf edge
-        self.add_node('geoId/88', 'Unknown Place', ['State'])
+        self.add_node('geoId/88', 'Unknown Place', types=['State'])
         
-        self.add_node('State', 'State Class', ['Class'])
+        self.add_node('State', 'State Class', types=['Class'])
         
         # Add TimeSeries explicitly
         self.add_timeseries('Count_Person', 'geoId/06', 'CensusACS5yrSurvey', 'P1Y', '1', '1', import_name)
@@ -675,7 +640,7 @@ class PlaceAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
     def add_place(self, place_id, place_type, parent_id=None, name=None, import_name='USFed_ConstantMaturityRates_Test'):
         """Adds a place node and its basic topology (typeOf and containment) to mock lists."""
-        self.add_node(place_id, name, [place_type])
+        self.add_node(place_id, name, types=[place_type])
         self.add_edge(place_id, 'typeOf', place_type, import_name)
         if parent_id:
             self.add_edge(place_id, 'containedInPlace', parent_id, import_name)
@@ -1502,6 +1467,104 @@ class StatVarAggregatorCustomDcTest(StatVarAggregatorIntegrationTest):
     is_base_dc = False
 
 
+class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
+    """Integration E2E tests for StatVarGroupGenerator."""
+
+    def get_generator(self) -> StatVarGroupGenerator:
+        executor = BigQueryExecutor(
+            BQ_CONNECTION_ID,
+            PROJECT_ID,
+            SPANNER_INSTANCE_ID,
+            SPANNER_DATABASE_ID,
+            location=BQ_LOCATION,
+            run_sequential=True
+        )
+        return StatVarGroupGenerator(
+            executor,
+            is_base_dc=self.is_base_dc,
+            max_iterations=2,
+            should_filter_basic_population_type=False # Disabled for simpler test assertions
+        )
+
+    def test_stat_var_group_generation(self):
+        """Tests the generation of StatVarGroups and hierarchical edges from SV specs.
+        
+        Setup:
+          - A vertical spec mapping 'Student' population type to a 'TestVertical' SVG.
+          - An unconstrained SV 'Count_Student'.
+          - A constrained SV 'Count_Student_Female' (gender=Female).
+        """
+        generator = self.get_generator()
+        ns = generator.namespace
+        prov = generator.generated_provenance
+        
+        # 1. Setup mock Vertical Node and Spec mappings
+        self.add_node(f'{ns}g/TestVertical', 'Test Vertical', value=f'{ns}g/TestVertical', types=['StatVarGroup'])
+        self.add_node('Student', 'Student Population', value='Student', types=['Class'])
+        
+        # Spec mappings
+        self.add_edge('Spec_Student', 'typeOf', 'StatVarGroupSpec', 'TestImport')
+        self.add_edge('Spec_Student', 'populationType', 'Student', 'TestImport')
+        self.add_edge('Spec_Student', 'vertical', f'{ns}g/TestVertical', 'TestImport')
+
+        # 2. Setup mock SV data
+        # Unconstrained Student SV
+        self.add_node('Count_Student', 'Count of Students', types=['StatisticalVariable'])
+        self.add_edge('Count_Student', 'typeOf', 'StatisticalVariable', 'TestImport')
+        self.add_edge('Count_Student', 'populationType', 'Student', 'TestImport')
+
+        # Constrained Student SV (gender = Female)
+        self.add_node('Count_Student_Female', 'Female Students', types=['StatisticalVariable'])
+        self.add_edge('Count_Student_Female', 'typeOf', 'StatisticalVariable', 'TestImport')
+        self.add_edge('Count_Student_Female', 'populationType', 'Student', 'TestImport')
+        self.add_edge('Count_Student_Female', 'constraintProperties', 'gender', 'TestImport')
+        self.add_edge('Count_Student_Female', 'gender', 'Female', 'TestImport')
+
+        self.flush_to_spanner()
+
+        # 2. Run generator
+        job = generator.run_all(import_names=['Schema'])
+        self.assertIsNotNone(job)
+
+        # 3. Verify results in Spanner
+        with self.database.snapshot(multi_use=True) as snapshot:
+            # Check newly created SVG nodes (Should generate root 'Student' and constrained 'Student_Gender-Female')
+            node_query = """
+                SELECT subject_id 
+                FROM Node 
+                WHERE 'StatVarGroup' IN UNNEST(types) 
+                  AND subject_id LIKE '%/g/Student%'
+                ORDER BY subject_id
+            """
+            nodes = [r[0] for r in snapshot.execute_sql(node_query)]
+            self.assertIn(f'{ns}g/Student', nodes)
+            self.assertIn(f'{ns}g/Student_Gender', nodes)
+
+            # Check linkedMemberOf/memberOf attachments
+            edge_query = """
+                SELECT subject_id, predicate, object_id, provenance
+                FROM Edge 
+                WHERE predicate IN ('memberOf', 'specializationOf', 'linkedMemberOf')
+                ORDER BY subject_id, predicate, object_id
+            """
+            edges = [(r[0], r[1], r[2], r[3]) for r in snapshot.execute_sql(edge_query)]
+
+            # Verify unconstrained SV attached directly to the Student Root SVG
+            self.assertIn(('Count_Student', 'memberOf', f'{ns}g/Student', prov), edges)
+            
+            # Verify constrained SV attached to the constrained SVG
+            self.assertIn(('Count_Student_Female', 'memberOf', f'{ns}g/Student_Gender', prov), edges)
+
+            # Verify hierarchical specialization of generated SVGs
+            self.assertIn((f'{ns}g/Student_Gender', 'specializationOf', f'{ns}g/Student', prov), edges)
+
+            # Verify the root SVG attached to the Vertical declared in the Spec
+            self.assertIn((f'{ns}g/Student', 'specializationOf', f'{ns}g/TestVertical', prov), edges)
+
+
+class StatVarGroupGeneratorCustomDcTest(StatVarGroupGeneratorIntegrationTest):
+    is_base_dc = False
+
+
 if __name__ == '__main__':
     unittest.main()
-

--- a/pipeline/workflow/ingestion-helper/aggregation/e2e_tests/aggregation_e2e_test.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/e2e_tests/aggregation_e2e_test.py
@@ -1468,7 +1468,6 @@ class StatVarAggregatorCustomDcTest(StatVarAggregatorIntegrationTest):
 
 
 class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
-
     """Integration E2E tests for StatVarGroupGenerator."""
 
     def get_generator(self) -> StatVarGroupGenerator:
@@ -1525,8 +1524,10 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
         self.flush_to_spanner()
 
         # 2. Run generator
-        job = generator.run_all(import_names=['Schema'])
-        self.assertIsNotNone(job)
+        jobs = generator.run_all(import_names=['Schema'])
+        self.assertIsNotNone(jobs)
+        for job in jobs:
+            job.result()
 
         # 3. Verify results in Spanner
         with self.database.snapshot(multi_use=True) as snapshot:

--- a/pipeline/workflow/ingestion-helper/aggregation/e2e_tests/aggregation_e2e_test.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/e2e_tests/aggregation_e2e_test.py
@@ -1468,6 +1468,7 @@ class StatVarAggregatorCustomDcTest(StatVarAggregatorIntegrationTest):
 
 
 class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
+
     """Integration E2E tests for StatVarGroupGenerator."""
 
     def get_generator(self) -> StatVarGroupGenerator:
@@ -1487,7 +1488,8 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
         )
 
     def test_stat_var_group_generation(self):
-        """Tests the generation of StatVarGroups and hierarchical edges from SV specs.
+        """
+        Tests the generation of StatVarGroups and hierarchical edges from SV specs.
         
         Setup:
           - A vertical spec mapping 'Student' population type to a 'TestVertical' SVG.

--- a/pipeline/workflow/ingestion-helper/aggregation/linked_edge_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/linked_edge_generator.py
@@ -42,7 +42,6 @@ class LinkedEdgeGenerator:
 
         jobs = [
             self.run_linked_contained_in_place(import_names),
-            self.run_linked_member_of(import_names),
             self.run_linked_member(import_names)
         ]
         return [job for job in jobs if job]
@@ -121,99 +120,6 @@ class LinkedEdgeGenerator:
           WHERE NOT EXISTS (
             SELECT 1
             FROM `temp_existing_linked_contained_in_place` e
-            WHERE n.subject_id = e.subject_id
-              AND n.predicate = e.predicate
-              AND n.object_id = e.object_id
-              AND n.provenance = e.provenance
-          )
-        )
-        SELECT
-          subject_id,
-          predicate,
-          object_id,
-          provenance
-        FROM
-          FilteredEdges
-        """
-        return self.executor.execute(query)
-
-    def run_linked_member_of(
-            self,
-            import_names: List[str] = None) -> Optional[bigquery.job.QueryJob]:
-        """Expands membership hierarchies using memberOf and specializationOf."""
-        if not import_names:
-            return None
-
-        dest = self.executor.get_spanner_destination_uri()
-        safe_names = [_escape_sql_literal(name) for name in import_names]
-        prefix = "dc/base/" if self.is_base_dc else ""
-        provenances = [f"'{prefix}{name}'" for name in safe_names]
-        provenance_filter = f" AND provenance IN ({', '.join(provenances)})"
-        gen_graphs_prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
-
-        query = f"""  # nosec
-        -- Pull base edges needed for memberOf aggregation
-        CREATE OR REPLACE TEMPORARY TABLE `temp_base_member_of` AS
-        SELECT * FROM EXTERNAL_QUERY("{self.executor.connection_id}", 
-          "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate IN ('memberOf', 'specializationOf'){provenance_filter}");
-
-        -- Pull existing generated edges to filter them out later
-        CREATE OR REPLACE TEMPORARY TABLE `temp_existing_linked_member_of` AS
-        SELECT * FROM EXTERNAL_QUERY("{self.executor.connection_id}", 
-          "SELECT subject_id, predicate, object_id, provenance FROM Edge WHERE predicate = 'linkedMemberOf'");
-
-        CREATE OR REPLACE TEMPORARY TABLE `temp_hierarchy` AS
-        SELECT DISTINCT subject_id, predicate, object_id
-        FROM `temp_base_member_of`;
-
-        EXPORT DATA
-          OPTIONS( uri="{dest}",
-            format='CLOUD_SPANNER',
-            spanner_options = '{{"table": "Edge"}}' ) AS
-        WITH RECURSIVE Ancestors AS (
-          SELECT
-            subject_id,
-            object_id AS ancestor,
-            1 AS level
-          FROM
-            temp_hierarchy
-          WHERE
-            predicate = 'memberOf'
-          UNION ALL
-
-          SELECT
-            a.subject_id,
-            t.object_id AS ancestor,
-            a.level + 1
-          FROM
-            Ancestors AS a
-          JOIN
-            temp_hierarchy AS t
-            ON a.ancestor = t.subject_id
-          WHERE
-            a.level <= 20 -- Limit to 20 levels
-            AND t.predicate = 'specializationOf'
-        ),
-        NewEdges AS (
-          SELECT DISTINCT
-            subject_id,
-            'linkedMemberOf' as predicate,
-            ancestor as object_id,
-            '{gen_graphs_prov}' as provenance
-          FROM
-            Ancestors
-        ),
-        FilteredEdges AS (
-          SELECT
-            subject_id,
-            predicate,
-            object_id,
-            provenance
-          FROM
-            NewEdges n
-          WHERE NOT EXISTS (
-            SELECT 1
-            FROM `temp_existing_linked_member_of` e
             WHERE n.subject_id = e.subject_id
               AND n.predicate = e.predicate
               AND n.object_id = e.object_id

--- a/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
@@ -1,0 +1,445 @@
+import logging
+from typing import List, Optional
+
+from google.cloud import bigquery
+from .bq_executor import BigQueryExecutor
+
+class StatVarGroupGenerator:
+    """Iteratively generates StatVarGroup nodes and hierarchical edges from MCF schemas."""
+
+    def __init__(self,
+                 executor: BigQueryExecutor,
+                 is_base_dc: bool = True,
+                 max_iterations: int = 50,
+                 namespace: Optional[str] = None,
+                 generated_provenance: Optional[str] = None,
+                 should_filter_basic_population_type: bool = True) -> None:
+        """Initializes the StatVarGroupGenerator with executor and configuration parameters.
+        
+        Args:
+            executor: BigQueryExecutor instance.
+            is_base_dc: Whether this is running in the base Data Commons environment.
+            max_iterations: Max loop iterations for SV generation.
+            namespace: Namespace for generated DCIDs.
+            generated_provenance: Provenance for generated Edges.
+            self.should_filter_basic_population_type = Filter basic population type SVGs.
+        """
+        self.executor = executor
+        self.max_iterations = max_iterations
+        self.namespace = namespace if namespace is not None else ('dc/' if is_base_dc else 'custom/')
+        self.generated_provenance = generated_provenance if generated_provenance is not None else ('dc/base/GeneratedGraphs' if is_base_dc else 'GeneratedGraphs')
+        self.should_filter_basic_population_type = should_filter_basic_population_type
+
+    def run_all(self,
+                import_names: List[str] = None) -> List[bigquery.job.QueryJob]:
+        """Runs all global aggregations asynchronously and returns their jobs."""
+        if not import_names:
+            logging.info("No imports specified. Skipping global aggregations.")
+            return []
+
+        logging.info(f"Running global aggregations for imports: {import_names}")
+
+        jobs = [
+            self.run_stat_var_group(),
+        ]
+        return [job for job in jobs if job]
+
+    def run_stat_var_group(self) -> List[Optional[bigquery.job.QueryJob]]:
+        """Compiles and executes the StatVarGroup generation script."""
+        logging.info("Starting StatVarGroup generation script...")
+        
+        dest_uri = self.executor.get_spanner_destination_uri()
+        conn_id = self.executor.connection_id
+        filter_bool = "TRUE" if self.should_filter_basic_population_type else "FALSE"
+
+        # Using rf-string to safely pass SQL regex backslashes while enabling variable injection
+        query = rf"""  # nosec
+        DECLARE new_rows_found BOOL DEFAULT TRUE; -- Flag to continue loop
+        DECLARE iteration_count INT64 DEFAULT 0; -- Iteration of loop
+        DECLARE max_iterations INT64 DEFAULT {self.max_iterations}; -- Maximum number of iterations to generate
+        DECLARE namespace STRING DEFAULT '{self.namespace}'; -- Namespace for generated DCIDs 
+        DECLARE generated_provenance STRING DEFAULT '{self.generated_provenance}'; -- Provenance for generated Edges
+        DECLARE uncategorized_svg STRING DEFAULT CONCAT(namespace, 'g/Uncategorized'); -- DCID for uncategorized SVs/SVGs
+        DECLARE root_svg STRING DEFAULT CONCAT(namespace, 'g/Root'); -- DCID for root SVG
+        DECLARE should_filter_basic_population_type BOOL DEFAULT {filter_bool}; -- Whether to filter basic population type SVGs. Default to true for base DC 
+
+        -- ============================================================================
+        -- UDFs
+        -- ============================================================================
+        -- Generate readable name from MCF schema
+        CREATE TEMP FUNCTION FormatName(input_string STRING) AS (
+          (
+            SELECT CONCAT(UPPER(SUBSTR(val, 1, 1)), SUBSTR(val, 2))
+            FROM UNNEST([
+              TRIM(
+                REGEXP_REPLACE(
+                  REGEXP_REPLACE(
+                    REGEXP_REPLACE(
+                      REGEXP_REPLACE(
+                        REPLACE(input_string, '_', ' '),
+                        r'([a-z])([A-Z])', r'\1 \2'
+                      ),
+                      r'([A-Z])([A-Z][a-z])', r'\1 \2'
+                    ),
+                    r'([A-Za-z])([0-9])', r'\1 \2'
+                  ),
+                  r'([0-9])([A-Za-z])', r'\1 \2'
+                )
+              )
+            ]) AS val
+          )
+        );
+
+        -- Checks whether a pouplationType is a basic population type.
+        -- Based on the legacy Prophet IsBasicPopulationType.
+        CREATE TEMP FUNCTION IsBasicPopulationType(populationType STRING) RETURNS BOOL AS (
+          populationType IN (
+            'Person', 'BLSWorker', 'USCWorker', 'Thing', 'Household',
+            'HousingUnit', 'Place', 'Energy'
+          )
+        );
+
+        -- ============================================================================
+        -- Base Tables
+        -- ============================================================================
+        -- Fetch all StatVarGroupSpec nodes.
+        CREATE OR REPLACE TEMP TABLE StatVarGroupSpec AS (
+          SELECT DISTINCT subject_id
+          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id FROM Edge WHERE predicate = 'typeOf' AND object_id = 'StatVarGroupSpec'")
+        );
+
+        -- Fetch StatVarGroupSpec edges for relevant properties.
+        CREATE OR REPLACE TEMP TABLE SpecObjects AS (
+          SELECT DISTINCT E.subject_id, E.predicate, E.object_id
+          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate IN ('populationType', 'constraintProperties', 'vertical', 'dependentPropertyValue')") E
+          JOIN StatVarGroupSpec S ON E.subject_id = S.subject_id
+        );
+
+        -- Resolve StatVarGroup spec object_ids to values. 
+        CREATE OR REPLACE TEMP TABLE SpecValues AS (
+          SELECT S.subject_id, S.predicate, N.value
+          FROM SpecObjects S
+          JOIN EXTERNAL_QUERY("{conn_id}", "SELECT subject_id, value FROM Node") N 
+            ON S.object_id = N.subject_id
+          WHERE S.subject_id NOT IN (
+            SELECT subject_id FROM SpecObjects WHERE predicate = 'dependentPropertyValue'
+          )
+        );
+
+        -- Fetch all specializationOf edges.
+        -- NOTE: specializationOf edges will be generated in this script. We only need the edges for the verticals here.
+        CREATE OR REPLACE TEMP TABLE VerticalHierarchy AS (
+          SELECT subject_id, object_id 
+          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id, object_id FROM Edge WHERE predicate = 'specializationOf'")
+        );
+
+        -- Find all vertical ancestors. 
+        CREATE OR REPLACE TEMP TABLE VerticalAncestors AS (
+          WITH RECURSIVE Ancestors AS (
+            SELECT H.subject_id, H.object_id AS ancestor_svg, 1 AS level
+            FROM VerticalHierarchy H
+            JOIN (
+              SELECT DISTINCT value AS subject_id FROM SpecValues WHERE predicate = 'vertical'
+            ) V ON H.subject_id = V.subject_id
+            
+            UNION ALL
+            SELECT A.subject_id, H.object_id AS ancestor_svg, A.level + 1
+            FROM Ancestors A
+            JOIN VerticalHierarchy H ON A.ancestor_svg = H.subject_id
+            WHERE A.level <= 10
+          ) 
+          SELECT DISTINCT subject_id, ARRAY_AGG(ancestor_svg ORDER BY ancestor_svg) AS ancestors
+          FROM (SELECT DISTINCT subject_id, ancestor_svg FROM Ancestors)
+          GROUP BY subject_id
+        );
+
+        -- Generate vertical spec.
+        CREATE OR REPLACE TEMPORARY TABLE VerticalSpec AS (
+          WITH PivotSpec AS (
+            SELECT * FROM SpecValues
+            PIVOT (
+              ARRAY_AGG(value IGNORE NULLS ORDER BY value) 
+              -- NOTE: Currently excluding ObsProp. This is because it can cause unexpected behavior when an SV is attached to a vertical due to another SV having a matching mprop.
+              -- Instead, the SV will get attached only based on popType and cpops, so the result is deterministic per SV.
+              -- TODO: Determine what the intended behavior is. 
+              FOR predicate IN ('populationType', 'constraintProperties', 'vertical')
+            )
+          )
+          SELECT 
+            PivotSpec.subject_id,
+            populationType[SAFE_OFFSET(0)] AS populationType,
+            IFNULL(constraintProperties, []) AS constraintProperties,
+            vertical,
+            ARRAY(
+              SELECT DISTINCT val
+              FROM UNNEST(ARRAY_CONCAT(IFNULL(PivotSpec.vertical, []), IFNULL(A.ancestors, []))) AS val
+              ORDER BY val
+            ) AS linkedVertical
+          FROM PivotSpec
+          LEFT JOIN VerticalAncestors A ON A.subject_id IN UNNEST(PivotSpec.vertical)
+          WHERE ARRAY_LENGTH(constraintProperties) <= 1 OR constraintProperties IS NULL
+          ORDER BY subject_id
+        );
+
+        -- Fetch all StatisticalVariable nodes.
+        CREATE OR REPLACE TEMP TABLE StatVar AS (
+          SELECT subject_id
+          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id FROM Edge WHERE predicate = 'typeOf' AND object_id = 'StatisticalVariable'")
+        );
+
+        -- Fetch relevant StatisticalVariable triples.
+        -- This list is based on the legacy Prophet PropsThatAreNotConstraintProps, 
+        -- but excluding constraintProperties, populationType, measuredProperty, measurementDenominator, measurementQualifier which are part of the vertical spec.
+        -- Also including domainIncludes/rangeIncludes due to some incorrectly modeled SVs. TODO: Clean these up.
+        -- Also including definition, linkedMemberOf, and linkedMember, which are generated properties.    
+        CREATE OR REPLACE TEMP TABLE StatVarTriple AS (
+          SELECT DISTINCT E.subject_id, E.predicate, E.object_id
+          FROM EXTERNAL_QUERY("{conn_id}",
+            "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate NOT IN ('typeOf', 'dcid', 'provenance', 'isPublic', 'localCuratorLevelId', 'url', 'memberOf', 'name', 'label', 'description', 'descriptionUrl', 'alternateName', 'utteranceTemplate', 'source', 'footnote', 'keyString', 'resMCFFile', 'populationGroup', 'location', 'childhoodLocation', 'statType', 'censusACSTableId', 'measurementMethod', 'scalingFactor', 'unit', 'isNormalizable', 'denominatorForNormalization', 'domainIncludes', 'rangeIncludes', 'definition', 'linkedMemberOf', 'linkedMember')"
+          ) E
+          JOIN StatVar SV ON SV.subject_id = E.subject_id
+        );
+
+        -- Seed the intial data for iteratively generating SVGs.
+        CREATE OR REPLACE TEMPORARY TABLE InitialData AS (
+          WITH PopType AS (
+            SELECT subject_id, object_id FROM StatVarTriple WHERE predicate = 'populationType'
+          ),
+          ConstraintProps AS (
+            SELECT subject_id, ARRAY_AGG(object_id ORDER BY object_id) AS constraintProperties
+            FROM StatVarTriple WHERE predicate = 'constraintProperties' GROUP BY subject_id
+          ),
+          Constraints AS (
+            SELECT T.subject_id, ARRAY_AGG(CONCAT(FormatName(T.predicate), ' = ', FormatName(T.object_id)) ORDER BY T.predicate) AS pvs
+            FROM StatVarTriple T
+            JOIN ConstraintProps ON T.subject_id = ConstraintProps.subject_id
+            WHERE predicate IN UNNEST(ConstraintProps.constraintProperties) GROUP BY subject_id 
+          )
+          SELECT
+            CAST(NULL AS STRING) AS node1,
+            CAST(NULL AS STRING) AS node2,
+            '' AS node2name,
+            IF(ARRAY_LENGTH(Constraints.pvs) > 0, 
+              CONCAT(namespace, 'g/', PopType.object_id, '_', REPLACE(REPLACE(ARRAY_TO_STRING(Constraints.pvs, '_'), ' ', ''), '=', '-')), 
+              CAST(NULL AS STRING)
+            ) AS node3,
+            IF(ARRAY_LENGTH(Constraints.pvs) > 0, 
+              CONCAT(FormatName(PopType.object_id), ' With ', ARRAY_TO_STRING(Constraints.pvs, ', ')), 
+              ''
+            ) AS node3name,
+            PopType.subject_id AS statvar,
+            PopType.object_id AS populationType,
+            ARRAY<STRING>[] AS constraintProperties,
+            ConstraintProps.constraintProperties AS newConstraintProperties,
+            Constraints.pvs AS attributes,
+            0 AS iteration
+          FROM PopType
+          LEFT JOIN ConstraintProps ON ConstraintProps.subject_id = PopType.subject_id
+          LEFT JOIN Constraints ON Constraints.subject_id = PopType.subject_id
+        );
+
+        -- Create Edges for top level SVs (those with no constraintProperties) to verticals.
+        -- We only do this directly for basic population types. Non-basic ones get an intermediate group.
+        CREATE OR REPLACE TEMP TABLE SVVerticalEdges AS (
+          WITH ZeroConstraintStatVars AS (
+            SELECT * FROM InitialData WHERE ARRAY_LENGTH(attributes) = 0
+            AND (should_filter_basic_population_type AND IsBasicPopulationType(populationType))
+          )
+          SELECT DISTINCT
+            SV.statvar AS subject_id, map.predicate, v AS object_id, generated_provenance AS provenance 
+          FROM ZeroConstraintStatVars SV
+          LEFT JOIN VerticalSpec VS 
+            ON SV.populationType = VS.populationType AND IFNULL(ARRAY_LENGTH(VS.constraintProperties), 0) = 0
+          CROSS JOIN UNNEST([
+            STRUCT('memberOf' AS predicate, IF(IFNULL(ARRAY_LENGTH(VS.vertical), 0) = 0, ARRAY<STRING>[uncategorized_svg], VS.vertical) AS target_array),
+            STRUCT('linkedMemberOf' AS predicate, IF(IFNULL(ARRAY_LENGTH(VS.linkedVertical), 0) = 0, ARRAY<STRING>[root_svg, uncategorized_svg], VS.linkedVertical) AS target_array)
+          ]) AS map
+          CROSS JOIN UNNEST(map.target_array) AS v
+        );
+
+        -- ============================================================================
+        -- Iterative Loop
+        -- ============================================================================
+        -- Create table to hold the results from the iteration.
+        CREATE OR REPLACE TEMP TABLE AllResults ( 
+          node1 STRING, node2 STRING, node2name STRING, node3 STRING, node3name STRING,
+          statvar STRING, populationType STRING, constraintProperties ARRAY<STRING>,
+          newConstraintProperties ARRAY<STRING>, attributes ARRAY<STRING>, iteration INT64 
+        );
+
+        -- Seed 0-constraint SVs with non-basic population types so they generate an intermediate SVG
+        INSERT INTO AllResults
+        SELECT
+          CAST(NULL AS STRING) AS node1,
+          CONCAT(namespace, 'g/', populationType) AS node2,
+          FormatName(populationType) AS node2name,
+          CAST(NULL AS STRING) AS node3,
+          CAST(NULL AS STRING) AS node3name,
+          statvar,
+          populationType,
+          ARRAY<STRING>[] AS constraintProperties,
+          ARRAY<STRING>[] AS newConstraintProperties,
+          ARRAY<STRING>[] AS attributes,
+          1 AS iteration
+        FROM InitialData
+        WHERE ARRAY_LENGTH(attributes) = 0
+          AND NOT (should_filter_basic_population_type AND IsBasicPopulationType(populationType));
+
+        WHILE new_rows_found AND iteration_count < max_iterations DO
+          SET iteration_count = iteration_count + 1;
+          SET new_rows_found = FALSE;
+          
+          CREATE OR REPLACE TEMP TABLE CurrentIterationOutput AS (
+            SELECT
+              -- Set node1 to node3 of previous iteration.
+              node3 AS node1,
+              -- Remove one PV from node1 to produce node2.
+              CONCAT(namespace, 'g/', populationType, '_', ARRAY_TO_STRING(ARRAY(
+                SELECT IF(unnest_idx = target_idx, REPLACE(SPLIT(unnested, ' = ')[OFFSET(0)], ' ', ''), REPLACE(REPLACE(unnested, ' ', ''), '=', '-'))
+                FROM UNNEST(attributes) AS unnested WITH OFFSET AS unnest_idx
+              ), '_')) AS node2,
+              CONCAT(FormatName(populationType), ' With ', ARRAY_TO_STRING(ARRAY(
+                SELECT IF(unnest_idx = target_idx, SPLIT(unnested, ' = ')[OFFSET(0)], unnested)
+                FROM UNNEST(attributes) AS unnested WITH OFFSET AS unnest_idx
+              ), ', ')) AS node2name,
+              -- Remove corresponding P from node2 to produce node3.
+              IF(ARRAY_LENGTH(attributes) > 1, 
+                CONCAT(namespace, 'g/', populationType, '_', ARRAY_TO_STRING(ARRAY( 
+                  SELECT REPLACE(REPLACE(a, ' ', ''), '=', '-') 
+                  FROM UNNEST(attributes) AS a WITH OFFSET AS a_idx WHERE a_idx != target_idx 
+                ), '_')),
+                IF(NOT (should_filter_basic_population_type AND IsBasicPopulationType(populationType)), CONCAT(namespace, 'g/', populationType), CAST(NULL AS STRING))
+              ) AS node3,
+              IF(ARRAY_LENGTH(attributes) > 1, 
+                CONCAT(FormatName(populationType), ' With ', ARRAY_TO_STRING(ARRAY( 
+                  SELECT a FROM UNNEST(attributes) AS a WITH OFFSET AS a_idx WHERE a_idx != target_idx 
+                ), ', ')),
+                IF(NOT (should_filter_basic_population_type AND IsBasicPopulationType(populationType)), FormatName(populationType), CAST(NULL AS STRING))
+              ) AS node3name,
+              statvar, populationType, newConstraintProperties AS constraintProperties,
+              ARRAY(SELECT cp FROM UNNEST(newConstraintProperties) AS cp WITH OFFSET AS cp_idx WHERE cp_idx != target_idx) AS newConstraintProperties,
+              ARRAY(SELECT a FROM UNNEST(attributes) AS a WITH OFFSET AS a_idx WHERE a_idx != target_idx) AS attributes,
+              iteration + 1 AS iteration
+            FROM InitialData AS T, UNNEST(attributes) AS attr WITH OFFSET AS target_idx
+            WHERE ARRAY_LENGTH(attributes) >= 1
+          );
+
+          -- Isolate new rows generated in this iteration. This is to help prune identical paths from a SV.
+          CREATE OR REPLACE TEMP TABLE NewDistinctRows AS (
+            SELECT DISTINCT C.node1, C.node2, C.node2name, C.node3, C.node3name, C.statvar, C.populationType,
+              C.constraintProperties, C.newConstraintProperties, C.attributes, C.iteration
+            FROM CurrentIterationOutput C
+            LEFT JOIN AllResults AR ON C.statvar = AR.statvar AND C.node1 IS NOT DISTINCT FROM AR.node1
+              AND C.node2 IS NOT DISTINCT FROM AR.node2 AND C.node3 IS NOT DISTINCT FROM AR.node3
+            WHERE AR.statvar IS NULL
+          );
+
+          IF (SELECT COUNT(1) FROM NewDistinctRows) > 0 THEN
+            INSERT INTO AllResults SELECT * FROM NewDistinctRows;
+            SET new_rows_found = TRUE;
+          END IF;
+
+          CREATE OR REPLACE TEMP TABLE InitialData AS (SELECT * FROM NewDistinctRows);
+        END WHILE;
+
+        -- ============================================================================
+        -- Final Edges and Nodes Generation
+        -- ============================================================================
+        -- Create Edges for top level SVGs (those with 0 or 1 constraintProperties) to verticals.
+        CREATE OR REPLACE TEMP TABLE SVGVerticalEdges AS (
+          WITH FilteredSVG AS (
+            SELECT * FROM AllResults WHERE ARRAY_LENGTH(constraintProperties) = 1
+          ),
+          BaseJoined AS (
+            SELECT
+              SVG.statvar, COALESCE(SVG.node3, SVG.node2) AS svg_id, generated_provenance AS provenance,
+              IF(IFNULL(ARRAY_LENGTH(VS.vertical), 0) = 0, ARRAY<STRING>[uncategorized_svg], VS.vertical) AS svg_targets,
+              IF(IFNULL(ARRAY_LENGTH(VS.linkedVertical), 0) = 0, ARRAY<STRING>[root_svg, uncategorized_svg], VS.linkedVertical) AS statvar_targets
+            FROM FilteredSVG SVG
+            LEFT JOIN VerticalSpec VS 
+              ON SVG.populationType = VS.populationType AND (
+                (SVG.node3 IS NOT NULL AND IFNULL(ARRAY_LENGTH(VS.constraintProperties), 0) = 0) OR 
+                (SVG.node3 IS NULL AND TO_JSON_STRING(SVG.constraintProperties) = TO_JSON_STRING(VS.constraintProperties))
+              )
+          ),
+          RawSVGEdges AS (
+            SELECT DISTINCT svg_id AS subject_id, 'specializationOf' AS predicate, v AS object_id, provenance
+            FROM BaseJoined CROSS JOIN UNNEST(svg_targets) AS v
+          ),
+          -- Filter SVGs from Uncategorized if they're part of a different vertical.
+          FilteredSVGEdges AS (
+            SELECT subject_id, predicate, object_id, provenance 
+            FROM (SELECT *, COUNTIF(object_id != uncategorized_svg) OVER(PARTITION BY subject_id, predicate, provenance) AS categorized_count FROM RawSVGEdges)
+            WHERE object_id != uncategorized_svg OR categorized_count = 0
+          ),
+          RawStatVarEdges AS (
+            SELECT DISTINCT statvar AS subject_id, 'linkedMemberOf' AS predicate, v AS object_id, provenance, svg_id AS parent_svg_id
+            FROM BaseJoined CROSS JOIN UNNEST(statvar_targets) AS v
+          ),
+          -- Filter SVs from Uncategorized if none of their ancestor SVGs are uncategorized.
+          FilteredStatVarEdges AS (
+            SELECT DISTINCT subject_id, predicate, object_id, provenance
+            FROM RawStatVarEdges r
+            WHERE object_id != uncategorized_svg OR EXISTS (
+                 SELECT 1 FROM FilteredSVGEdges f WHERE f.subject_id = r.parent_svg_id AND f.provenance = r.provenance AND f.object_id = uncategorized_svg
+               )
+          )
+          SELECT subject_id, predicate, object_id, provenance FROM FilteredSVGEdges
+          UNION ALL
+          SELECT subject_id, predicate, object_id, provenance FROM FilteredStatVarEdges
+        );
+
+        -- Generate Spanner Node rows.
+        CREATE OR REPLACE TEMP TABLE Node AS (
+          SELECT DISTINCT node_data.subject_id, node_data.value, node_data.name, node_data.types
+          FROM AllResults
+          CROSS JOIN UNNEST([
+            STRUCT(node2 AS subject_id, node2 AS value, node2name AS name, ['StatVarGroup'] AS types, node2 IS NOT NULL AS keep),
+            STRUCT(node3, node3, node3name, ['StatVarGroup'], node3 IS NOT NULL),
+            STRUCT(CONCAT(SUBSTR(node2name, 1, 16), ':', TO_BASE64(SHA256(node2name))), node2name, '', ARRAY<STRING>[], node2 IS NOT NULL),
+            STRUCT(CONCAT(SUBSTR(node3name, 1, 16), ':', TO_BASE64(SHA256(node3name))), node3name, '', ARRAY<STRING>[], node3 IS NOT NULL)
+          ]) AS node_data
+          WHERE node_data.keep = TRUE
+          ORDER BY subject_id
+        );
+
+        -- Generate Spanner Edge rows.
+        CREATE OR REPLACE TEMP TABLE Edge AS (
+          SELECT DISTINCT edge_data.subject_id, edge_data.predicate, edge_data.object_id, generated_provenance AS provenance
+          FROM AllResults
+          CROSS JOIN UNNEST([
+            STRUCT(statvar AS subject_id, 'memberOf' AS predicate, node2 AS object_id, iteration = 1 AS keep),
+            STRUCT(node2, 'typeOf', 'StatVarGroup', node2 IS NOT NULL),
+            STRUCT(node2, 'name', CONCAT(SUBSTR(node2name, 1, 16), ':', TO_BASE64(SHA256(node2name))), node2 IS NOT NULL),
+            STRUCT(node3, 'typeOf', 'StatVarGroup', node3 IS NOT NULL),
+            STRUCT(node3, 'name', CONCAT(SUBSTR(node3name, 1, 16), ':', TO_BASE64(SHA256(node3name))), node3 IS NOT NULL),
+            STRUCT(node1, 'specializationOf', node2, node1 IS NOT NULL AND node2 IS NOT NULL AND iteration > 1),
+            STRUCT(node2, 'specializationOf', node3, node2 IS NOT NULL AND node3 IS NOT NULL),
+            STRUCT(statvar, 'linkedMemberOf', node2, node2 IS NOT NULL),
+            STRUCT(statvar, 'linkedMemberOf', node3, node3 IS NOT NULL)
+          ]) AS edge_data
+          WHERE edge_data.keep = TRUE
+          UNION ALL SELECT * FROM SVVerticalEdges
+          UNION ALL SELECT * FROM SVGVerticalEdges
+          ORDER BY subject_id, predicate, object_id
+        );
+
+        -- ============================================================================
+        -- Exports
+        -- ============================================================================
+        EXPORT DATA
+          OPTIONS(
+            uri="{dest_uri}",
+            format='CLOUD_SPANNER',
+            spanner_options = '{{"table": "Node"}}'
+          ) AS (SELECT * FROM Node);
+
+        EXPORT DATA
+          OPTIONS(
+            uri="{dest_uri}",
+            format='CLOUD_SPANNER',
+            spanner_options = '{{"table": "Edge"}}'
+          ) AS (SELECT * FROM Edge);
+        """
+        
+        return self.executor.execute(query)

--- a/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
@@ -3,8 +3,10 @@ from typing import List, Optional
 
 from google.cloud import bigquery
 from .bq_executor import BigQueryExecutor
+from .sql_utils import _escape_sql_literal
 
 class StatVarGroupGenerator:
+
     """Iteratively generates StatVarGroup nodes and hierarchical edges from MCF schemas."""
 
     def __init__(self,
@@ -14,20 +16,27 @@ class StatVarGroupGenerator:
                  namespace: Optional[str] = None,
                  generated_provenance: Optional[str] = None,
                  should_filter_basic_population_type: bool = True) -> None:
-        """Initializes the StatVarGroupGenerator with executor and configuration parameters.
-        
+        """
+        Initializes the StatVarGroupGenerator with executor and configuration parameters.
+
         Args:
-            executor: BigQueryExecutor instance.
-            is_base_dc: Whether this is running in the base Data Commons environment.
-            max_iterations: Max loop iterations for SV generation.
-            namespace: Namespace for generated DCIDs.
-            generated_provenance: Provenance for generated Edges.
-            self.should_filter_basic_population_type = Filter basic population type SVGs.
+        ----
+        executor: BigQueryExecutor instance.
+        is_base_dc: Whether this is running in the base Data Commons environment.
+        max_iterations: Max loop iterations for SV generation.
+        namespace: Namespace for generated DCIDs.
+        generated_provenance: Provenance for generated Edges.
+        should_filter_basic_population_type = Filter basic population type SVGs.
+        
         """
         self.executor = executor
         self.max_iterations = max_iterations
         self.namespace = namespace if namespace is not None else ('dc/' if is_base_dc else 'custom/')
-        self.generated_provenance = generated_provenance if generated_provenance is not None else ('dc/base/GeneratedGraphs' if is_base_dc else 'GeneratedGraphs')
+        self.generated_provenance = (
+          generated_provenance 
+          if generated_provenance is not None 
+          else ('dc/base/GeneratedGraphs' if is_base_dc else 'GeneratedGraphs')
+        )
         self.should_filter_basic_population_type = should_filter_basic_population_type
 
     def run_all(self,
@@ -47,21 +56,64 @@ class StatVarGroupGenerator:
     def run_stat_var_group(self) -> List[Optional[bigquery.job.QueryJob]]:
         """Compiles and executes the StatVarGroup generation script."""
         logging.info("Starting StatVarGroup generation script...")
+
+        dest_uri = _escape_sql_literal(self.executor.get_spanner_destination_uri())
+        conn_id = _escape_sql_literal(self.executor.connection_id)
+
+        # =====================================================================
+        # OPTIMIZATION: Two-Stage Fetch for StatVar Triples
+        # =====================================================================
+        logging.info("Fetching distinct constraint properties...")
+        prep_query = f"""
+            SELECT DISTINCT object_id
+            FROM EXTERNAL_QUERY("{conn_id}", "SELECT object_id FROM Edge WHERE predicate = 'constraintProperties'")
+        """
+        prep_sv_job = self.executor.execute(prep_query)
+        constraint_props = [row.object_id for row in prep_sv_job]
+
+        # Combine base predicates with the dynamically discovered constraint properties
+        needed_predicates = ['populationType', 'constraintProperties'] + constraint_props
         
-        dest_uri = self.executor.get_spanner_destination_uri()
-        conn_id = self.executor.connection_id
-        filter_bool = "TRUE" if self.should_filter_basic_population_type else "FALSE"
+        # Format into a SQL-safe string
+        sv_predicates = [f"'{p.replace('\'', '')}'" for p in needed_predicates]
+        sv_predicates_sql = ", ".join(sv_predicates)
+        logging.info(f"Optimizing Spanner fetch. Pulling {len(sv_predicates)} specific predicates.")
+        # =====================================================================
+        # OPTIMIZATION 2: Two-Stage Fetch for Spec Nodes (Object IDs)
+        # =====================================================================
+        logging.info("Fetching distinct object_ids...")
+        prep_objects_query = f"""
+            SELECT DISTINCT object_id
+            FROM EXTERNAL_QUERY(
+                "{conn_id}", 
+                '''SELECT object_id 
+                   FROM Edge 
+                   WHERE predicate IN (
+                       'populationType', 
+                       'constraintProperties', 
+                       'vertical', 
+                       'dependentPropertyValue'
+                   )'''
+            )
+        """
+        prep_objs_job = self.executor.execute(prep_objects_query)
+        
+        # Format into a SQL-safe array string for Spanner injection
+        spec_objects = [f"'{row.object_id.replace('\'', '')}'" for row in prep_objs_job if row.object_id]
+        spec_objects_sql = ", ".join(spec_objects)
+        logging.info(f"Optimizing Spanner fetch. Pulling {len(spec_objects)} specific Spec objects.")
+        # =====================================================================
 
         # Using rf-string to safely pass SQL regex backslashes while enabling variable injection
         query = rf"""  # nosec
         DECLARE new_rows_found BOOL DEFAULT TRUE; -- Flag to continue loop
         DECLARE iteration_count INT64 DEFAULT 0; -- Iteration of loop
-        DECLARE max_iterations INT64 DEFAULT {self.max_iterations}; -- Maximum number of iterations to generate
-        DECLARE namespace STRING DEFAULT '{self.namespace}'; -- Namespace for generated DCIDs 
-        DECLARE generated_provenance STRING DEFAULT '{self.generated_provenance}'; -- Provenance for generated Edges
+        DECLARE max_iterations INT64 DEFAULT @max_iterations; -- Maximum number of iterations to generate
+        DECLARE namespace STRING DEFAULT @namespace; -- Namespace for generated DCIDs
+        DECLARE generated_provenance STRING DEFAULT @generated_provenance; -- Provenance for generated Edges
         DECLARE uncategorized_svg STRING DEFAULT CONCAT(namespace, 'g/Uncategorized'); -- DCID for uncategorized SVs/SVGs
         DECLARE root_svg STRING DEFAULT CONCAT(namespace, 'g/Root'); -- DCID for root SVG
-        DECLARE should_filter_basic_population_type BOOL DEFAULT {filter_bool}; -- Whether to filter basic population type SVGs. Default to true for base DC 
+        DECLARE should_filter_basic_population_type BOOL DEFAULT @should_filter; -- Whether to filter basic population type SVGs. Default to true for base DC
 
         -- ============================================================================
         -- UDFs
@@ -111,7 +163,17 @@ class StatVarGroupGenerator:
         -- Fetch StatVarGroupSpec edges for relevant properties.
         CREATE OR REPLACE TEMP TABLE SpecObjects AS (
           SELECT DISTINCT E.subject_id, E.predicate, E.object_id
-          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate IN ('populationType', 'constraintProperties', 'vertical', 'dependentPropertyValue')") E
+          FROM EXTERNAL_QUERY(
+            "{conn_id}", 
+            '''
+            SELECT subject_id, predicate, object_id 
+            FROM Edge 
+            WHERE predicate IN (
+              'populationType', 
+              'constraintProperties', 
+              'vertical', 
+              'dependentPropertyValue'
+            )''') E
           JOIN StatVarGroupSpec S ON E.subject_id = S.subject_id
         );
 
@@ -119,7 +181,9 @@ class StatVarGroupGenerator:
         CREATE OR REPLACE TEMP TABLE SpecValues AS (
           SELECT S.subject_id, S.predicate, N.value
           FROM SpecObjects S
-          JOIN EXTERNAL_QUERY("{conn_id}", "SELECT subject_id, value FROM Node") N 
+          JOIN EXTERNAL_QUERY("{conn_id}", 
+            "SELECT subject_id, value FROM Node WHERE subject_id IN UNNEST([{spec_objects_sql}])"
+          ) N
             ON S.object_id = N.subject_id
           WHERE S.subject_id NOT IN (
             SELECT subject_id FROM SpecObjects WHERE predicate = 'dependentPropertyValue'
@@ -159,7 +223,8 @@ class StatVarGroupGenerator:
             SELECT * FROM SpecValues
             PIVOT (
               ARRAY_AGG(value IGNORE NULLS ORDER BY value) 
-              -- NOTE: Currently excluding ObsProp. This is because it can cause unexpected behavior when an SV is attached to a vertical due to another SV having a matching mprop.
+              -- NOTE: Currently excluding ObsProp.
+              -- This is because it can cause unexpected behavior when an SV is attached to a vertical due to another SV having a matching mprop.
               -- Instead, the SV will get attached only based on popType and cpops, so the result is deterministic per SV.
               -- TODO: Determine what the intended behavior is. 
               FOR predicate IN ('populationType', 'constraintProperties', 'vertical')
@@ -188,14 +253,10 @@ class StatVarGroupGenerator:
         );
 
         -- Fetch relevant StatisticalVariable triples.
-        -- This list is based on the legacy Prophet PropsThatAreNotConstraintProps, 
-        -- but excluding constraintProperties, populationType, measuredProperty, measurementDenominator, measurementQualifier which are part of the vertical spec.
-        -- Also including domainIncludes/rangeIncludes due to some incorrectly modeled SVs. TODO: Clean these up.
-        -- Also including definition, linkedMemberOf, and linkedMember, which are generated properties.    
         CREATE OR REPLACE TEMP TABLE StatVarTriple AS (
           SELECT DISTINCT E.subject_id, E.predicate, E.object_id
           FROM EXTERNAL_QUERY("{conn_id}",
-            "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate NOT IN ('typeOf', 'dcid', 'provenance', 'isPublic', 'localCuratorLevelId', 'url', 'memberOf', 'name', 'label', 'description', 'descriptionUrl', 'alternateName', 'utteranceTemplate', 'source', 'footnote', 'keyString', 'resMCFFile', 'populationGroup', 'location', 'childhoodLocation', 'statType', 'censusACSTableId', 'measurementMethod', 'scalingFactor', 'unit', 'isNormalizable', 'denominatorForNormalization', 'domainIncludes', 'rangeIncludes', 'definition', 'linkedMemberOf', 'linkedMember')"
+            "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate IN UNNEST([{sv_predicates_sql}])"
           ) E
           JOIN StatVar SV ON SV.subject_id = E.subject_id
         );
@@ -252,7 +313,10 @@ class StatVarGroupGenerator:
             ON SV.populationType = VS.populationType AND IFNULL(ARRAY_LENGTH(VS.constraintProperties), 0) = 0
           CROSS JOIN UNNEST([
             STRUCT('memberOf' AS predicate, IF(IFNULL(ARRAY_LENGTH(VS.vertical), 0) = 0, ARRAY<STRING>[uncategorized_svg], VS.vertical) AS target_array),
-            STRUCT('linkedMemberOf' AS predicate, IF(IFNULL(ARRAY_LENGTH(VS.linkedVertical), 0) = 0, ARRAY<STRING>[root_svg, uncategorized_svg], VS.linkedVertical) AS target_array)
+            STRUCT(
+              'linkedMemberOf' AS predicate, 
+              IF(IFNULL(ARRAY_LENGTH(VS.linkedVertical), 0) = 0, ARRAY<STRING>[root_svg, uncategorized_svg], VS.linkedVertical) AS target_array
+            )
           ]) AS map
           CROSS JOIN UNNEST(map.target_array) AS v
         );
@@ -289,7 +353,9 @@ class StatVarGroupGenerator:
           SET iteration_count = iteration_count + 1;
           SET new_rows_found = FALSE;
           
-          CREATE OR REPLACE TEMP TABLE CurrentIterationOutput AS (
+          -- Insert new distinct rows into AllResults
+          INSERT INTO AllResults
+          WITH CurrentIterationOutput AS (
             SELECT
               -- Set node1 to node3 of previous iteration.
               node3 AS node1,
@@ -308,7 +374,8 @@ class StatVarGroupGenerator:
                   SELECT REPLACE(REPLACE(a, ' ', ''), '=', '-') 
                   FROM UNNEST(attributes) AS a WITH OFFSET AS a_idx WHERE a_idx != target_idx 
                 ), '_')),
-                IF(NOT (should_filter_basic_population_type AND IsBasicPopulationType(populationType)), CONCAT(namespace, 'g/', populationType), CAST(NULL AS STRING))
+                IF(NOT (should_filter_basic_population_type AND IsBasicPopulationType(populationType)), 
+                  CONCAT(namespace, 'g/', populationType), CAST(NULL AS STRING))
               ) AS node3,
               IF(ARRAY_LENGTH(attributes) > 1, 
                 CONCAT(FormatName(populationType), ' With ', ARRAY_TO_STRING(ARRAY( 
@@ -320,26 +387,27 @@ class StatVarGroupGenerator:
               ARRAY(SELECT cp FROM UNNEST(newConstraintProperties) AS cp WITH OFFSET AS cp_idx WHERE cp_idx != target_idx) AS newConstraintProperties,
               ARRAY(SELECT a FROM UNNEST(attributes) AS a WITH OFFSET AS a_idx WHERE a_idx != target_idx) AS attributes,
               iteration + 1 AS iteration
-            FROM InitialData AS T, UNNEST(attributes) AS attr WITH OFFSET AS target_idx
-            WHERE ARRAY_LENGTH(attributes) >= 1
-          );
-
-          -- Isolate new rows generated in this iteration. This is to help prune identical paths from a SV.
-          CREATE OR REPLACE TEMP TABLE NewDistinctRows AS (
-            SELECT DISTINCT C.node1, C.node2, C.node2name, C.node3, C.node3name, C.statvar, C.populationType,
-              C.constraintProperties, C.newConstraintProperties, C.attributes, C.iteration
+            FROM InitialData AS T, UNNEST(T.attributes) AS attr WITH OFFSET AS target_idx
+            WHERE T.iteration = iteration_count - 1
+              AND ARRAY_LENGTH(T.attributes) >= 1
+          ),
+          NewDistinctRows AS (
+            SELECT DISTINCT C.*
             FROM CurrentIterationOutput C
-            LEFT JOIN AllResults AR ON C.statvar = AR.statvar AND C.node1 IS NOT DISTINCT FROM AR.node1
-              AND C.node2 IS NOT DISTINCT FROM AR.node2 AND C.node3 IS NOT DISTINCT FROM AR.node3
+            LEFT JOIN AllResults AR ON C.statvar = AR.statvar 
+              AND C.node1 IS NOT DISTINCT FROM AR.node1
+              AND C.node2 IS NOT DISTINCT FROM AR.node2 
+              AND C.node3 IS NOT DISTINCT FROM AR.node3
             WHERE AR.statvar IS NULL
-          );
+          )
+          SELECT * FROM NewDistinctRows;
 
-          IF (SELECT COUNT(1) FROM NewDistinctRows) > 0 THEN
-            INSERT INTO AllResults SELECT * FROM NewDistinctRows;
+          -- If new rows were inserted, continue the loop and update InitialData
+          IF @@row_count > 0 THEN
             SET new_rows_found = TRUE;
+            INSERT INTO InitialData
+            SELECT * FROM AllResults WHERE iteration = iteration_count;
           END IF;
-
-          CREATE OR REPLACE TEMP TABLE InitialData AS (SELECT * FROM NewDistinctRows);
         END WHILE;
 
         -- ============================================================================
@@ -442,4 +510,12 @@ class StatVarGroupGenerator:
           ) AS (SELECT * FROM Edge);
         """
         
-        return self.executor.execute(query)
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ScalarQueryParameter("namespace", "STRING", self.namespace),
+                bigquery.ScalarQueryParameter("generated_provenance", "STRING", self.generated_provenance),
+                bigquery.ScalarQueryParameter("max_iterations", "INT64", self.max_iterations),
+                bigquery.ScalarQueryParameter("should_filter", "BOOL", self.should_filter_basic_population_type),
+            ]
+        )
+        return self.executor.execute(query, job_config=job_config)

--- a/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
@@ -139,7 +139,7 @@ class StatVarGroupGenerator:
         CREATE OR REPLACE TEMP TABLE SpecObjects AS (
           SELECT DISTINCT E.subject_id, E.predicate, E.object_id
           FROM EXTERNAL_QUERY(
-            "{conn_id}", 
+            "{conn_id}",
             '''
             SELECT subject_id, predicate, object_id 
             FROM Edge 
@@ -481,7 +481,7 @@ class StatVarGroupGenerator:
             spanner_options = '{{"table": "Edge"}}'
           ) AS (SELECT * FROM Edge);
         """
-        
+
         job_config = bigquery.QueryJobConfig(
             use_query_cache=False,
             query_parameters=[

--- a/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
@@ -6,7 +6,6 @@ from .bq_executor import BigQueryExecutor
 from .sql_utils import _escape_sql_literal
 
 class StatVarGroupGenerator:
-
     """Iteratively generates StatVarGroup nodes and hierarchical edges from MCF schemas."""
 
     def __init__(self,
@@ -16,8 +15,7 @@ class StatVarGroupGenerator:
                  namespace: Optional[str] = None,
                  generated_provenance: Optional[str] = None,
                  should_filter_basic_population_type: bool = True) -> None:
-        """
-        Initializes the StatVarGroupGenerator with executor and configuration parameters.
+        """Initializes the StatVarGroupGenerator with executor and configuration parameters.
 
         Args:
         ----
@@ -33,8 +31,8 @@ class StatVarGroupGenerator:
         self.max_iterations = max_iterations
         self.namespace = namespace if namespace is not None else ('dc/' if is_base_dc else 'custom/')
         self.generated_provenance = (
-          generated_provenance 
-          if generated_provenance is not None 
+          generated_provenance
+          if generated_provenance is not None
           else ('dc/base/GeneratedGraphs' if is_base_dc else 'GeneratedGraphs')
         )
         self.should_filter_basic_population_type = should_filter_basic_population_type
@@ -59,6 +57,7 @@ class StatVarGroupGenerator:
 
         dest_uri = _escape_sql_literal(self.executor.get_spanner_destination_uri())
         conn_id = _escape_sql_literal(self.executor.connection_id)
+        no_cache_config = bigquery.QueryJobConfig(use_query_cache=False)
 
         # =====================================================================
         # OPTIMIZATION: Two-Stage Fetch for StatVar Triples
@@ -68,40 +67,16 @@ class StatVarGroupGenerator:
             SELECT DISTINCT object_id
             FROM EXTERNAL_QUERY("{conn_id}", "SELECT object_id FROM Edge WHERE predicate = 'constraintProperties'")
         """
-        prep_sv_job = self.executor.execute(prep_query)
+        prep_sv_job = self.executor.execute(prep_query, job_config=no_cache_config)
         constraint_props = [row.object_id for row in prep_sv_job]
 
         # Combine base predicates with the dynamically discovered constraint properties
         needed_predicates = ['populationType', 'constraintProperties'] + constraint_props
-        
-        # Format into a SQL-safe string
+
+        # Format into a SQL-safe string for Spanner injection
         sv_predicates = [f"'{p.replace('\'', '')}'" for p in needed_predicates]
         sv_predicates_sql = ", ".join(sv_predicates)
         logging.info(f"Optimizing Spanner fetch. Pulling {len(sv_predicates)} specific predicates.")
-        # =====================================================================
-        # OPTIMIZATION 2: Two-Stage Fetch for Spec Nodes (Object IDs)
-        # =====================================================================
-        logging.info("Fetching distinct object_ids...")
-        prep_objects_query = f"""
-            SELECT DISTINCT object_id
-            FROM EXTERNAL_QUERY(
-                "{conn_id}", 
-                '''SELECT object_id 
-                   FROM Edge 
-                   WHERE predicate IN (
-                       'populationType', 
-                       'constraintProperties', 
-                       'vertical', 
-                       'dependentPropertyValue'
-                   )'''
-            )
-        """
-        prep_objs_job = self.executor.execute(prep_objects_query)
-        
-        # Format into a SQL-safe array string for Spanner injection
-        spec_objects = [f"'{row.object_id.replace('\'', '')}'" for row in prep_objs_job if row.object_id]
-        spec_objects_sql = ", ".join(spec_objects)
-        logging.info(f"Optimizing Spanner fetch. Pulling {len(spec_objects)} specific Spec objects.")
         # =====================================================================
 
         # Using rf-string to safely pass SQL regex backslashes while enabling variable injection
@@ -179,13 +154,10 @@ class StatVarGroupGenerator:
 
         -- Resolve StatVarGroup spec object_ids to values. 
         CREATE OR REPLACE TEMP TABLE SpecValues AS (
-          SELECT S.subject_id, S.predicate, N.value
-          FROM SpecObjects S
-          JOIN EXTERNAL_QUERY("{conn_id}", 
-            "SELECT subject_id, value FROM Node WHERE subject_id IN UNNEST([{spec_objects_sql}])"
-          ) N
-            ON S.object_id = N.subject_id
-          WHERE S.subject_id NOT IN (
+          SELECT subject_id, predicate, object_id AS value
+          FROM SpecObjects
+          -- NOTE: Excluding DPVs for now.
+          WHERE subject_id NOT IN (
             SELECT subject_id FROM SpecObjects WHERE predicate = 'dependentPropertyValue'
           )
         );
@@ -511,6 +483,7 @@ class StatVarGroupGenerator:
         """
         
         job_config = bigquery.QueryJobConfig(
+            use_query_cache=False,
             query_parameters=[
                 bigquery.ScalarQueryParameter("namespace", "STRING", self.namespace),
                 bigquery.ScalarQueryParameter("generated_provenance", "STRING", self.generated_provenance),

--- a/pipeline/workflow/ingestion-helper/utils/aggregation.py
+++ b/pipeline/workflow/ingestion-helper/utils/aggregation.py
@@ -19,6 +19,7 @@ from aggregation import BigQueryExecutor
 from aggregation import LinkedEdgeGenerator
 from aggregation import ProvenanceSummaryGenerator
 from aggregation import StatVarAggregator
+from aggregation import StatVarGroupGenerator
 from google.cloud import bigquery
 
 logging.getLogger().setLevel(logging.INFO)
@@ -46,6 +47,8 @@ class AggregationUtils:
         self.linked_edge_generator = LinkedEdgeGenerator(
             self.executor, is_base_dc)
         self.provenance_summary_generator = ProvenanceSummaryGenerator(
+            self.executor, is_base_dc)
+        self.stat_var_group_generator = StatVarGroupGenerator(
             self.executor, is_base_dc)
 
     def run_aggregation(self, import_list: List[Dict[str, Any]]) -> List[str]:
@@ -76,6 +79,7 @@ class AggregationUtils:
             jobs = []
             jobs.extend(self.linked_edge_generator.run_all(import_names))
             jobs.extend(self.provenance_summary_generator.run_all(import_names))
+            jobs.extend(self.stat_var_group_generator.run_all(import_names))
 
             job_ids = [job.job_id for job in jobs if job]
             logging.info(f"Submitted async aggregation jobs: {job_ids}")

--- a/pipeline/workflow/ingestion-helper/utils/aggregation_test.py
+++ b/pipeline/workflow/ingestion-helper/utils/aggregation_test.py
@@ -26,6 +26,7 @@ from utils.aggregation import AggregationUtils
 @patch('utils.aggregation.BigQueryExecutor')
 @patch('utils.aggregation.LinkedEdgeGenerator')
 @patch('utils.aggregation.ProvenanceSummaryGenerator')
+@patch('utils.aggregation.StatVarGroupGenerator')
 class TestAggregationUtils(unittest.TestCase):
 
     def test_run_aggregation(self, mock_prov_gen, mock_edge_gen, mock_executor):


### PR DESCRIPTION
Adds basic SVG generation with BQ federation

This assumes that the vertical spec exists in Spanner (since this runs as a post-ingestion step). Base DC specs have already been converted to MCF and ingested to Spanner (part of Schema import). However handling for DCP is still TBD, depending on what the plans are for the vertical spec json.

This is also just an initial iteration of the tree, but can (and should definitely) be iterated on to clean it up further. It has much simpler generation than legacy Prophet, but because of these changes could potentially be split by import to create partial trees since each partial tree is independent. Some of the key differences are
* No pruning
* No DPVs
* Does not include mprop for vertical matching - this causes some unexpected behavior in base DC that requires extra steps to clean. Instead vertical matching is done just by popType + cprops (which is effectively what ends up happening for base DC)
* Does not include should_include_under_listed_verticals_only
* No special handling of curated SVs (e.g. WHO variables, NAICS) -- some of this should likely be added as follow up

Tested via e2e test and also did a sample load of full base dc hierarchy into spanner (~10 mins). 

I also removed the separate query for generating linkedMemberOf triples since these are now handled as part of SVG generation. 