### PR TITLE
fix: Fix constraint property inference for multi-entity meta-properties

### DIFF
--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphTransformer.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphTransformer.java
@@ -37,7 +37,9 @@ public class GraphTransformer extends DoFn<McfGraph, McfGraph> {
           "measurementQualifier",
           "measurementDenominator",
           "measurementMethod",
-          "constraintProperties");
+          "constraintProperties",
+          "observationProperty",
+          "entityMapping");
 
   @ProcessElement
   public void processElement(@Element McfGraph inputGraph, OutputReceiver<McfGraph> receiver) {

--- a/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphTransformerTest.java
+++ b/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphTransformerTest.java
@@ -636,6 +636,141 @@ public class GraphTransformerTest {
   }
 
   @Test
+  public void testStatVarTransformationWithObservationPropertyAndEntityMapping() {
+    McfGraph inputGraph =
+        McfGraph.newBuilder()
+            .putNodes(
+                "FinancialAid",
+                PropertyValues.newBuilder()
+                    .putPvs(
+                        "typeOf",
+                        Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setValue("dcid:StatisticalVariable")
+                                    .setType(ValueType.RESOLVED_REF))
+                            .build())
+                    .putPvs(
+                        "populationType",
+                        Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setValue("dcid:FinancialTransaction")
+                                    .setType(ValueType.RESOLVED_REF))
+                            .build())
+                    .putPvs(
+                        "measuredProperty",
+                        Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setValue("dcid:amount")
+                                    .setType(ValueType.RESOLVED_REF))
+                            .build())
+                    .putPvs(
+                        "observationProperty",
+                        Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setValue("dcid:destinationCountry")
+                                    .setType(ValueType.RESOLVED_REF))
+                            .build())
+                    .putPvs(
+                        "entityMapping",
+                        Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setValue("dcid:someMapping")
+                                    .setType(ValueType.RESOLVED_REF))
+                            .build())
+                    .putPvs(
+                        "someActualConstraint",
+                        Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setValue("dcid:someValue")
+                                    .setType(ValueType.RESOLVED_REF))
+                            .build())
+                    .build())
+            .build();
+
+    McfGraph expectedGraph =
+        McfGraph.newBuilder()
+            .putNodes(
+                "FinancialAid",
+                PropertyValues.newBuilder()
+                    .putPvs(
+                        "typeOf",
+                        Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setValue("dcid:StatisticalVariable")
+                                    .setType(ValueType.RESOLVED_REF))
+                            .build())
+                    .putPvs(
+                        "populationType",
+                        Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setValue("dcid:FinancialTransaction")
+                                    .setType(ValueType.RESOLVED_REF))
+                            .build())
+                    .putPvs(
+                        "measuredProperty",
+                        Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setValue("dcid:amount")
+                                    .setType(ValueType.RESOLVED_REF))
+                            .build())
+                    .putPvs(
+                        "observationProperty",
+                        Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setValue("dcid:destinationCountry")
+                                    .setType(ValueType.RESOLVED_REF))
+                            .build())
+                    .putPvs(
+                        "entityMapping",
+                        Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setValue("dcid:someMapping")
+                                    .setType(ValueType.RESOLVED_REF))
+                            .build())
+                    .putPvs(
+                        "someActualConstraint",
+                        Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setValue("dcid:someValue")
+                                    .setType(ValueType.RESOLVED_REF))
+                            .build())
+                    .putPvs(
+                        "constraintProperties",
+                        Values.newBuilder()
+                            .addTypedValues(
+                                TypedValue.newBuilder()
+                                    .setValue("someActualConstraint")
+                                    .setType(ValueType.RESOLVED_REF))
+                            .build())
+                    .build())
+            .build();
+
+    PCollection<McfGraph> output =
+        p.apply(Create.of(inputGraph)).apply(ParDo.of(new GraphTransformer()));
+
+    PCollection<McfGraph> mergedOutput =
+        output.apply(
+            org.apache.beam.sdk.transforms.Combine.globally(
+                    new PipelineUtilsTest.MergeMcfGraphsCombineFn())
+                .withoutDefaults());
+
+    PAssert.that(mergedOutput).containsInAnyOrder(expectedGraph);
+    p.run().waitUntilFinish();
+  }
+
+  @Test
   public void testQuantityTransformationNoOverwrite() {
     McfGraph inputGraph =
         McfGraph.newBuilder()

--- a/simple/stats/schema_constants.py
+++ b/simple/stats/schema_constants.py
@@ -23,7 +23,8 @@ SV_HIERARCHY_PROPS_BLOCKLIST: set[str] = {
     "searchDescription", "source", "footnote", "isNormalizable",
     "denominatorForNormalization", "measuredProperty", "measurementMethod",
     "measurementDenominator", "measurementQualifier", "scalingFactor", "unit",
-    "statType", "censusACSTableId", "includedIn"
+    "statType", "censusACSTableId", "includedIn", "observationProperty",
+    "entityMapping"
 }
 
 PREDICATE_TYPE_OF = "typeOf"

--- a/simple/tests/stats/stat_var_hierarchy_generator_test.py
+++ b/simple/tests/stats/stat_var_hierarchy_generator_test.py
@@ -147,6 +147,8 @@ class TestStatVarHierarchyGenerator(unittest.TestCase):
         Triple("sv1", "gender", "Female", ""),
         Triple("sv1", "measuredProperty", "count", ""),
         Triple("sv1", "searchDescription", "", "SV1 search description"),
+        Triple("sv1", "observationProperty", "destinationCountry", ""),
+        Triple("sv1", "entityMapping", "someMapping", ""),
         Triple("non_sv1", "typeOf", "Person", ""),
         Triple("non_sv1", "gender", "Male", ""),
         Triple("non_sv1", "race", "AmericanIndianOrAlaskaNative", ""),

--- a/util/src/main/java/org/datacommons/util/Vocabulary.java
+++ b/util/src/main/java/org/datacommons/util/Vocabulary.java
@@ -120,6 +120,8 @@ public final class Vocabulary {
   public static final String VARIABLE_MEASURED = "variableMeasured";
   public static final String STAT_TYPE = "statType";
   public static final String CONSTRAINT_PROPS = "constraintProperties";
+  public static final String OBSERVATION_PROPERTY = "observationProperty";
+  public static final String ENTITY_MAPPING = "entityMapping";
   public static final String MEASUREMENT_DENOMINATOR = "measurementDenominator";
   public static final String MEASUREMENT_QUALIFIER = "measurementQualifier";
   public static final String SCALING_FACTOR = "scalingFactor";
@@ -254,6 +256,8 @@ public final class Vocabulary {
           POPULATION_GROUP,
           LOCATION,
           CONSTRAINT_PROPS,
+          OBSERVATION_PROPERTY,
+          ENTITY_MAPPING,
           MEASURED_PROP,
           STAT_TYPE,
           MEASUREMENT_DENOMINATOR,

--- a/util/src/main/java/org/datacommons/util/Vocabulary.java
+++ b/util/src/main/java/org/datacommons/util/Vocabulary.java
@@ -317,7 +317,9 @@ public final class Vocabulary {
         || prop.equals(MEASUREMENT_DENOMINATOR)
         || prop.equals(MEASUREMENT_QUALIFIER)
         || prop.equals(STAT_TYPE)
-        || prop.equals(UNIT);
+        || prop.equals(UNIT)
+        || prop.equals(OBSERVATION_PROPERTY)
+        || prop.equals(ENTITY_MAPPING);
   }
 
   public static boolean isGlobalReference(String val) {

--- a/util/src/main/java/org/datacommons/util/Vocabulary.java
+++ b/util/src/main/java/org/datacommons/util/Vocabulary.java
@@ -318,8 +318,7 @@ public final class Vocabulary {
         || prop.equals(MEASUREMENT_QUALIFIER)
         || prop.equals(STAT_TYPE)
         || prop.equals(UNIT)
-        || prop.equals(OBSERVATION_PROPERTY)
-        || prop.equals(ENTITY_MAPPING);
+        || prop.equals(OBSERVATION_PROPERTY);
   }
 
   public static boolean isGlobalReference(String val) {

--- a/util/src/test/java/org/datacommons/util/McfMutatorTest.java
+++ b/util/src/test/java/org/datacommons/util/McfMutatorTest.java
@@ -105,4 +105,31 @@ public class McfMutatorTest {
         McfMutator.mutate(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx());
     assertEquals(McfUtil.serializeMcfGraph(got, true), mcf);
   }
+
+  @Test
+  public void testMultiEntityProperties() throws IOException {
+    String mcf =
+        "Node: dcid:FinancialAid\n"
+            + "typeOf: schema:StatisticalVariable\n"
+            + "populationType: dcs:FinancialTransaction\n"
+            + "measuredProperty: dcs:amount\n"
+            + "observationProperty: dcs:destinationCountry\n"
+            + "entityMapping: dcs:someMapping\n"
+            + "someActualConstraint: dcs:someValue\n";
+    Mcf.McfGraph got =
+        McfMutator.mutate(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx());
+
+    String want =
+        "Node: dcid:FinancialAid\n"
+            + "constraintProperties: dcid:someActualConstraint\n"
+            + "dcid: \"FinancialAid\"\n"
+            + "entityMapping: dcid:someMapping\n"
+            + "measuredProperty: dcid:amount\n"
+            + "observationProperty: dcid:destinationCountry\n"
+            + "populationType: dcid:FinancialTransaction\n"
+            + "someActualConstraint: dcid:someValue\n"
+            + "typeOf: dcid:StatisticalVariable\n"
+            + "\n";
+    assertEquals(McfUtil.serializeMcfGraph(got, true), want);
+  }
 }

--- a/util/src/test/java/org/datacommons/util/McfParserTest.java
+++ b/util/src/test/java/org/datacommons/util/McfParserTest.java
@@ -204,5 +204,23 @@ public class McfParserTest {
     actual = parseTypedValue(McfType.INSTANCE_MCF, false, regProp, "testVal", null);
     assertNotNull(actual);
     assertEquals(expected.build(), actual.build());
+
+    // Verify observationProperty is parsed as RESOLVED_REF (reference property)
+    expected.clear();
+    expected.setValue("destinationCountry");
+    expected.setType(ValueType.RESOLVED_REF);
+    actual =
+        parseTypedValue(
+            McfType.INSTANCE_MCF, false, "observationProperty", "destinationCountry", null);
+    assertNotNull(actual);
+    assertEquals(expected.build(), actual.build());
+
+    // Verify entityMapping is parsed as TEXT (non-reference property)
+    expected.clear();
+    expected.setValue("origin=entity1");
+    expected.setType(ValueType.TEXT);
+    actual = parseTypedValue(McfType.INSTANCE_MCF, false, "entityMapping", "origin=entity1", null);
+    assertNotNull(actual);
+    assertEquals(expected.build(), actual.build());
   }
 }

--- a/util/src/test/java/org/datacommons/util/McfResolverTest.java
+++ b/util/src/test/java/org/datacommons/util/McfResolverTest.java
@@ -120,6 +120,40 @@ public class McfResolverTest {
     assertTrue(!McfUtil.getPropVal(observationNode, Vocabulary.DCID).isEmpty());
   }
 
+  @Test
+  public void multiEntityPropertiesReferenceResolution() throws IOException {
+    Debug.Log.Builder log = Debug.Log.newBuilder();
+    LogWrapper logCtx = new LogWrapper(log, Paths.get("."));
+    McfResolver resolver =
+        new McfResolver(
+            TestUtil.graphFromMcf(
+                String.join(
+                    "\n",
+                    "Node: MyCustomProp",
+                    "typeOf: schema:Property",
+                    "dcid: \"customDestinationCountry\"",
+                    "",
+                    "Node: FinancialAid",
+                    "typeOf: schema:StatisticalVariable",
+                    "dcid: \"FinancialAid\"",
+                    "populationType: dcs:FinancialTransaction",
+                    "measuredProperty: dcs:amount",
+                    "observationProperty: l:MyCustomProp",
+                    "")),
+            true,
+            null,
+            logCtx);
+
+    resolver.resolve();
+
+    assertEquals(0, resolver.failedGraph().getNodesCount());
+
+    var resolvedGraph = resolver.resolvedGraph();
+    var svNode = resolvedGraph.getNodesOrThrow("FinancialAid");
+    assertEquals(
+        "customDestinationCountry", McfUtil.getPropVal(svNode, Vocabulary.OBSERVATION_PROPERTY));
+  }
+
   private String getFile(String name) throws IOException {
     return this.getClass().getResource(name).getPath();
   }


### PR DESCRIPTION
Add 'observationProperty' and 'entityMapping' to the blocklist of non-constraint properties in both Java and Python import pipelines. This prevents the generator from treating these meta-properties as actual constraints on StatisticalVariables, which was causing the creation of incorrect StatVarGroups and linkedMemberOf edges.