### PR TITLE
Set import type to observations and input file format to variable per row by default

### DIFF
--- a/simple/stats/config.py
+++ b/simple/stats/config.py
@@ -140,10 +140,10 @@ class Config:
       )
     return ImportType(import_type_str)
 
-  def format(self, input_file: File) -> ImportType | None:
+  def format(self, input_file: File) -> InputFileFormat:
     format_str = self._per_file_config(input_file).get(_FORMAT_FIELD)
     if not format_str:
-      return None
+      return InputFileFormat.VARIABLE_PER_ROW
     if format_str not in iter(InputFileFormat):
       raise ValueError(f"Unsupported format: {format_str} ({input_file})")
     return InputFileFormat(format_str)

--- a/simple/tests/stats/config_test.py
+++ b/simple/tests/stats/config_test.py
@@ -306,7 +306,8 @@ class TestConfig(unittest.TestCase):
 
   def test_input_file_format(self):
     config = Config({})
-    self.assertEqual(config.format(self.make_file("foo.csv")), None, "empty")
+    self.assertEqual(config.format(self.make_file("foo.csv")),
+                     InputFileFormat.VARIABLE_PER_ROW, "empty")
 
     config = Config({"inputFiles": {"foo.csv": {"format": "variablePerRow"}}})
     self.assertEqual(config.format(self.make_file("foo.csv")),

--- a/simple/tests/stats/runner_test.py
+++ b/simple/tests/stats/runner_test.py
@@ -428,20 +428,24 @@ class TestRunner(unittest.TestCase):
       oecd_config = {
           "importName":
               "oecd",
-          "inputFiles": [{
-              "pattern": "data.csv",
-              "entityType": "Country",
-              "provenance": "dcid:oecd"
-          }, {
-              "pattern": "*.mcf",
-              "provenance": "dcid:oecd"
-          }]
+          "inputFiles": [
+              {
+                  "pattern": "data.csv",
+                  "entityType": "Country",
+                  "provenance": "dcid:oecd"
+                  # Assume no format = variable per row
+              },
+              {
+                  "pattern": "*.mcf",
+                  "provenance": "dcid:oecd"
+              }
+          ]
       }
       with open(os.path.join(oecd_dir, "config.json"), "w") as f:
         json.dump(oecd_config, f)
 
-      # OECD data.csv (entity, date, variable)
-      oecd_data = "entity,date,Average_Age_Frog\nUSA,2020,5.5\n"
+      # OECD data.csv (entity, date, variable, value)
+      oecd_data = "entity,date,variable,value\nUSA,2020,Average_Age_Frog,5.5\n"
       with open(os.path.join(oecd_dir, "data.csv"), "w") as f:
         f.write(oecd_data)
 
@@ -460,19 +464,23 @@ class TestRunner(unittest.TestCase):
       ilo_config = {
           "importName":
               "ilo",
-          "inputFiles": [{
-              "pattern": "data.csv",
-              "entityType": "Country",
-              "provenance": "dcid:ilo"
-          }, {
-              "pattern": "*.mcf",
-              "provenance": "dcid:ilo"
-          }]
+          "inputFiles": [
+              {
+                  "pattern": "data.csv",
+                  "entityType": "Country",
+                  "provenance": "dcid:ilo"
+                  # Assume no format = variable per row
+              },
+              {
+                  "pattern": "*.mcf",
+                  "provenance": "dcid:ilo"
+              }
+          ]
       }
       with open(os.path.join(ilo_dir, "config.json"), "w") as f:
         json.dump(ilo_config, f)
 
-      ilo_data = "entity,date,Count_Frog_Green\nUSA,2020,40\n"
+      ilo_data = "entity,date,variable,value\nUSA,2020,Count_Frog_Green,40\n"
       with open(os.path.join(ilo_dir, "data.csv"), "w") as f:
         f.write(ilo_data)
 


### PR DESCRIPTION
This is a stopgap to prevent hard-to-debug failures caused by forgetting to specify the format as variable per row. Eventually, all of the variable per column and entities and events code should be removed.