### PR TITLE
Optimize ingestion path for tfrecord files

### DIFF
--- a/pipeline/ingestion/metadata.json
+++ b/pipeline/ingestion/metadata.json
@@ -70,6 +70,13 @@
             "helpText": "Whether to skip transformation step.",
             "paramType": "TEXT",
             "isOptional": true
+        },
+        {
+            "name": "skipWait",
+            "label": "Skip Wait Operations",
+            "helpText": "Whether to skip wait operations between pipeline stages.",
+            "paramType": "TEXT",
+            "isOptional": true
         }
     ]
 }

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
@@ -25,6 +25,7 @@ import org.datacommons.ingestion.util.GraphReader;
 import org.datacommons.ingestion.util.GraphTransformer;
 import org.datacommons.ingestion.util.PipelineUtils;
 import org.datacommons.proto.Mcf.McfGraph;
+import org.datacommons.proto.Mcf.McfOptimizedGraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -149,20 +150,29 @@ public class GraphIngestionPipeline {
               "CreateEmptyEdgesWait-" + importName, Create.empty(TypeDescriptor.of(Void.class)));
     }
 
+    PipelineUtils.InputFormat format = PipelineUtils.resolveFormat(graphPath);
+    if (format == PipelineUtils.InputFormat.TFRECORD) {
+      TfRecordProcessingResult result =
+          processTfRecordImport(pipeline, importName, graphPath, isBaseDc);
+      writeToSpanner(
+          pipeline,
+          spannerClient,
+          importName,
+          result.nodeMutations,
+          result.edgeMutations,
+          result.uniqueSeries,
+          result.obsDataPoints,
+          deleteObsWait,
+          deleteEdgesWait,
+          options);
+      return;
+    }
+
     PCollection<McfGraph> graph;
-    switch (PipelineUtils.resolveFormat(graphPath)) {
-      case TFRECORD:
-        graph = PipelineUtils.readMcfGraph(importName, graphPath, pipeline);
-        break;
-      case JSONLD:
-        graph = PipelineUtils.readJsonLdFiles(importName, graphPath, pipeline);
-        break;
-      case MCF:
-        graph = PipelineUtils.readMcfFiles(importName, graphPath, pipeline);
-        break;
-      default:
-        throw new IllegalArgumentException(
-            "Invalid import config: missing graphPath or template/csv paths");
+    if (format == PipelineUtils.InputFormat.JSONLD) {
+      graph = PipelineUtils.readJsonLdFiles(importName, graphPath, pipeline);
+    } else {
+      graph = PipelineUtils.readMcfFiles(importName, graphPath, pipeline);
     }
 
     PCollectionTuple graphNodes = PipelineUtils.splitGraph(importName, graph);
@@ -210,21 +220,49 @@ public class GraphIngestionPipeline {
                 edgeCounter)
             .apply("ExtractEdgeMutations-" + importName, Values.create());
 
+    PCollection<TimeSeries> uniqueSeries =
+        GraphReader.extractUniqueSeries(observationNodes, importName, isBaseDc, timeSeriesCounter);
+    PCollection<Observation> obsDataPoints =
+        GraphReader.extractObservations(observationNodes, importName, isBaseDc, obsCounter);
+
+    writeToSpanner(
+        pipeline,
+        spannerClient,
+        importName,
+        nodeMutations,
+        edgeMutations,
+        uniqueSeries,
+        obsDataPoints,
+        deleteObsWait,
+        deleteEdgesWait,
+        options);
+  }
+
+  private static void writeToSpanner(
+      Pipeline pipeline,
+      SpannerClient spannerClient,
+      String importName,
+      PCollection<Mutation> nodeMutations,
+      PCollection<Mutation> edgeMutations,
+      PCollection<TimeSeries> uniqueSeries,
+      PCollection<Observation> obsDataPoints,
+      PCollection<Void> deleteObsWait,
+      PCollection<Void> deleteEdgesWait,
+      IngestionPipelineOptions options) {
     // Write Nodes
     SpannerWriteResult writtenNodes =
         spannerClient.writeMutations(pipeline, "WriteNodesToSpanner-" + importName, nodeMutations);
 
     // Write Edges (wait for Nodes write and Edges delete)
-    PCollection<Mutation> waitingEdges =
-        edgeMutations.apply(
-            "EdgesWaitOn-" + importName,
-            Wait.on(List.of(writtenNodes.getOutput(), deleteEdgesWait)));
+    PCollection<Mutation> waitingEdges = edgeMutations;
+    if (!options.getSkipWait()) {
+      waitingEdges =
+          edgeMutations.apply(
+              "EdgesWaitOn-" + importName,
+              Wait.on(List.of(writtenNodes.getOutput(), deleteEdgesWait)));
+    }
     spannerClient.writeMutations(pipeline, "WriteEdgesToSpanner-" + importName, waitingEdges);
 
-    // Path 1: TimeSeries (Metadata)
-    // Extract unique series keys and convert to metadata-only TimeSeries
-    PCollection<TimeSeries> uniqueSeries =
-        GraphReader.extractUniqueSeries(observationNodes, importName, isBaseDc, timeSeriesCounter);
     // Convert unique TimeSeries to TimeSeries mutations
     PCollection<Mutation> timeSeriesMutations =
         uniqueSeries.apply(
@@ -232,10 +270,6 @@ public class GraphIngestionPipeline {
             MapElements.into(TypeDescriptor.of(Mutation.class))
                 .via(spannerClient::toTimeSeriesMutation));
 
-    // Path 2: Observations (Data Points)
-    // Extract all individual data points as Observations (one per date/value)
-    PCollection<Observation> obsDataPoints =
-        GraphReader.extractObservations(observationNodes, importName, isBaseDc, obsCounter);
     // Convert Observations to Observation mutations
     PCollection<Mutation> observationMutations =
         obsDataPoints.apply(
@@ -244,17 +278,58 @@ public class GraphIngestionPipeline {
                 .via(spannerClient::toObservationMutation));
 
     // Write TimeSeries (wait for Obs delete)
-    PCollection<Mutation> waitingTimeSeries =
-        timeSeriesMutations.apply("TimeSeriesWaitOn-" + importName, Wait.on(deleteObsWait));
+    PCollection<Mutation> waitingTimeSeries = timeSeriesMutations;
+    if (!options.getSkipWait()) {
+      waitingTimeSeries =
+          timeSeriesMutations.apply("TimeSeriesWaitOn-" + importName, Wait.on(deleteObsWait));
+    }
     SpannerWriteResult writtenTimeSeries =
         spannerClient.writeMutations(
             pipeline, "WriteTimeSeriesToSpanner-" + importName, waitingTimeSeries);
 
     // Write Observations (wait for TimeSeries write)
-    PCollection<Mutation> waitingObservations =
-        observationMutations.apply(
-            "ObservationWaitOn-" + importName, Wait.on(writtenTimeSeries.getOutput()));
+    PCollection<Mutation> waitingObservations = observationMutations;
+    if (!options.getSkipWait()) {
+      waitingObservations =
+          observationMutations.apply(
+              "ObservationWaitOn-" + importName, Wait.on(writtenTimeSeries.getOutput()));
+    }
     spannerClient.writeMutations(
         pipeline, "WriteObservationsToSpanner-" + importName, waitingObservations);
+  }
+
+  private static class TfRecordProcessingResult {
+    final PCollection<TimeSeries> uniqueSeries;
+    final PCollection<Observation> obsDataPoints;
+    final PCollection<Mutation> nodeMutations;
+    final PCollection<Mutation> edgeMutations;
+
+    TfRecordProcessingResult(
+        PCollection<TimeSeries> uniqueSeries,
+        PCollection<Observation> obsDataPoints,
+        PCollection<Mutation> nodeMutations,
+        PCollection<Mutation> edgeMutations) {
+      this.uniqueSeries = uniqueSeries;
+      this.obsDataPoints = obsDataPoints;
+      this.nodeMutations = nodeMutations;
+      this.edgeMutations = edgeMutations;
+    }
+  }
+
+  private static TfRecordProcessingResult processTfRecordImport(
+      Pipeline pipeline, String importName, String graphPath, boolean isBaseDc) {
+    PCollection<McfOptimizedGraph> optGraph =
+        PipelineUtils.readOptimizedMcfGraph(importName, graphPath, pipeline);
+    PCollection<TimeSeries> uniqueSeries =
+        GraphReader.extractSeriesFromOptimized(optGraph, importName, isBaseDc, timeSeriesCounter);
+    PCollection<Observation> obsDataPoints =
+        GraphReader.extractObservationsFromOptimized(optGraph, importName, isBaseDc, obsCounter);
+    PCollection<Mutation> nodeMutations =
+        pipeline.apply(
+            "EmptyNodeMutations-" + importName, Create.empty(TypeDescriptor.of(Mutation.class)));
+    PCollection<Mutation> edgeMutations =
+        pipeline.apply(
+            "EmptyEdgeMutations-" + importName, Create.empty(TypeDescriptor.of(Mutation.class)));
+    return new TfRecordProcessingResult(uniqueSeries, obsDataPoints, nodeMutations, edgeMutations);
   }
 }

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
@@ -88,4 +88,10 @@ public interface IngestionPipelineOptions extends PipelineOptions {
   boolean getSkipTransformation();
 
   void setSkipTransformation(boolean skipTransformation);
+
+  @Description("Whether to skip wait operations between pipeline stages.")
+  @Default.Boolean(false)
+  boolean getSkipWait();
+
+  void setSkipWait(boolean skipWait);
 }

--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphReader.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphReader.java
@@ -25,6 +25,7 @@ import org.datacommons.ingestion.spanner.SpannerClient;
 import org.datacommons.proto.Mcf.McfGraph;
 import org.datacommons.proto.Mcf.McfGraph.PropertyValues;
 import org.datacommons.proto.Mcf.McfGraph.TypedValue;
+import org.datacommons.proto.Mcf.McfOptimizedGraph;
 import org.datacommons.proto.Mcf.McfStatVarObsSeries;
 import org.datacommons.proto.Mcf.McfStatVarObsSeries.StatVarObs;
 import org.datacommons.proto.Mcf.ValueType;
@@ -374,6 +375,46 @@ public class GraphReader implements Serializable {
         .isDcAggregate(isDcAggregate)
         .provenanceUrl(provenanceUrl)
         .build();
+  }
+
+  public static PCollection<TimeSeries> extractSeriesFromOptimized(
+      PCollection<McfOptimizedGraph> graph,
+      String importName,
+      boolean isBaseDc,
+      Counter tsCounter) {
+    return graph.apply(
+        "SeriesToTimeSeriesObservations-" + importName,
+        ParDo.of(
+            new DoFn<McfOptimizedGraph, TimeSeries>() {
+              @ProcessElement
+              public void processElement(
+                  @Element McfOptimizedGraph g, OutputReceiver<TimeSeries> receiver) {
+                receiver.output(toTimeSeries(g.getSvObsSeries().getKey(), importName, isBaseDc));
+                tsCounter.inc();
+              }
+            }));
+  }
+
+  public static PCollection<Observation> extractObservationsFromOptimized(
+      PCollection<McfOptimizedGraph> graph,
+      String importName,
+      boolean isBaseDc,
+      Counter obsCounter) {
+    return graph.apply(
+        "ExtractObservationDataPoints-" + importName,
+        ParDo.of(
+            new DoFn<McfOptimizedGraph, Observation>() {
+              @ProcessElement
+              public void processElement(
+                  @Element McfOptimizedGraph g, OutputReceiver<Observation> receiver) {
+                McfStatVarObsSeries svoSeries = g.getSvObsSeries();
+                TimeSeriesKey seriesKey = toTimeSeriesKey(svoSeries.getKey(), importName);
+                for (StatVarObs obs : svoSeries.getSvObsListList()) {
+                  receiver.output(toObservation(seriesKey, obs));
+                  obsCounter.inc();
+                }
+              }
+            }));
   }
 
   static TimeSeries toTimeSeries(McfStatVarObsSeries.Key key, String importName, boolean isBaseDc) {

--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/PipelineUtils.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/PipelineUtils.java
@@ -420,8 +420,9 @@ public class PipelineUtils {
    * @return The corresponding key.
    */
   public static String generateObjectValueKey(String input) {
-    String hash = Encode.generateSha256(input);
-    String prefix = input.substring(0, Math.min(input.length(), OBJECT_VALUE_PREFIX));
+    String trimmedInput = input.trim();
+    String hash = Encode.generateSha256(trimmedInput);
+    String prefix = trimmedInput.substring(0, Math.min(trimmedInput.length(), OBJECT_VALUE_PREFIX));
     return prefix + ":" + hash;
   }
 

--- a/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphReaderTest.java
+++ b/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphReaderTest.java
@@ -134,7 +134,7 @@ public class GraphReaderTest {
                 .value("Node Zero")
                 .build(),
             Node.builder()
-                .subjectId("{   \"type\": \"Pol:G8RZr2tV3+cSSDVRj8Q4KnMpxDhZyZr438T3Fvq1Zkk=")
+                .subjectId("{   \"type\": \"Pol:EvbccRWWGibzhA4ntdF1bboIUsn4ThUiAZe3TV4hmB8=")
                 .bytes(
                     ByteArray.copyFrom(
                         PipelineUtils.compressString(
@@ -279,7 +279,7 @@ public class GraphReaderTest {
             Edge.builder()
                 .subjectId("dcid_subject")
                 .predicate("geoJsonCoordinates")
-                .objectId("{   \"type\": \"Pol:G8RZr2tV3+cSSDVRj8Q4KnMpxDhZyZr438T3Fvq1Zkk=")
+                .objectId("{   \"type\": \"Pol:EvbccRWWGibzhA4ntdF1bboIUsn4ThUiAZe3TV4hmB8=")
                 .provenance("dc/base/Test")
                 .build(),
             Edge.builder()


### PR DESCRIPTION
Special ingestion logic for tfrecord to create timeseries from tfrecord and skipping dedup. Also, added an option to skip wait operations between ingestion steps. This is used for the initial load of the data from the legacy pipelines into Spanner graph.