### PR TITLE
Align StatVar multi-entity properties: use observationProperties and remove entityMapping

### DIFF
--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphTransformer.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphTransformer.java
@@ -38,7 +38,7 @@ public class GraphTransformer extends DoFn<McfGraph, McfGraph> {
           "measurementDenominator",
           "measurementMethod",
           "constraintProperties",
-          "observationProperty",
+          "observationProperties",
           "entityMapping");
 
   @ProcessElement

--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphTransformer.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphTransformer.java
@@ -38,8 +38,7 @@ public class GraphTransformer extends DoFn<McfGraph, McfGraph> {
           "measurementDenominator",
           "measurementMethod",
           "constraintProperties",
-          "observationProperties",
-          "entityMapping");
+          "observationProperties");
 
   @ProcessElement
   public void processElement(@Element McfGraph inputGraph, OutputReceiver<McfGraph> receiver) {

--- a/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphTransformerTest.java
+++ b/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphTransformerTest.java
@@ -636,7 +636,7 @@ public class GraphTransformerTest {
   }
 
   @Test
-  public void testStatVarTransformationWithObservationPropertiesAndEntityMapping() {
+  public void testStatVarTransformationWithObservationProperties() {
     McfGraph inputGraph =
         McfGraph.newBuilder()
             .putNodes(
@@ -672,14 +672,6 @@ public class GraphTransformerTest {
                             .addTypedValues(
                                 TypedValue.newBuilder()
                                     .setValue("dcid:destinationCountry")
-                                    .setType(ValueType.RESOLVED_REF))
-                            .build())
-                    .putPvs(
-                        "entityMapping",
-                        Values.newBuilder()
-                            .addTypedValues(
-                                TypedValue.newBuilder()
-                                    .setValue("dcid:someMapping")
                                     .setType(ValueType.RESOLVED_REF))
                             .build())
                     .putPvs(
@@ -728,14 +720,6 @@ public class GraphTransformerTest {
                             .addTypedValues(
                                 TypedValue.newBuilder()
                                     .setValue("dcid:destinationCountry")
-                                    .setType(ValueType.RESOLVED_REF))
-                            .build())
-                    .putPvs(
-                        "entityMapping",
-                        Values.newBuilder()
-                            .addTypedValues(
-                                TypedValue.newBuilder()
-                                    .setValue("dcid:someMapping")
                                     .setType(ValueType.RESOLVED_REF))
                             .build())
                     .putPvs(

--- a/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphTransformerTest.java
+++ b/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphTransformerTest.java
@@ -636,7 +636,7 @@ public class GraphTransformerTest {
   }
 
   @Test
-  public void testStatVarTransformationWithObservationPropertyAndEntityMapping() {
+  public void testStatVarTransformationWithObservationPropertiesAndEntityMapping() {
     McfGraph inputGraph =
         McfGraph.newBuilder()
             .putNodes(
@@ -667,7 +667,7 @@ public class GraphTransformerTest {
                                     .setType(ValueType.RESOLVED_REF))
                             .build())
                     .putPvs(
-                        "observationProperty",
+                        "observationProperties",
                         Values.newBuilder()
                             .addTypedValues(
                                 TypedValue.newBuilder()
@@ -723,7 +723,7 @@ public class GraphTransformerTest {
                                     .setType(ValueType.RESOLVED_REF))
                             .build())
                     .putPvs(
-                        "observationProperty",
+                        "observationProperties",
                         Values.newBuilder()
                             .addTypedValues(
                                 TypedValue.newBuilder()

--- a/simple/stats/jsonld_exporter.py
+++ b/simple/stats/jsonld_exporter.py
@@ -111,7 +111,8 @@ def _add_observation_to_graph(g, row, DCID, prov_urls):
     try:
       props_dict = json.loads(props)
       for k in props_dict.keys():
-        g.add((var_ref, DCID["observationProperty"], expand_id(k)))
+        g.add((var_ref, DCID["observationProperties"], expand_id(k)))
+        g.add((subject, DCID["observationProperties"], expand_id(k)))
     except json.JSONDecodeError:
       pass
   g.add((subject, DCID["observationDate"], Literal(date)))

--- a/simple/stats/jsonld_exporter.py
+++ b/simple/stats/jsonld_exporter.py
@@ -112,7 +112,6 @@ def _add_observation_to_graph(g, row, DCID, prov_urls):
       props_dict = json.loads(props)
       for k in props_dict.keys():
         g.add((var_ref, DCID["observationProperties"], expand_id(k)))
-        g.add((subject, DCID["observationProperties"], expand_id(k)))
     except json.JSONDecodeError:
       pass
   g.add((subject, DCID["observationDate"], Literal(date)))

--- a/simple/stats/jsonld_exporter.py
+++ b/simple/stats/jsonld_exporter.py
@@ -110,8 +110,9 @@ def _add_observation_to_graph(g, row, DCID, prov_urls):
   if props:
     try:
       props_dict = json.loads(props)
-      for k in props_dict.keys():
-        g.add((var_ref, DCID["observationProperties"], expand_id(k)))
+      if isinstance(props_dict, dict):
+        for k in props_dict.keys():
+          g.add((var_ref, DCID["observationProperties"], expand_id(k)))
     except json.JSONDecodeError:
       pass
   g.add((subject, DCID["observationDate"], Literal(date)))
@@ -137,11 +138,12 @@ def _add_observation_to_graph(g, row, DCID, prov_urls):
   if props:
     try:
       props_dict = json.loads(props)
-      for k, v in props_dict.items():
-        if is_entity_reference(v):
-          g.add((subject, expand_id(k), expand_id(v)))
-        else:
-          g.add((subject, expand_id(k), Literal(v)))
+      if isinstance(props_dict, dict):
+        for k, v in props_dict.items():
+          if is_entity_reference(v):
+            g.add((subject, expand_id(k), expand_id(v)))
+          else:
+            g.add((subject, expand_id(k), Literal(v)))
     except json.JSONDecodeError as e:
       logging.warning(
           f"Failed to decode properties JSON for observation {entity}/{variable}: {e}"

--- a/simple/stats/jsonld_stream_db.py
+++ b/simple/stats/jsonld_stream_db.py
@@ -106,8 +106,6 @@ def _write_observation_shard(args):
         "dcid:observationDate": _parse_numeric(date),
         "dcid:value": _parse_numeric(value),
     }
-    if prop_keys:
-      obs_obj["dcid:observationProperties"] = prop_keys
 
     entity_ref = _uri_ref(entity)
     if entity_ref:

--- a/simple/stats/jsonld_stream_db.py
+++ b/simple/stats/jsonld_stream_db.py
@@ -94,7 +94,7 @@ def _write_observation_shard(args):
                 ("dcid:", "http://", "https://")) else k
             for k in props_dict.keys()
         ]
-        if prop_keys:
+        if prop_keys and var_obj:
           var_obj["dcid:observationProperties"] = prop_keys
       except json.JSONDecodeError:
         pass

--- a/simple/stats/jsonld_stream_db.py
+++ b/simple/stats/jsonld_stream_db.py
@@ -111,7 +111,6 @@ def _write_observation_shard(args):
     if entity_ref:
       obs_obj["dcid:observationAbout"] = entity_ref
 
-
     if provenance:
       obs_obj["dcid:provenance"] = _uri_ref(provenance)
       if provenance in prov_urls and prov_urls[provenance]:

--- a/simple/stats/jsonld_stream_db.py
+++ b/simple/stats/jsonld_stream_db.py
@@ -89,13 +89,14 @@ def _write_observation_shard(args):
     if props:
       try:
         props_dict = json.loads(props)
-        prop_keys = [
-            f"dcid:{k}" if not k.startswith(
-                ("dcid:", "http://", "https://")) else k
-            for k in props_dict.keys()
-        ]
-        if prop_keys and var_obj:
-          var_obj["dcid:observationProperties"] = prop_keys
+        if isinstance(props_dict, dict):
+          prop_keys = [
+              f"dcid:{k}" if not k.startswith(
+                  ("dcid:", "http://", "https://")) else k
+              for k in props_dict.keys()
+          ]
+          if prop_keys and var_obj:
+            var_obj["dcid:observationProperties"] = prop_keys
       except json.JSONDecodeError:
         pass
 
@@ -127,13 +128,14 @@ def _write_observation_shard(args):
     if props:
       try:
         props_dict = json.loads(props)
-        for k, v in props_dict.items():
-          prop_key = f"dcid:{k}" if not k.startswith(
-              "dcid:") and not k.startswith("http") else k
-          if is_entity_reference(v):
-            obs_obj[prop_key] = _uri_ref(v)
-          else:
-            obs_obj[prop_key] = _parse_numeric(v)
+        if isinstance(props_dict, dict):
+          for k, v in props_dict.items():
+            prop_key = f"dcid:{k}" if not k.startswith(
+                "dcid:") and not k.startswith("http") else k
+            if is_entity_reference(v):
+              obs_obj[prop_key] = _uri_ref(v)
+            else:
+              obs_obj[prop_key] = _parse_numeric(v)
       except json.JSONDecodeError as e:
         logging.warning(
             "Failed to decode properties JSON for observation %s/%s: %s",

--- a/simple/stats/jsonld_stream_db.py
+++ b/simple/stats/jsonld_stream_db.py
@@ -113,9 +113,6 @@ def _write_observation_shard(args):
     if entity_ref:
       obs_obj["dcid:observationAbout"] = entity_ref
 
-    entity_ref = _uri_ref(entity)
-    if entity_ref:
-      obs_obj["dcid:observationAbout"] = entity_ref
 
     if provenance:
       obs_obj["dcid:provenance"] = _uri_ref(provenance)

--- a/simple/stats/jsonld_stream_db.py
+++ b/simple/stats/jsonld_stream_db.py
@@ -85,6 +85,7 @@ def _write_observation_shard(args):
     obs_hash = hashlib.sha256(key.encode('utf-8')).hexdigest()
 
     var_obj = _uri_ref(variable)
+    prop_keys = None
     if props:
       try:
         props_dict = json.loads(props)
@@ -94,7 +95,7 @@ def _write_observation_shard(args):
             for k in props_dict.keys()
         ]
         if prop_keys:
-          var_obj["dcid:observationProperty"] = prop_keys
+          var_obj["dcid:observationProperties"] = prop_keys
       except json.JSONDecodeError:
         pass
 
@@ -105,6 +106,12 @@ def _write_observation_shard(args):
         "dcid:observationDate": _parse_numeric(date),
         "dcid:value": _parse_numeric(value),
     }
+    if prop_keys:
+      obs_obj["dcid:observationProperties"] = prop_keys
+
+    entity_ref = _uri_ref(entity)
+    if entity_ref:
+      obs_obj["dcid:observationAbout"] = entity_ref
 
     entity_ref = _uri_ref(entity)
     if entity_ref:

--- a/simple/stats/schema_constants.py
+++ b/simple/stats/schema_constants.py
@@ -23,7 +23,7 @@ SV_HIERARCHY_PROPS_BLOCKLIST: set[str] = {
     "searchDescription", "source", "footnote", "isNormalizable",
     "denominatorForNormalization", "measuredProperty", "measurementMethod",
     "measurementDenominator", "measurementQualifier", "scalingFactor", "unit",
-    "statType", "censusACSTableId", "includedIn", "observationProperty",
+    "statType", "censusACSTableId", "includedIn", "observationProperties",
     "entityMapping"
 }
 

--- a/simple/stats/schema_constants.py
+++ b/simple/stats/schema_constants.py
@@ -23,8 +23,7 @@ SV_HIERARCHY_PROPS_BLOCKLIST: set[str] = {
     "searchDescription", "source", "footnote", "isNormalizable",
     "denominatorForNormalization", "measuredProperty", "measurementMethod",
     "measurementDenominator", "measurementQualifier", "scalingFactor", "unit",
-    "statType", "censusACSTableId", "includedIn", "observationProperties",
-    "entityMapping"
+    "statType", "censusACSTableId", "includedIn", "observationProperties"
 }
 
 PREDICATE_TYPE_OF = "typeOf"

--- a/simple/tests/stats/stat_var_hierarchy_generator_test.py
+++ b/simple/tests/stats/stat_var_hierarchy_generator_test.py
@@ -148,7 +148,6 @@ class TestStatVarHierarchyGenerator(unittest.TestCase):
         Triple("sv1", "measuredProperty", "count", ""),
         Triple("sv1", "searchDescription", "", "SV1 search description"),
         Triple("sv1", "observationProperties", "destinationCountry", ""),
-        Triple("sv1", "entityMapping", "someMapping", ""),
         Triple("non_sv1", "typeOf", "Person", ""),
         Triple("non_sv1", "gender", "Male", ""),
         Triple("non_sv1", "race", "AmericanIndianOrAlaskaNative", ""),

--- a/simple/tests/stats/stat_var_hierarchy_generator_test.py
+++ b/simple/tests/stats/stat_var_hierarchy_generator_test.py
@@ -147,7 +147,7 @@ class TestStatVarHierarchyGenerator(unittest.TestCase):
         Triple("sv1", "gender", "Female", ""),
         Triple("sv1", "measuredProperty", "count", ""),
         Triple("sv1", "searchDescription", "", "SV1 search description"),
-        Triple("sv1", "observationProperty", "destinationCountry", ""),
+        Triple("sv1", "observationProperties", "destinationCountry", ""),
         Triple("sv1", "entityMapping", "someMapping", ""),
         Triple("non_sv1", "typeOf", "Person", ""),
         Triple("non_sv1", "gender", "Male", ""),

--- a/util/src/main/java/org/datacommons/util/Vocabulary.java
+++ b/util/src/main/java/org/datacommons/util/Vocabulary.java
@@ -120,7 +120,7 @@ public final class Vocabulary {
   public static final String VARIABLE_MEASURED = "variableMeasured";
   public static final String STAT_TYPE = "statType";
   public static final String CONSTRAINT_PROPS = "constraintProperties";
-  public static final String OBSERVATION_PROPERTY = "observationProperty";
+  public static final String OBSERVATION_PROPERTIES = "observationProperties";
   public static final String ENTITY_MAPPING = "entityMapping";
   public static final String MEASUREMENT_DENOMINATOR = "measurementDenominator";
   public static final String MEASUREMENT_QUALIFIER = "measurementQualifier";
@@ -256,7 +256,7 @@ public final class Vocabulary {
           POPULATION_GROUP,
           LOCATION,
           CONSTRAINT_PROPS,
-          OBSERVATION_PROPERTY,
+          OBSERVATION_PROPERTIES,
           ENTITY_MAPPING,
           MEASURED_PROP,
           STAT_TYPE,
@@ -318,7 +318,7 @@ public final class Vocabulary {
         || prop.equals(MEASUREMENT_QUALIFIER)
         || prop.equals(STAT_TYPE)
         || prop.equals(UNIT)
-        || prop.equals(OBSERVATION_PROPERTY);
+        || prop.equals(OBSERVATION_PROPERTIES);
   }
 
   public static boolean isGlobalReference(String val) {

--- a/util/src/main/java/org/datacommons/util/Vocabulary.java
+++ b/util/src/main/java/org/datacommons/util/Vocabulary.java
@@ -121,7 +121,6 @@ public final class Vocabulary {
   public static final String STAT_TYPE = "statType";
   public static final String CONSTRAINT_PROPS = "constraintProperties";
   public static final String OBSERVATION_PROPERTIES = "observationProperties";
-  public static final String ENTITY_MAPPING = "entityMapping";
   public static final String MEASUREMENT_DENOMINATOR = "measurementDenominator";
   public static final String MEASUREMENT_QUALIFIER = "measurementQualifier";
   public static final String SCALING_FACTOR = "scalingFactor";
@@ -257,7 +256,6 @@ public final class Vocabulary {
           LOCATION,
           CONSTRAINT_PROPS,
           OBSERVATION_PROPERTIES,
-          ENTITY_MAPPING,
           MEASURED_PROP,
           STAT_TYPE,
           MEASUREMENT_DENOMINATOR,

--- a/util/src/test/java/org/datacommons/util/McfMutatorTest.java
+++ b/util/src/test/java/org/datacommons/util/McfMutatorTest.java
@@ -113,7 +113,7 @@ public class McfMutatorTest {
             + "typeOf: schema:StatisticalVariable\n"
             + "populationType: dcs:FinancialTransaction\n"
             + "measuredProperty: dcs:amount\n"
-            + "observationProperty: dcs:destinationCountry\n"
+            + "observationProperties: dcs:destinationCountry\n"
             + "entityMapping: dcs:someMapping\n"
             + "someActualConstraint: dcs:someValue\n";
     Mcf.McfGraph got =
@@ -125,7 +125,7 @@ public class McfMutatorTest {
             + "dcid: \"FinancialAid\"\n"
             + "entityMapping: dcid:someMapping\n"
             + "measuredProperty: dcid:amount\n"
-            + "observationProperty: dcid:destinationCountry\n"
+            + "observationProperties: dcid:destinationCountry\n"
             + "populationType: dcid:FinancialTransaction\n"
             + "someActualConstraint: dcid:someValue\n"
             + "typeOf: dcid:StatisticalVariable\n"

--- a/util/src/test/java/org/datacommons/util/McfMutatorTest.java
+++ b/util/src/test/java/org/datacommons/util/McfMutatorTest.java
@@ -114,7 +114,6 @@ public class McfMutatorTest {
             + "populationType: dcs:FinancialTransaction\n"
             + "measuredProperty: dcs:amount\n"
             + "observationProperties: dcs:destinationCountry\n"
-            + "entityMapping: dcs:someMapping\n"
             + "someActualConstraint: dcs:someValue\n";
     Mcf.McfGraph got =
         McfMutator.mutate(TestUtil.graphFromMcf(mcf).toBuilder(), TestUtil.newLogCtx());
@@ -123,7 +122,6 @@ public class McfMutatorTest {
         "Node: dcid:FinancialAid\n"
             + "constraintProperties: dcid:someActualConstraint\n"
             + "dcid: \"FinancialAid\"\n"
-            + "entityMapping: dcid:someMapping\n"
             + "measuredProperty: dcid:amount\n"
             + "observationProperties: dcid:destinationCountry\n"
             + "populationType: dcid:FinancialTransaction\n"

--- a/util/src/test/java/org/datacommons/util/McfParserTest.java
+++ b/util/src/test/java/org/datacommons/util/McfParserTest.java
@@ -214,13 +214,5 @@ public class McfParserTest {
             McfType.INSTANCE_MCF, false, "observationProperties", "destinationCountry", null);
     assertNotNull(actual);
     assertEquals(expected.build(), actual.build());
-
-    // Verify entityMapping is parsed as TEXT (non-reference property)
-    expected.clear();
-    expected.setValue("origin=entity1");
-    expected.setType(ValueType.TEXT);
-    actual = parseTypedValue(McfType.INSTANCE_MCF, false, "entityMapping", "origin=entity1", null);
-    assertNotNull(actual);
-    assertEquals(expected.build(), actual.build());
   }
 }

--- a/util/src/test/java/org/datacommons/util/McfParserTest.java
+++ b/util/src/test/java/org/datacommons/util/McfParserTest.java
@@ -205,13 +205,13 @@ public class McfParserTest {
     assertNotNull(actual);
     assertEquals(expected.build(), actual.build());
 
-    // Verify observationProperty is parsed as RESOLVED_REF (reference property)
+    // Verify observationProperties is parsed as RESOLVED_REF (reference property)
     expected.clear();
     expected.setValue("destinationCountry");
     expected.setType(ValueType.RESOLVED_REF);
     actual =
         parseTypedValue(
-            McfType.INSTANCE_MCF, false, "observationProperty", "destinationCountry", null);
+            McfType.INSTANCE_MCF, false, "observationProperties", "destinationCountry", null);
     assertNotNull(actual);
     assertEquals(expected.build(), actual.build());
 

--- a/util/src/test/java/org/datacommons/util/McfResolverTest.java
+++ b/util/src/test/java/org/datacommons/util/McfResolverTest.java
@@ -138,7 +138,7 @@ public class McfResolverTest {
                     "dcid: \"FinancialAid\"",
                     "populationType: dcs:FinancialTransaction",
                     "measuredProperty: dcs:amount",
-                    "observationProperty: l:MyCustomProp",
+                    "observationProperties: l:MyCustomProp",
                     "")),
             true,
             null,
@@ -151,7 +151,7 @@ public class McfResolverTest {
     var resolvedGraph = resolver.resolvedGraph();
     var svNode = resolvedGraph.getNodesOrThrow("FinancialAid");
     assertEquals(
-        "customDestinationCountry", McfUtil.getPropVal(svNode, Vocabulary.OBSERVATION_PROPERTY));
+        "customDestinationCountry", McfUtil.getPropVal(svNode, Vocabulary.OBSERVATION_PROPERTIES));
   }
 
   private String getFile(String name) throws IOException {


### PR DESCRIPTION
This PR aligns the StatisticalVariable properties used for multi-entity observations to be consistent with existing patterns and removes obsolete mapping properties.

### Changes

1. **Unify on Plural `observationProperties`**:
   Aligns the property name on the StatisticalVariable to be plural (**`observationProperties`**), making it consistent with the existing **`constraintProperties`** pattern. Previously, the preprocessor and Java transformation pipeline used the singular `observationProperty` on the StatVar.

2. **Remove Obsolete `entityMapping`**:
   Removes the `entityMapping` property entirely from the preprocessor, Java vocabulary, and tests. Since the pipeline now resolves property-to-entity mapping based on lexicographical (alphabetical) order of the properties, explicit mapping definitions are no longer needed.

### Details
- Updated Python preprocessor (both standard exporter and streaming DB) to write `observationProperties` (plural) to the StatisticalVariable.
- Updated Java transformation pipeline (`GraphTransformer`, `Vocabulary`) to support `observationProperties` (plural) on the StatisticalVariable (marking it as a non-constraint property).
- Removed `entityMapping` from schema constants, vocabulary, and all related tests in both Python and Java.
- Updated related tests to use `observationProperties`.

TAG=agy
CONV=3284f4a5-479a-48fc-adff-82a4a1ed8296
