### PR TITLE
Fix: Add isBaseDc to Flex Template metadata parameters

### DIFF
--- a/pipeline/ingestion/metadata.json
+++ b/pipeline/ingestion/metadata.json
@@ -56,6 +56,13 @@
             "helpText": "Spanner TimeSeries table name",
             "paramType": "TEXT",
             "isOptional": true
+        },
+        {
+            "name": "isBaseDc",
+            "label": "Is Base Data Commons",
+            "helpText": "Whether this is a base Data Commons ingestion run.",
+            "paramType": "TEXT",
+            "isOptional": true
         }
     ]
 }


### PR DESCRIPTION
The 'isBaseDc' parameter is supported by the Java ingestion pipeline but was missing from the Flex Template 'metadata.json'. This caused the Dataflow API to reject the parameter as unrecognized when launching the template from the Cloud Workflow. (https://github.com/datacommonsorg/datacommons/pull/135)

This change adds 'isBaseDc' to the allowed parameters in 'metadata.json' so that it can be passed at runtime to control whether 'dc/base/' is prepended to provenances.