### PR TITLE
Add linkedMemberOf query back until SVG generation can support curated hierarchies

### DIFF
--- a/pipeline/workflow/ingestion-helper/aggregation/e2e_tests/aggregation_e2e_test.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/e2e_tests/aggregation_e2e_test.py
@@ -237,6 +237,44 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
             self.assertEqual(tuple(results[2]), ('geoId/06075', 'geoId/06', expected_provenance))
 
 
+    def test_linked_member_of(self):
+        """Tests run_linked_member_of.
+        
+        Hierarchy: Instance_A -> memberOf -> Class_B -> specializationOf -> Class_C
+        """
+        import_name = 'Schema_Import_Test'
+        
+        # 1. Setup mock data
+        self.add_node('Instance_A', 'Instance A', types=['Class_B'])
+        self.add_node('Class_B', 'Class B', types=['Class'])
+        self.add_node('Class_C', 'Class C', types=['Class'])
+        
+        self.add_edge('Instance_A', 'memberOf', 'Class_B', import_name)
+        self.add_edge('Class_B', 'specializationOf', 'Class_C', import_name)
+        
+        self.flush_to_spanner()
+        
+        # 2. Run generator
+        generator = self.get_generator()
+        job = generator.run_linked_member_of([import_name])
+        self.assertIsNotNone(job)
+        
+        # 3. Verify results
+        with self.database.snapshot() as snapshot:
+            query = """
+                SELECT subject_id, object_id, provenance 
+                FROM Edge 
+                WHERE predicate = 'linkedMemberOf'
+                ORDER BY subject_id, object_id
+            """
+            results = list(snapshot.execute_sql(query))
+            
+            expected_provenance = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+            self.assertEqual(len(results), 2)
+            self.assertEqual(tuple(results[0]), ('Instance_A', 'Class_B', expected_provenance))
+            self.assertEqual(tuple(results[1]), ('Instance_A', 'Class_C', expected_provenance))
+    
+    
     def test_linked_member(self):
         """Tests run_linked_member.
         

--- a/pipeline/workflow/ingestion-helper/aggregation/linked_edge_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/linked_edge_generator.py
@@ -46,7 +46,7 @@ class LinkedEdgeGenerator:
             self.run_linked_member(import_names)
         ]
         return [job for job in jobs if job]
-    
+
     def run_linked_member_of(
             self,
             import_names: List[str] = None) -> Optional[bigquery.job.QueryJob]:

--- a/pipeline/workflow/ingestion-helper/aggregation/linked_edge_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/linked_edge_generator.py
@@ -42,9 +42,103 @@ class LinkedEdgeGenerator:
 
         jobs = [
             self.run_linked_contained_in_place(import_names),
+            self.run_linked_member_of(import_names),
             self.run_linked_member(import_names)
         ]
         return [job for job in jobs if job]
+    
+    def run_linked_member_of(
+            self,
+            import_names: List[str] = None) -> Optional[bigquery.job.QueryJob]:
+        """Expands membership hierarchies using memberOf and specializationOf."""
+        if not import_names:
+            return None
+
+        dest = self.executor.get_spanner_destination_uri()
+        safe_names = [_escape_sql_literal(name) for name in import_names]
+        prefix = "dc/base/" if self.is_base_dc else ""
+        provenances = [f"'{prefix}{name}'" for name in safe_names]
+        provenance_filter = f" AND provenance IN ({', '.join(provenances)})"
+        gen_graphs_prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+
+        query = f"""  # nosec
+        -- Pull base edges needed for memberOf aggregation
+        CREATE OR REPLACE TEMPORARY TABLE `temp_base_member_of` AS
+        SELECT * FROM EXTERNAL_QUERY("{self.executor.connection_id}", 
+          "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate IN ('memberOf', 'specializationOf'){provenance_filter}");
+
+        -- Pull existing generated edges to filter them out later
+        CREATE OR REPLACE TEMPORARY TABLE `temp_existing_linked_member_of` AS
+        SELECT * FROM EXTERNAL_QUERY("{self.executor.connection_id}", 
+          "SELECT subject_id, predicate, object_id, provenance FROM Edge WHERE predicate = 'linkedMemberOf'");
+
+        CREATE OR REPLACE TEMPORARY TABLE `temp_hierarchy` AS
+        SELECT DISTINCT subject_id, predicate, object_id
+        FROM `temp_base_member_of`;
+
+        EXPORT DATA
+          OPTIONS( uri="{dest}",
+            format='CLOUD_SPANNER',
+            spanner_options = '{{"table": "Edge"}}' ) AS
+        WITH RECURSIVE Ancestors AS (
+          SELECT
+            subject_id,
+            object_id AS ancestor,
+            1 AS level
+          FROM
+            temp_hierarchy
+          WHERE
+            predicate = 'memberOf'
+          UNION ALL
+
+          SELECT
+            a.subject_id,
+            t.object_id AS ancestor,
+            a.level + 1
+          FROM
+            Ancestors AS a
+          JOIN
+            temp_hierarchy AS t
+            ON a.ancestor = t.subject_id
+          WHERE
+            a.level <= 20 -- Limit to 20 levels
+            AND t.predicate = 'specializationOf'
+        ),
+        NewEdges AS (
+          SELECT DISTINCT
+            subject_id,
+            'linkedMemberOf' as predicate,
+            ancestor as object_id,
+            '{gen_graphs_prov}' as provenance
+          FROM
+            Ancestors
+        ),
+        FilteredEdges AS (
+          SELECT
+            subject_id,
+            predicate,
+            object_id,
+            provenance
+          FROM
+            NewEdges n
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM `temp_existing_linked_member_of` e
+            WHERE n.subject_id = e.subject_id
+              AND n.predicate = e.predicate
+              AND n.object_id = e.object_id
+              AND n.provenance = e.provenance
+          )
+        )
+        SELECT
+          subject_id,
+          predicate,
+          object_id,
+          provenance
+        FROM
+          FilteredEdges
+        """
+        return self.executor.execute(query)
 
     def run_linked_contained_in_place(
             self,

--- a/pipeline/workflow/ingestion-helper/utils/aggregation.py
+++ b/pipeline/workflow/ingestion-helper/utils/aggregation.py
@@ -48,8 +48,6 @@ class AggregationUtils:
             self.executor, is_base_dc)
         self.provenance_summary_generator = ProvenanceSummaryGenerator(
             self.executor, is_base_dc)
-        self.stat_var_group_generator = StatVarGroupGenerator(
-            self.executor, is_base_dc)
 
     def run_aggregation(self, import_list: List[Dict[str, Any]]) -> List[str]:
         """


### PR DESCRIPTION
This was removed in https://github.com/datacommonsorg/import/pull/553/changes

however this means that curated hierarchies won't get the linkedMemberOf edges generated.

Since DCP users like UN specify a custom hierarchy, adding this back until we can reliably merge custom + generated hierarchies. 

Also disable svg generation in the mean time