### PR TITLE
Add missing Edge node audit Dataflow pipeline

### DIFF
--- a/pipeline/missing-edge-nodes/README.md
+++ b/pipeline/missing-edge-nodes/README.md
@@ -19,6 +19,8 @@ mvn compile exec:java -pl missing-edge-nodes -am \
     --tempLocation=gs://<bucket>/tmp \
     --stagingLocation=gs://<bucket>/staging \
     --jobName=missing-edge-node-dcids \
+    --workerMachineType=e2-highmem-16 \
+    --numberOfWorkerHarnessThreads=8 \
     --spannerProjectId=<spanner-project> \
     --spannerInstanceId=<spanner-instance> \
     --spannerDatabaseId=<spanner-database> \
@@ -29,8 +31,13 @@ mvn compile exec:java -pl missing-edge-nodes -am \
 Staging Spanner command:
 
 ```bash
-mvn compile exec:java -pl missing-edge-nodes -am -Dexec.mainClass=org.datacommons.ingestion.missingnodes.MissingEdgeNodesPipeline -Dexec.args="--runner=DataflowRunner --project=datcom-store --region=us-central1 --tempLocation=gs://rohitrkumar-dataflow/temp/tmp --stagingLocation=gs://rohitrkumar-dataflow/temp/staging --jobName=missing-edge-node-dcids --spannerProjectId=datcom-store --spannerInstanceId=dc-graph-staging --spannerDatabaseId=dc_graph --writeDedupedInputs=true --outputLocation=gs://rohitrkumar-dataflow/edge-node-audit"
+mvn compile exec:java -pl missing-edge-nodes -am -Dexec.mainClass=org.datacommons.ingestion.missingnodes.MissingEdgeNodesPipeline -Dexec.args="--runner=DataflowRunner --project=datcom-store --region=us-central1 --tempLocation=gs://rohitrkumar-dataflow/temp/tmp --stagingLocation=gs://rohitrkumar-dataflow/temp/staging --jobName=missing-edge-node-dcids --workerMachineType=e2-highmem-16 --numberOfWorkerHarnessThreads=8 --spannerProjectId=datcom-store --spannerInstanceId=dc-graph-staging --spannerDatabaseId=dc_graph --writeDedupedInputs=true --outputLocation=gs://rohitrkumar-dataflow/edge-node-audit"
 ```
+
+For large runs, start with `e2-highmem-16`. If workers still OOM, retry with
+`--numberOfWorkerHarnessThreads=4` to reduce per-worker concurrency. Avoid
+`e2-standard-32` for this job; it has the same total memory as `e2-highmem-16`
+but more worker concurrency and less memory per vCPU.
 
 Output:
 

--- a/pipeline/missing-edge-nodes/README.md
+++ b/pipeline/missing-edge-nodes/README.md
@@ -19,12 +19,28 @@ mvn compile exec:java -pl missing-edge-nodes -am \
     --spannerProjectId=<spanner-project> \
     --spannerInstanceId=<spanner-instance> \
     --spannerDatabaseId=<spanner-database> \
-    --outputLocation=gs://<bucket>/missing-edge-node-dcids"
+    --writeDedupedInputs=true \
+    --outputLocation=gs://<bucket>/edge-node-audit"
+```
+
+Staging Spanner command:
+
+```bash
+mvn compile exec:java -pl missing-edge-nodes -am -Dexec.mainClass=org.datacommons.ingestion.missingnodes.MissingEdgeNodesPipeline -Dexec.args="--runner=DataflowRunner --project=datcom-store --region=us-central1 --tempLocation=gs://rohitrkumar-dataflow/temp/tmp --stagingLocation=gs://rohitrkumar-dataflow/temp/staging --jobName=missing-edge-node-dcids --spannerProjectId=datcom-store --spannerInstanceId=dc-graph-staging --spannerDatabaseId=dc_graph --writeDedupedInputs=true --outputLocation=gs://rohitrkumar-dataflow/edge-node-audit"
 ```
 
 Output:
 
 ```text
-gs://<bucket>/missing-edge-node-dcids/missing-edge-node-dcids-*.csv
+gs://<bucket>/edge-node-audit/missing-edge-node-dcids/part-*.csv
 dcid,type
+```
+
+When `writeDedupedInputs` is enabled, the job also writes headerless files:
+
+```text
+gs://<bucket>/edge-node-audit/distinct-nodes/part-*.csv
+gs://<bucket>/edge-node-audit/distinct-predicates/part-*.csv
+gs://<bucket>/edge-node-audit/distinct-object-ids/part-*.csv
+gs://<bucket>/edge-node-audit/distinct-provenances/part-*.csv
 ```

--- a/pipeline/missing-edge-nodes/README.md
+++ b/pipeline/missing-edge-nodes/README.md
@@ -1,0 +1,30 @@
+# Missing Edge Nodes Pipeline
+
+Migration-only Dataflow pipeline to find distinct values from `Edge.subject_id`,
+`Edge.predicate`, `Edge.object_id`, and `Edge.provenance` that are missing from
+`Node.subject_id`.
+
+Run from `import/pipeline`:
+
+```bash
+mvn compile exec:java -pl missing-edge-nodes -am \
+  -Dexec.mainClass=org.datacommons.ingestion.missingnodes.MissingEdgeNodesPipeline \
+  -Dexec.args="\
+    --runner=DataflowRunner \
+    --project=<dataflow-project> \
+    --region=<region> \
+    --tempLocation=gs://<bucket>/tmp \
+    --stagingLocation=gs://<bucket>/staging \
+    --jobName=missing-edge-node-dcids \
+    --spannerProjectId=<spanner-project> \
+    --spannerInstanceId=<spanner-instance> \
+    --spannerDatabaseId=<spanner-database> \
+    --outputLocation=gs://<bucket>/missing-edge-node-dcids"
+```
+
+Output:
+
+```text
+gs://<bucket>/missing-edge-node-dcids/missing-edge-node-dcids-*.csv
+dcid,type
+```

--- a/pipeline/missing-edge-nodes/README.md
+++ b/pipeline/missing-edge-nodes/README.md
@@ -39,7 +39,8 @@ dcid,type
 When `writeDedupedInputs` is enabled, the job also writes headerless files:
 
 ```text
-gs://<bucket>/edge-node-audit/distinct-nodes/part-*.csv
+gs://<bucket>/edge-node-audit/distinct-node-subject-ids/part-*.csv
+gs://<bucket>/edge-node-audit/distinct-edge-subject-ids/part-*.csv
 gs://<bucket>/edge-node-audit/distinct-predicates/part-*.csv
 gs://<bucket>/edge-node-audit/distinct-object-ids/part-*.csv
 gs://<bucket>/edge-node-audit/distinct-provenances/part-*.csv

--- a/pipeline/missing-edge-nodes/README.md
+++ b/pipeline/missing-edge-nodes/README.md
@@ -4,6 +4,9 @@ Migration-only Dataflow pipeline to find distinct values from `Edge.subject_id`,
 `Edge.predicate`, `Edge.object_id`, and `Edge.provenance` that are missing from
 `Node.subject_id`.
 
+The Spanner queries are plain scans; Beam deduplicates the combined typed Edge
+candidate stream.
+
 Run from `import/pipeline`:
 
 ```bash

--- a/pipeline/missing-edge-nodes/pom.xml
+++ b/pipeline/missing-edge-nodes/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.datacommons</groupId>
+        <artifactId>pipeline</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <groupId>org.datacommons</groupId>
+    <artifactId>missing-edge-nodes</artifactId>
+    <version>${revision}</version>
+    <name>Data Commons - Missing Edge Nodes Pipeline</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-sdks-java-core</artifactId>
+            <version>${beam.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
+            <version>${beam.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-runners-direct-java</artifactId>
+            <version>${beam.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
+            <version>${beam.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                    <cleanupDaemonThreads>false</cleanupDaemonThreads>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${project.artifactId}-bundled-${project.version}</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.datacommons.ingestion.missingnodes.MissingEdgeNodesPipeline</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesOptions.java
+++ b/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesOptions.java
@@ -1,5 +1,6 @@
 package org.datacommons.ingestion.missingnodes;
 
+import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.Validation.Required;
@@ -29,4 +30,10 @@ public interface MissingEdgeNodesOptions extends PipelineOptions {
   String getOutputLocation();
 
   void setOutputLocation(String value);
+
+  @Description("Whether to write deduplicated Edge column audit files")
+  @Default.Boolean(true)
+  boolean getWriteDedupedInputs();
+
+  void setWriteDedupedInputs(boolean value);
 }

--- a/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesOptions.java
+++ b/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesOptions.java
@@ -1,0 +1,32 @@
+package org.datacommons.ingestion.missingnodes;
+
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.Validation.Required;
+
+/** Parameters for finding Edge dcids that do not have Node rows. */
+public interface MissingEdgeNodesOptions extends PipelineOptions {
+  @Description("GCP project id containing the Spanner database")
+  @Required
+  String getSpannerProjectId();
+
+  void setSpannerProjectId(String value);
+
+  @Description("Spanner instance id")
+  @Required
+  String getSpannerInstanceId();
+
+  void setSpannerInstanceId(String value);
+
+  @Description("Spanner database id")
+  @Required
+  String getSpannerDatabaseId();
+
+  void setSpannerDatabaseId(String value);
+
+  @Description("GCS output folder for missing dcid CSV shards")
+  @Required
+  String getOutputLocation();
+
+  void setOutputLocation(String value);
+}

--- a/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesPipeline.java
+++ b/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesPipeline.java
@@ -17,6 +17,13 @@ public class MissingEdgeNodesPipeline {
   private static final String EDGE_QUERY =
       "SELECT subject_id, predicate, object_id, provenance FROM Edge";
   private static final String PART_PREFIX = "part";
+  private static final String SPANNER_NODE_ROWS_READ = "spanner_node_rows_read";
+  private static final String SPANNER_EDGE_ROWS_READ = "spanner_edge_rows_read";
+  private static final String DISTINCT_NODE_SUBJECT_IDS = "distinct_node_subject_ids";
+  private static final String DISTINCT_EDGE_SUBJECT_IDS = "distinct_edge_subject_ids";
+  private static final String DISTINCT_PREDICATES = "distinct_predicates";
+  private static final String DISTINCT_OBJECT_IDS = "distinct_object_ids";
+  private static final String DISTINCT_PROVENANCES = "distinct_provenances";
 
   public static void main(String[] args) {
     MissingEdgeNodesOptions options =
@@ -24,43 +31,66 @@ public class MissingEdgeNodesPipeline {
     Pipeline pipeline = Pipeline.create(options);
 
     PCollection<Struct> nodeRows =
-        pipeline.apply("Read Node subject_ids", spannerRead(options, NODE_QUERY));
+        pipeline
+            .apply("Read Node subject_ids", spannerRead(options, NODE_QUERY))
+            .apply(
+                "Count Spanner Node rows",
+                MissingEdgeNodesUtils.countStructRows(SPANNER_NODE_ROWS_READ));
     PCollection<String> nodeSubjectIds =
         nodeRows
             .apply(
                 "Extract Node subject_ids",
                 MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.SUBJECT_ID))
-            .apply("Deduplicate Node subject_ids", MissingEdgeNodesUtils.distinctValues());
+            .apply("Deduplicate Node subject_ids", MissingEdgeNodesUtils.distinctValues())
+            .apply(
+                "Count distinct Node subject_ids",
+                MissingEdgeNodesUtils.countStringValues(DISTINCT_NODE_SUBJECT_IDS));
     PCollection<KV<String, String>> nodeKeys =
         nodeSubjectIds.apply("Key Node subject_ids", MissingEdgeNodesUtils.nodeKeys());
 
     PCollection<Struct> edgeRows =
-        pipeline.apply("Read Edge identifiers", spannerRead(options, EDGE_QUERY));
+        pipeline
+            .apply("Read Edge identifiers", spannerRead(options, EDGE_QUERY))
+            .apply(
+                "Count Spanner Edge rows",
+                MissingEdgeNodesUtils.countStructRows(SPANNER_EDGE_ROWS_READ));
 
     PCollection<String> subjectIds =
         edgeRows
             .apply(
                 "Extract Edge subject_ids",
                 MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.SUBJECT_ID))
-            .apply("Deduplicate Edge subject_ids", MissingEdgeNodesUtils.distinctValues());
+            .apply("Deduplicate Edge subject_ids", MissingEdgeNodesUtils.distinctValues())
+            .apply(
+                "Count distinct Edge subject_ids",
+                MissingEdgeNodesUtils.countStringValues(DISTINCT_EDGE_SUBJECT_IDS));
     PCollection<String> predicates =
         edgeRows
             .apply(
                 "Extract Edge predicates",
                 MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.PREDICATE))
-            .apply("Deduplicate Edge predicates", MissingEdgeNodesUtils.distinctValues());
+            .apply("Deduplicate Edge predicates", MissingEdgeNodesUtils.distinctValues())
+            .apply(
+                "Count distinct Edge predicates",
+                MissingEdgeNodesUtils.countStringValues(DISTINCT_PREDICATES));
     PCollection<String> objectIds =
         edgeRows
             .apply(
                 "Extract Edge object_ids",
                 MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.OBJECT_ID))
-            .apply("Deduplicate Edge object_ids", MissingEdgeNodesUtils.distinctValues());
+            .apply("Deduplicate Edge object_ids", MissingEdgeNodesUtils.distinctValues())
+            .apply(
+                "Count distinct Edge object_ids",
+                MissingEdgeNodesUtils.countStringValues(DISTINCT_OBJECT_IDS));
     PCollection<String> provenances =
         edgeRows
             .apply(
                 "Extract Edge provenances",
                 MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.PROVENANCE))
-            .apply("Deduplicate Edge provenances", MissingEdgeNodesUtils.distinctValues());
+            .apply("Deduplicate Edge provenances", MissingEdgeNodesUtils.distinctValues())
+            .apply(
+                "Count distinct Edge provenances",
+                MissingEdgeNodesUtils.countStringValues(DISTINCT_PROVENANCES));
 
     if (options.getWriteDedupedInputs()) {
       writeDedupedValues(

--- a/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesPipeline.java
+++ b/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesPipeline.java
@@ -1,0 +1,52 @@
+package org.datacommons.ingestion.missingnodes;
+
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerIO;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+
+/** Dataflow pipeline for finding Edge identifiers missing from Node.subject_id. */
+public class MissingEdgeNodesPipeline {
+  private static final String OUTPUT_HEADER = "dcid,type";
+  private static final String NODE_QUERY = "SELECT subject_id FROM Node";
+  private static final String EDGE_QUERY =
+      "SELECT subject_id, predicate, object_id, provenance FROM Edge";
+
+  public static void main(String[] args) {
+    MissingEdgeNodesOptions options =
+        PipelineOptionsFactory.fromArgs(args).withValidation().as(MissingEdgeNodesOptions.class);
+    Pipeline pipeline = Pipeline.create(options);
+
+    PCollection<KV<String, String>> nodeKeys =
+        pipeline
+            .apply("Read Node subject_ids", spannerRead(options, NODE_QUERY))
+            .apply("Key Node subject_ids", MissingEdgeNodesUtils.nodeKeys());
+
+    PCollection<KV<String, String>> edgeCandidates =
+        pipeline
+            .apply("Read Edge identifiers", spannerRead(options, EDGE_QUERY))
+            .apply("Extract Edge candidates", MissingEdgeNodesUtils.edgeCandidates())
+            .apply("Deduplicate Edge candidates", MissingEdgeNodesUtils.distinctCandidates());
+
+    MissingEdgeNodesUtils.findMissingCandidates(edgeCandidates, nodeKeys)
+        .apply("Format CSV rows", MissingEdgeNodesUtils.formatCsvRows())
+        .apply(
+            "Write missing dcids",
+            TextIO.write()
+                .to(options.getOutputLocation() + "/missing-edge-node-dcids")
+                .withSuffix(".csv")
+                .withHeader(OUTPUT_HEADER));
+
+    pipeline.run();
+  }
+
+  private static SpannerIO.Read spannerRead(MissingEdgeNodesOptions options, String query) {
+    return SpannerIO.read()
+        .withProjectId(options.getSpannerProjectId())
+        .withInstanceId(options.getSpannerInstanceId())
+        .withDatabaseId(options.getSpannerDatabaseId())
+        .withQuery(query);
+  }
+}

--- a/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesPipeline.java
+++ b/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesPipeline.java
@@ -22,6 +22,10 @@ public class MissingEdgeNodesPipeline {
   private static final String DISTINCT_PREDICATES = "distinct_predicates";
   private static final String DISTINCT_OBJECT_IDS = "distinct_object_ids";
   private static final String DISTINCT_PROVENANCES = "distinct_provenances";
+  private static final String MISSING_EDGE_SUBJECT_IDS = "missing_edge_subject_ids";
+  private static final String MISSING_PREDICATES = "missing_predicates";
+  private static final String MISSING_OBJECT_IDS = "missing_object_ids";
+  private static final String MISSING_PROVENANCES = "missing_provenances";
 
   public static void main(String[] args) {
     MissingEdgeNodesOptions options =
@@ -58,7 +62,7 @@ public class MissingEdgeNodesPipeline {
             .apply("Deduplicate Edge candidates", MissingEdgeNodesUtils.distinctValues())
             .apply(
                 "Count distinct Edge candidate types",
-                MissingEdgeNodesUtils.countCandidateTypes(
+                MissingEdgeNodesUtils.countTypedValues(
                     DISTINCT_EDGE_SUBJECT_IDS,
                     DISTINCT_PREDICATES,
                     DISTINCT_OBJECT_IDS,
@@ -96,6 +100,13 @@ public class MissingEdgeNodesPipeline {
     }
 
     MissingEdgeNodesUtils.findMissingCandidates(edgeCandidates, nodeKeys)
+        .apply(
+            "Count missing candidate types",
+            MissingEdgeNodesUtils.countTypedValues(
+                MISSING_EDGE_SUBJECT_IDS,
+                MISSING_PREDICATES,
+                MISSING_OBJECT_IDS,
+                MISSING_PROVENANCES))
         .apply("Format CSV rows", MissingEdgeNodesUtils.formatCsvRows())
         .apply(
             "Write missing dcids",

--- a/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesPipeline.java
+++ b/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesPipeline.java
@@ -23,10 +23,16 @@ public class MissingEdgeNodesPipeline {
         PipelineOptionsFactory.fromArgs(args).withValidation().as(MissingEdgeNodesOptions.class);
     Pipeline pipeline = Pipeline.create(options);
 
+    PCollection<Struct> nodeRows =
+        pipeline.apply("Read Node subject_ids", spannerRead(options, NODE_QUERY));
+    PCollection<String> nodeSubjectIds =
+        nodeRows
+            .apply(
+                "Extract Node subject_ids",
+                MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.SUBJECT_ID))
+            .apply("Deduplicate Node subject_ids", MissingEdgeNodesUtils.distinctValues());
     PCollection<KV<String, String>> nodeKeys =
-        pipeline
-            .apply("Read Node subject_ids", spannerRead(options, NODE_QUERY))
-            .apply("Key Node subject_ids", MissingEdgeNodesUtils.nodeKeys());
+        nodeSubjectIds.apply("Key Node subject_ids", MissingEdgeNodesUtils.nodeKeys());
 
     PCollection<Struct> edgeRows =
         pipeline.apply("Read Edge identifiers", spannerRead(options, EDGE_QUERY));
@@ -58,7 +64,13 @@ public class MissingEdgeNodesPipeline {
 
     if (options.getWriteDedupedInputs()) {
       writeDedupedValues(
-          subjectIds, "subject_ids", outputPrefix(options.getOutputLocation(), "distinct-nodes"));
+          nodeSubjectIds,
+          "node_subject_ids",
+          outputPrefix(options.getOutputLocation(), "distinct-node-subject-ids"));
+      writeDedupedValues(
+          subjectIds,
+          "edge_subject_ids",
+          outputPrefix(options.getOutputLocation(), "distinct-edge-subject-ids"));
       writeDedupedValues(
           predicates,
           "predicates",

--- a/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesPipeline.java
+++ b/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesPipeline.java
@@ -1,11 +1,14 @@
 package org.datacommons.ingestion.missingnodes;
 
+import com.google.cloud.spanner.Struct;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
 
 /** Dataflow pipeline for finding Edge identifiers missing from Node.subject_id. */
 public class MissingEdgeNodesPipeline {
@@ -13,6 +16,7 @@ public class MissingEdgeNodesPipeline {
   private static final String NODE_QUERY = "SELECT subject_id FROM Node";
   private static final String EDGE_QUERY =
       "SELECT subject_id, predicate, object_id, provenance FROM Edge";
+  private static final String PART_PREFIX = "part";
 
   public static void main(String[] args) {
     MissingEdgeNodesOptions options =
@@ -24,18 +28,76 @@ public class MissingEdgeNodesPipeline {
             .apply("Read Node subject_ids", spannerRead(options, NODE_QUERY))
             .apply("Key Node subject_ids", MissingEdgeNodesUtils.nodeKeys());
 
+    PCollection<Struct> edgeRows =
+        pipeline.apply("Read Edge identifiers", spannerRead(options, EDGE_QUERY));
+
+    PCollection<String> subjectIds =
+        edgeRows
+            .apply(
+                "Extract Edge subject_ids",
+                MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.SUBJECT_ID))
+            .apply("Deduplicate Edge subject_ids", MissingEdgeNodesUtils.distinctValues());
+    PCollection<String> predicates =
+        edgeRows
+            .apply(
+                "Extract Edge predicates",
+                MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.PREDICATE))
+            .apply("Deduplicate Edge predicates", MissingEdgeNodesUtils.distinctValues());
+    PCollection<String> objectIds =
+        edgeRows
+            .apply(
+                "Extract Edge object_ids",
+                MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.OBJECT_ID))
+            .apply("Deduplicate Edge object_ids", MissingEdgeNodesUtils.distinctValues());
+    PCollection<String> provenances =
+        edgeRows
+            .apply(
+                "Extract Edge provenances",
+                MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.PROVENANCE))
+            .apply("Deduplicate Edge provenances", MissingEdgeNodesUtils.distinctValues());
+
+    if (options.getWriteDedupedInputs()) {
+      writeDedupedValues(
+          subjectIds, "subject_ids", outputPrefix(options.getOutputLocation(), "distinct-nodes"));
+      writeDedupedValues(
+          predicates,
+          "predicates",
+          outputPrefix(options.getOutputLocation(), "distinct-predicates"));
+      writeDedupedValues(
+          objectIds,
+          "object_ids",
+          outputPrefix(options.getOutputLocation(), "distinct-object-ids"));
+      writeDedupedValues(
+          provenances,
+          "provenances",
+          outputPrefix(options.getOutputLocation(), "distinct-provenances"));
+    }
+
     PCollection<KV<String, String>> edgeCandidates =
-        pipeline
-            .apply("Read Edge identifiers", spannerRead(options, EDGE_QUERY))
-            .apply("Extract Edge candidates", MissingEdgeNodesUtils.edgeCandidates())
-            .apply("Deduplicate Edge candidates", MissingEdgeNodesUtils.distinctCandidates());
+        PCollectionList.of(
+                subjectIds.apply(
+                    "Convert subject_ids to candidates",
+                    MissingEdgeNodesUtils.toCandidates(MissingEdgeNodesUtils.SUBJECT_ID)))
+            .and(
+                predicates.apply(
+                    "Convert predicates to candidates",
+                    MissingEdgeNodesUtils.toCandidates(MissingEdgeNodesUtils.PREDICATE)))
+            .and(
+                objectIds.apply(
+                    "Convert object_ids to candidates",
+                    MissingEdgeNodesUtils.toCandidates(MissingEdgeNodesUtils.OBJECT_ID)))
+            .and(
+                provenances.apply(
+                    "Convert provenances to candidates",
+                    MissingEdgeNodesUtils.toCandidates(MissingEdgeNodesUtils.PROVENANCE)))
+            .apply("Flatten Edge candidates", Flatten.pCollections());
 
     MissingEdgeNodesUtils.findMissingCandidates(edgeCandidates, nodeKeys)
         .apply("Format CSV rows", MissingEdgeNodesUtils.formatCsvRows())
         .apply(
             "Write missing dcids",
             TextIO.write()
-                .to(options.getOutputLocation() + "/missing-edge-node-dcids")
+                .to(outputPrefix(options.getOutputLocation(), "missing-edge-node-dcids"))
                 .withSuffix(".csv")
                 .withHeader(OUTPUT_HEADER));
 
@@ -48,5 +110,16 @@ public class MissingEdgeNodesPipeline {
         .withInstanceId(options.getSpannerInstanceId())
         .withDatabaseId(options.getSpannerDatabaseId())
         .withQuery(query);
+  }
+
+  private static void writeDedupedValues(
+      PCollection<String> values, String label, String outputPath) {
+    values
+        .apply("Format distinct " + label, MissingEdgeNodesUtils.formatCsvValues())
+        .apply("Write distinct " + label, TextIO.write().to(outputPath).withSuffix(".csv"));
+  }
+
+  private static String outputPrefix(String outputLocation, String resultFolder) {
+    return outputLocation + "/" + resultFolder + "/" + PART_PREFIX;
   }
 }

--- a/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesPipeline.java
+++ b/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesPipeline.java
@@ -5,10 +5,8 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionList;
 
 /** Dataflow pipeline for finding Edge identifiers missing from Node.subject_id. */
 public class MissingEdgeNodesPipeline {
@@ -41,7 +39,6 @@ public class MissingEdgeNodesPipeline {
             .apply(
                 "Extract Node subject_ids",
                 MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.SUBJECT_ID))
-            .apply("Deduplicate Node subject_ids", MissingEdgeNodesUtils.distinctValues())
             .apply(
                 "Count distinct Node subject_ids",
                 MissingEdgeNodesUtils.countStringValues(DISTINCT_NODE_SUBJECT_IDS));
@@ -55,42 +52,17 @@ public class MissingEdgeNodesPipeline {
                 "Count Spanner Edge rows",
                 MissingEdgeNodesUtils.countStructRows(SPANNER_EDGE_ROWS_READ));
 
-    PCollection<String> subjectIds =
+    PCollection<KV<String, String>> edgeCandidates =
         edgeRows
+            .apply("Extract Edge candidates", MissingEdgeNodesUtils.extractCandidates())
+            .apply("Deduplicate Edge candidates", MissingEdgeNodesUtils.distinctValues())
             .apply(
-                "Extract Edge subject_ids",
-                MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.SUBJECT_ID))
-            .apply("Deduplicate Edge subject_ids", MissingEdgeNodesUtils.distinctValues())
-            .apply(
-                "Count distinct Edge subject_ids",
-                MissingEdgeNodesUtils.countStringValues(DISTINCT_EDGE_SUBJECT_IDS));
-    PCollection<String> predicates =
-        edgeRows
-            .apply(
-                "Extract Edge predicates",
-                MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.PREDICATE))
-            .apply("Deduplicate Edge predicates", MissingEdgeNodesUtils.distinctValues())
-            .apply(
-                "Count distinct Edge predicates",
-                MissingEdgeNodesUtils.countStringValues(DISTINCT_PREDICATES));
-    PCollection<String> objectIds =
-        edgeRows
-            .apply(
-                "Extract Edge object_ids",
-                MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.OBJECT_ID))
-            .apply("Deduplicate Edge object_ids", MissingEdgeNodesUtils.distinctValues())
-            .apply(
-                "Count distinct Edge object_ids",
-                MissingEdgeNodesUtils.countStringValues(DISTINCT_OBJECT_IDS));
-    PCollection<String> provenances =
-        edgeRows
-            .apply(
-                "Extract Edge provenances",
-                MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.PROVENANCE))
-            .apply("Deduplicate Edge provenances", MissingEdgeNodesUtils.distinctValues())
-            .apply(
-                "Count distinct Edge provenances",
-                MissingEdgeNodesUtils.countStringValues(DISTINCT_PROVENANCES));
+                "Count distinct Edge candidate types",
+                MissingEdgeNodesUtils.countCandidateTypes(
+                    DISTINCT_EDGE_SUBJECT_IDS,
+                    DISTINCT_PREDICATES,
+                    DISTINCT_OBJECT_IDS,
+                    DISTINCT_PROVENANCES));
 
     if (options.getWriteDedupedInputs()) {
       writeDedupedValues(
@@ -98,41 +70,30 @@ public class MissingEdgeNodesPipeline {
           "node_subject_ids",
           outputPrefix(options.getOutputLocation(), "distinct-node-subject-ids"));
       writeDedupedValues(
-          subjectIds,
+          edgeCandidates.apply(
+              "Filter distinct Edge subject_ids",
+              MissingEdgeNodesUtils.filterAndExtractKeys(MissingEdgeNodesUtils.SUBJECT_ID)),
           "edge_subject_ids",
           outputPrefix(options.getOutputLocation(), "distinct-edge-subject-ids"));
       writeDedupedValues(
-          predicates,
+          edgeCandidates.apply(
+              "Filter distinct predicates",
+              MissingEdgeNodesUtils.filterAndExtractKeys(MissingEdgeNodesUtils.PREDICATE)),
           "predicates",
           outputPrefix(options.getOutputLocation(), "distinct-predicates"));
       writeDedupedValues(
-          objectIds,
+          edgeCandidates.apply(
+              "Filter distinct object_ids",
+              MissingEdgeNodesUtils.filterAndExtractKeys(MissingEdgeNodesUtils.OBJECT_ID)),
           "object_ids",
           outputPrefix(options.getOutputLocation(), "distinct-object-ids"));
       writeDedupedValues(
-          provenances,
+          edgeCandidates.apply(
+              "Filter distinct provenances",
+              MissingEdgeNodesUtils.filterAndExtractKeys(MissingEdgeNodesUtils.PROVENANCE)),
           "provenances",
           outputPrefix(options.getOutputLocation(), "distinct-provenances"));
     }
-
-    PCollection<KV<String, String>> edgeCandidates =
-        PCollectionList.of(
-                subjectIds.apply(
-                    "Convert subject_ids to candidates",
-                    MissingEdgeNodesUtils.toCandidates(MissingEdgeNodesUtils.SUBJECT_ID)))
-            .and(
-                predicates.apply(
-                    "Convert predicates to candidates",
-                    MissingEdgeNodesUtils.toCandidates(MissingEdgeNodesUtils.PREDICATE)))
-            .and(
-                objectIds.apply(
-                    "Convert object_ids to candidates",
-                    MissingEdgeNodesUtils.toCandidates(MissingEdgeNodesUtils.OBJECT_ID)))
-            .and(
-                provenances.apply(
-                    "Convert provenances to candidates",
-                    MissingEdgeNodesUtils.toCandidates(MissingEdgeNodesUtils.PROVENANCE)))
-            .apply("Flatten Edge candidates", Flatten.pCollections());
 
     MissingEdgeNodesUtils.findMissingCandidates(edgeCandidates, nodeKeys)
         .apply("Format CSV rows", MissingEdgeNodesUtils.formatCsvRows())

--- a/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtils.java
+++ b/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtils.java
@@ -22,7 +22,7 @@ class MissingEdgeNodesUtils {
 
   private MissingEdgeNodesUtils() {}
 
-  static ParDo.SingleOutput<Struct, KV<String, String>> nodeKeys() {
+  static ParDo.SingleOutput<String, KV<String, String>> nodeKeys() {
     return ParDo.of(new NodeKeyFn());
   }
 
@@ -78,10 +78,10 @@ class MissingEdgeNodesUtils {
     return "\"" + value.replace("\"", "\"\"") + "\"";
   }
 
-  static class NodeKeyFn extends DoFn<Struct, KV<String, String>> {
+  static class NodeKeyFn extends DoFn<String, KV<String, String>> {
     @ProcessElement
     public void processElement(ProcessContext context) {
-      String subjectId = nullableString(context.element(), SUBJECT_ID);
+      String subjectId = context.element();
       if (hasValue(subjectId)) {
         context.output(KV.of(subjectId, NODE_MARKER));
       }

--- a/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtils.java
+++ b/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtils.java
@@ -26,12 +26,16 @@ class MissingEdgeNodesUtils {
     return ParDo.of(new NodeKeyFn());
   }
 
-  static ParDo.SingleOutput<Struct, KV<String, String>> edgeCandidates() {
-    return ParDo.of(new EdgeCandidateFn());
+  static ParDo.SingleOutput<Struct, String> extractColumn(String columnName) {
+    return ParDo.of(new ExtractColumnFn(columnName));
   }
 
-  static Distinct<KV<String, String>> distinctCandidates() {
+  static Distinct<String> distinctValues() {
     return Distinct.create();
+  }
+
+  static ParDo.SingleOutput<String, KV<String, String>> toCandidates(String type) {
+    return ParDo.of(new CandidateFn(type));
   }
 
   static PCollection<KV<String, String>> findMissingCandidates(
@@ -47,6 +51,10 @@ class MissingEdgeNodesUtils {
 
   static ParDo.SingleOutput<KV<String, String>, String> formatCsvRows() {
     return ParDo.of(new FormatCsvRowFn());
+  }
+
+  static ParDo.SingleOutput<String, String> formatCsvValues() {
+    return ParDo.of(new FormatCsvValueFn());
   }
 
   private static boolean hasValue(String value) {
@@ -80,26 +88,32 @@ class MissingEdgeNodesUtils {
     }
   }
 
-  static class EdgeCandidateFn extends DoFn<Struct, KV<String, String>> {
+  static class ExtractColumnFn extends DoFn<Struct, String> {
+    private final String columnName;
+
+    ExtractColumnFn(String columnName) {
+      this.columnName = columnName;
+    }
+
     @ProcessElement
     public void processElement(ProcessContext context) {
-      Struct row = context.element();
-      String subjectId = nullableString(row, SUBJECT_ID);
-      String predicate = nullableString(row, PREDICATE);
-      String objectId = nullableString(row, OBJECT_ID);
-      String provenance = nullableString(row, PROVENANCE);
-      if (hasValue(subjectId)) {
-        context.output(KV.of(subjectId, SUBJECT_ID));
+      String value = nullableString(context.element(), columnName);
+      if (hasValue(value)) {
+        context.output(value);
       }
-      if (hasValue(predicate)) {
-        context.output(KV.of(predicate, PREDICATE));
-      }
-      if (hasValue(objectId)) {
-        context.output(KV.of(objectId, OBJECT_ID));
-      }
-      if (hasValue(provenance)) {
-        context.output(KV.of(provenance, PROVENANCE));
-      }
+    }
+  }
+
+  static class CandidateFn extends DoFn<String, KV<String, String>> {
+    private final String type;
+
+    CandidateFn(String type) {
+      this.type = type;
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      context.output(KV.of(context.element(), type));
     }
   }
 
@@ -129,6 +143,13 @@ class MissingEdgeNodesUtils {
     public void processElement(ProcessContext context) {
       KV<String, String> input = context.element();
       context.output(escapeCsv(input.getKey()) + "," + escapeCsv(input.getValue()));
+    }
+  }
+
+  static class FormatCsvValueFn extends DoFn<String, String> {
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      context.output(escapeCsv(context.element()));
     }
   }
 }

--- a/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtils.java
+++ b/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtils.java
@@ -40,12 +40,29 @@ class MissingEdgeNodesUtils {
     return ParDo.of(new ExtractColumnFn(columnName));
   }
 
-  static Distinct<String> distinctValues() {
+  static <T> Distinct<T> distinctValues() {
     return Distinct.create();
   }
 
-  static ParDo.SingleOutput<String, KV<String, String>> toCandidates(String type) {
-    return ParDo.of(new CandidateFn(type));
+  static ParDo.SingleOutput<Struct, KV<String, String>> extractCandidates() {
+    return ParDo.of(new ExtractCandidatesFn());
+  }
+
+  static ParDo.SingleOutput<KV<String, String>, KV<String, String>> countCandidateTypes(
+      String subjectIdCounterName,
+      String predicateCounterName,
+      String objectIdCounterName,
+      String provenanceCounterName) {
+    return ParDo.of(
+        new CountCandidateTypesFn(
+            subjectIdCounterName,
+            predicateCounterName,
+            objectIdCounterName,
+            provenanceCounterName));
+  }
+
+  static ParDo.SingleOutput<KV<String, String>, String> filterAndExtractKeys(String type) {
+    return ParDo.of(new FilterAndExtractKeysFn(type));
   }
 
   static PCollection<KV<String, String>> findMissingCandidates(
@@ -136,16 +153,106 @@ class MissingEdgeNodesUtils {
     }
   }
 
-  static class CandidateFn extends DoFn<String, KV<String, String>> {
+  static class ExtractCandidatesFn extends DoFn<Struct, KV<String, String>> {
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      Struct row = context.element();
+      outputIfValid(context, row, SUBJECT_ID);
+      outputIfValid(context, row, PREDICATE);
+      outputIfValid(context, row, OBJECT_ID);
+      outputIfValid(context, row, PROVENANCE);
+    }
+
+    private void outputIfValid(ProcessContext context, Struct row, String columnName) {
+      String value = nullableString(row, columnName);
+      if (hasValue(value)) {
+        context.output(KV.of(value, columnName));
+      }
+    }
+  }
+
+  static class CountCandidateTypesFn extends DoFn<KV<String, String>, KV<String, String>> {
+    private final String subjectIdCounterName;
+    private final String predicateCounterName;
+    private final String objectIdCounterName;
+    private final String provenanceCounterName;
+    private transient Counter subjectIdCounter;
+    private transient Counter predicateCounter;
+    private transient Counter objectIdCounter;
+    private transient Counter provenanceCounter;
+
+    CountCandidateTypesFn(
+        String subjectIdCounterName,
+        String predicateCounterName,
+        String objectIdCounterName,
+        String provenanceCounterName) {
+      this.subjectIdCounterName = subjectIdCounterName;
+      this.predicateCounterName = predicateCounterName;
+      this.objectIdCounterName = objectIdCounterName;
+      this.provenanceCounterName = provenanceCounterName;
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      KV<String, String> candidate = context.element();
+      incrementCounter(candidate.getValue());
+      context.output(candidate);
+    }
+
+    private void incrementCounter(String type) {
+      if (SUBJECT_ID.equals(type)) {
+        getSubjectIdCounter().inc();
+      } else if (PREDICATE.equals(type)) {
+        getPredicateCounter().inc();
+      } else if (OBJECT_ID.equals(type)) {
+        getObjectIdCounter().inc();
+      } else if (PROVENANCE.equals(type)) {
+        getProvenanceCounter().inc();
+      }
+    }
+
+    private Counter getSubjectIdCounter() {
+      if (subjectIdCounter == null) {
+        subjectIdCounter = Metrics.counter(MissingEdgeNodesUtils.class, subjectIdCounterName);
+      }
+      return subjectIdCounter;
+    }
+
+    private Counter getPredicateCounter() {
+      if (predicateCounter == null) {
+        predicateCounter = Metrics.counter(MissingEdgeNodesUtils.class, predicateCounterName);
+      }
+      return predicateCounter;
+    }
+
+    private Counter getObjectIdCounter() {
+      if (objectIdCounter == null) {
+        objectIdCounter = Metrics.counter(MissingEdgeNodesUtils.class, objectIdCounterName);
+      }
+      return objectIdCounter;
+    }
+
+    private Counter getProvenanceCounter() {
+      if (provenanceCounter == null) {
+        provenanceCounter = Metrics.counter(MissingEdgeNodesUtils.class, provenanceCounterName);
+      }
+      return provenanceCounter;
+    }
+  }
+
+  static class FilterAndExtractKeysFn extends DoFn<KV<String, String>, String> {
     private final String type;
 
-    CandidateFn(String type) {
+    FilterAndExtractKeysFn(String type) {
       this.type = type;
     }
 
     @ProcessElement
     public void processElement(ProcessContext context) {
-      context.output(KV.of(context.element(), type));
+      KV<String, String> candidate = context.element();
+      if (type.equals(candidate.getValue())) {
+        context.output(candidate.getKey());
+      }
     }
   }
 

--- a/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtils.java
+++ b/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtils.java
@@ -1,6 +1,8 @@
 package org.datacommons.ingestion.missingnodes;
 
 import com.google.cloud.spanner.Struct;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.Distinct;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -24,6 +26,14 @@ class MissingEdgeNodesUtils {
 
   static ParDo.SingleOutput<String, KV<String, String>> nodeKeys() {
     return ParDo.of(new NodeKeyFn());
+  }
+
+  static ParDo.SingleOutput<Struct, Struct> countStructRows(String counterName) {
+    return ParDo.of(new CountElementsFn<>(counterName));
+  }
+
+  static ParDo.SingleOutput<String, String> countStringValues(String counterName) {
+    return ParDo.of(new CountElementsFn<>(counterName));
   }
 
   static ParDo.SingleOutput<Struct, String> extractColumn(String columnName) {
@@ -85,6 +95,28 @@ class MissingEdgeNodesUtils {
       if (hasValue(subjectId)) {
         context.output(KV.of(subjectId, NODE_MARKER));
       }
+    }
+  }
+
+  static class CountElementsFn<T> extends DoFn<T, T> {
+    private final String counterName;
+    private transient Counter counter;
+
+    CountElementsFn(String counterName) {
+      this.counterName = counterName;
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      getCounter().inc();
+      context.output(context.element());
+    }
+
+    private Counter getCounter() {
+      if (counter == null) {
+        counter = Metrics.counter(MissingEdgeNodesUtils.class, counterName);
+      }
+      return counter;
     }
   }
 

--- a/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtils.java
+++ b/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtils.java
@@ -1,0 +1,134 @@
+package org.datacommons.ingestion.missingnodes;
+
+import com.google.cloud.spanner.Struct;
+import org.apache.beam.sdk.transforms.Distinct;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.join.CoGbkResult;
+import org.apache.beam.sdk.transforms.join.CoGroupByKey;
+import org.apache.beam.sdk.transforms.join.KeyedPCollectionTuple;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TupleTag;
+
+/** Utility transforms for the missing Edge dcids pipeline. */
+class MissingEdgeNodesUtils {
+  static final String SUBJECT_ID = "subject_id";
+  static final String PREDICATE = "predicate";
+  static final String OBJECT_ID = "object_id";
+  static final String PROVENANCE = "provenance";
+
+  private static final String NODE_MARKER = "node";
+
+  private MissingEdgeNodesUtils() {}
+
+  static ParDo.SingleOutput<Struct, KV<String, String>> nodeKeys() {
+    return ParDo.of(new NodeKeyFn());
+  }
+
+  static ParDo.SingleOutput<Struct, KV<String, String>> edgeCandidates() {
+    return ParDo.of(new EdgeCandidateFn());
+  }
+
+  static Distinct<KV<String, String>> distinctCandidates() {
+    return Distinct.create();
+  }
+
+  static PCollection<KV<String, String>> findMissingCandidates(
+      PCollection<KV<String, String>> edgeCandidates, PCollection<KV<String, String>> nodeKeys) {
+    TupleTag<String> edgeTag = new TupleTag<>();
+    TupleTag<String> nodeTag = new TupleTag<>();
+
+    return KeyedPCollectionTuple.of(edgeTag, edgeCandidates)
+        .and(nodeTag, nodeKeys)
+        .apply("Join Edge candidates to Node keys", CoGroupByKey.create())
+        .apply("Keep candidates without Node", ParDo.of(new MissingCandidateFn(edgeTag, nodeTag)));
+  }
+
+  static ParDo.SingleOutput<KV<String, String>, String> formatCsvRows() {
+    return ParDo.of(new FormatCsvRowFn());
+  }
+
+  private static boolean hasValue(String value) {
+    return value != null && !value.isEmpty();
+  }
+
+  private static String nullableString(Struct row, String columnName) {
+    if (row.isNull(columnName)) {
+      return null;
+    }
+    return row.getString(columnName);
+  }
+
+  private static String escapeCsv(String value) {
+    if (value.indexOf(',') < 0
+        && value.indexOf('"') < 0
+        && value.indexOf('\n') < 0
+        && value.indexOf('\r') < 0) {
+      return value;
+    }
+    return "\"" + value.replace("\"", "\"\"") + "\"";
+  }
+
+  static class NodeKeyFn extends DoFn<Struct, KV<String, String>> {
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      String subjectId = nullableString(context.element(), SUBJECT_ID);
+      if (hasValue(subjectId)) {
+        context.output(KV.of(subjectId, NODE_MARKER));
+      }
+    }
+  }
+
+  static class EdgeCandidateFn extends DoFn<Struct, KV<String, String>> {
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      Struct row = context.element();
+      String subjectId = nullableString(row, SUBJECT_ID);
+      String predicate = nullableString(row, PREDICATE);
+      String objectId = nullableString(row, OBJECT_ID);
+      String provenance = nullableString(row, PROVENANCE);
+      if (hasValue(subjectId)) {
+        context.output(KV.of(subjectId, SUBJECT_ID));
+      }
+      if (hasValue(predicate)) {
+        context.output(KV.of(predicate, PREDICATE));
+      }
+      if (hasValue(objectId)) {
+        context.output(KV.of(objectId, OBJECT_ID));
+      }
+      if (hasValue(provenance)) {
+        context.output(KV.of(provenance, PROVENANCE));
+      }
+    }
+  }
+
+  static class MissingCandidateFn extends DoFn<KV<String, CoGbkResult>, KV<String, String>> {
+    private final TupleTag<String> edgeTag;
+    private final TupleTag<String> nodeTag;
+
+    MissingCandidateFn(TupleTag<String> edgeTag, TupleTag<String> nodeTag) {
+      this.edgeTag = edgeTag;
+      this.nodeTag = nodeTag;
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      KV<String, CoGbkResult> input = context.element();
+      if (input.getValue().getAll(nodeTag).iterator().hasNext()) {
+        return;
+      }
+      for (String type : input.getValue().getAll(edgeTag)) {
+        context.output(KV.of(input.getKey(), type));
+      }
+    }
+  }
+
+  static class FormatCsvRowFn extends DoFn<KV<String, String>, String> {
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      KV<String, String> input = context.element();
+      context.output(escapeCsv(input.getKey()) + "," + escapeCsv(input.getValue()));
+    }
+  }
+}

--- a/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtils.java
+++ b/pipeline/missing-edge-nodes/src/main/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtils.java
@@ -48,13 +48,13 @@ class MissingEdgeNodesUtils {
     return ParDo.of(new ExtractCandidatesFn());
   }
 
-  static ParDo.SingleOutput<KV<String, String>, KV<String, String>> countCandidateTypes(
+  static ParDo.SingleOutput<KV<String, String>, KV<String, String>> countTypedValues(
       String subjectIdCounterName,
       String predicateCounterName,
       String objectIdCounterName,
       String provenanceCounterName) {
     return ParDo.of(
-        new CountCandidateTypesFn(
+        new CountTypedValuesFn(
             subjectIdCounterName,
             predicateCounterName,
             objectIdCounterName,
@@ -171,7 +171,7 @@ class MissingEdgeNodesUtils {
     }
   }
 
-  static class CountCandidateTypesFn extends DoFn<KV<String, String>, KV<String, String>> {
+  static class CountTypedValuesFn extends DoFn<KV<String, String>, KV<String, String>> {
     private final String subjectIdCounterName;
     private final String predicateCounterName;
     private final String objectIdCounterName;
@@ -181,7 +181,7 @@ class MissingEdgeNodesUtils {
     private transient Counter objectIdCounter;
     private transient Counter provenanceCounter;
 
-    CountCandidateTypesFn(
+    CountTypedValuesFn(
         String subjectIdCounterName,
         String predicateCounterName,
         String objectIdCounterName,

--- a/pipeline/missing-edge-nodes/src/test/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtilsTest.java
+++ b/pipeline/missing-edge-nodes/src/test/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtilsTest.java
@@ -1,0 +1,118 @@
+package org.datacommons.ingestion.missingnodes;
+
+import com.google.cloud.spanner.Struct;
+import java.util.Arrays;
+import org.apache.beam.runners.direct.DirectRunner;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MissingEdgeNodesUtilsTest {
+  private final PipelineOptions options = PipelineOptionsFactory.create();
+  @Rule public TestPipeline pipeline = TestPipeline.fromOptions(options);
+
+  @Test
+  public void edgeCandidatesEmitsAllNonEmptyValues() {
+    options.setStableUniqueNames(PipelineOptions.CheckEnabled.OFF);
+    options.setRunner(DirectRunner.class);
+
+    PCollection<KV<String, String>> candidates =
+        pipeline
+            .apply(
+                Create.of(
+                    Struct.newBuilder()
+                        .set(MissingEdgeNodesUtils.SUBJECT_ID)
+                        .to("subject")
+                        .set(MissingEdgeNodesUtils.PREDICATE)
+                        .to("predicate")
+                        .set(MissingEdgeNodesUtils.OBJECT_ID)
+                        .to("object")
+                        .set(MissingEdgeNodesUtils.PROVENANCE)
+                        .to("provenance")
+                        .build(),
+                    Struct.newBuilder()
+                        .set(MissingEdgeNodesUtils.SUBJECT_ID)
+                        .to("")
+                        .set(MissingEdgeNodesUtils.PREDICATE)
+                        .to("predicate2")
+                        .set(MissingEdgeNodesUtils.OBJECT_ID)
+                        .to("")
+                        .set(MissingEdgeNodesUtils.PROVENANCE)
+                        .to("provenance2")
+                        .build()))
+            .apply(MissingEdgeNodesUtils.edgeCandidates());
+
+    PAssert.that(candidates)
+        .containsInAnyOrder(
+            Arrays.asList(
+                KV.of("subject", MissingEdgeNodesUtils.SUBJECT_ID),
+                KV.of("predicate", MissingEdgeNodesUtils.PREDICATE),
+                KV.of("object", MissingEdgeNodesUtils.OBJECT_ID),
+                KV.of("provenance", MissingEdgeNodesUtils.PROVENANCE),
+                KV.of("predicate2", MissingEdgeNodesUtils.PREDICATE),
+                KV.of("provenance2", MissingEdgeNodesUtils.PROVENANCE)));
+
+    pipeline.run();
+  }
+
+  @Test
+  public void findMissingCandidatesFiltersExistingNodesAndKeepsDistinctTypes() {
+    options.setStableUniqueNames(PipelineOptions.CheckEnabled.OFF);
+    options.setRunner(DirectRunner.class);
+
+    PCollection<KV<String, String>> edgeCandidates =
+        pipeline.apply(
+            "Create edge candidates",
+            Create.<KV<String, String>>of(
+                KV.of("exists", MissingEdgeNodesUtils.SUBJECT_ID),
+                KV.of("missing", MissingEdgeNodesUtils.OBJECT_ID),
+                KV.of("missing", MissingEdgeNodesUtils.PROVENANCE),
+                KV.of("missing", MissingEdgeNodesUtils.PROVENANCE)));
+    PCollection<KV<String, String>> nodeKeys =
+        pipeline.apply("Create node keys", Create.<KV<String, String>>of(KV.of("exists", "node")));
+
+    PCollection<KV<String, String>> missing =
+        MissingEdgeNodesUtils.findMissingCandidates(
+            edgeCandidates.apply(MissingEdgeNodesUtils.distinctCandidates()), nodeKeys);
+
+    PAssert.that(missing)
+        .containsInAnyOrder(
+            Arrays.asList(
+                KV.of("missing", MissingEdgeNodesUtils.OBJECT_ID),
+                KV.of("missing", MissingEdgeNodesUtils.PROVENANCE)));
+
+    pipeline.run();
+  }
+
+  @Test
+  public void formatCsvRowsEscapesSpecialCharacters() {
+    options.setStableUniqueNames(PipelineOptions.CheckEnabled.OFF);
+    options.setRunner(DirectRunner.class);
+
+    PCollection<String> rows =
+        pipeline
+            .apply(
+                Create.<KV<String, String>>of(
+                    KV.of("plain", MissingEdgeNodesUtils.SUBJECT_ID),
+                    KV.of("has,comma", MissingEdgeNodesUtils.PREDICATE),
+                    KV.of("has\"quote", MissingEdgeNodesUtils.OBJECT_ID),
+                    KV.of("has\nnewline", MissingEdgeNodesUtils.PROVENANCE)))
+            .apply(MissingEdgeNodesUtils.formatCsvRows());
+
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            Arrays.asList(
+                "plain,subject_id",
+                "\"has,comma\",predicate",
+                "\"has\"\"quote\",object_id",
+                "\"has\nnewline\",provenance"));
+
+    pipeline.run();
+  }
+}

--- a/pipeline/missing-edge-nodes/src/test/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtilsTest.java
+++ b/pipeline/missing-edge-nodes/src/test/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtilsTest.java
@@ -8,8 +8,10 @@ import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -18,68 +20,77 @@ public class MissingEdgeNodesUtilsTest {
   @Rule public TestPipeline pipeline = TestPipeline.fromOptions(options);
 
   @Test
-  public void edgeCandidatesEmitsAllNonEmptyValues() {
+  public void extractColumnFiltersEmptyValues() {
     options.setStableUniqueNames(PipelineOptions.CheckEnabled.OFF);
     options.setRunner(DirectRunner.class);
 
-    PCollection<KV<String, String>> candidates =
-        pipeline
-            .apply(
-                Create.of(
-                    Struct.newBuilder()
-                        .set(MissingEdgeNodesUtils.SUBJECT_ID)
-                        .to("subject")
-                        .set(MissingEdgeNodesUtils.PREDICATE)
-                        .to("predicate")
-                        .set(MissingEdgeNodesUtils.OBJECT_ID)
-                        .to("object")
-                        .set(MissingEdgeNodesUtils.PROVENANCE)
-                        .to("provenance")
-                        .build(),
-                    Struct.newBuilder()
-                        .set(MissingEdgeNodesUtils.SUBJECT_ID)
-                        .to("")
-                        .set(MissingEdgeNodesUtils.PREDICATE)
-                        .to("predicate2")
-                        .set(MissingEdgeNodesUtils.OBJECT_ID)
-                        .to("")
-                        .set(MissingEdgeNodesUtils.PROVENANCE)
-                        .to("provenance2")
-                        .build()))
-            .apply(MissingEdgeNodesUtils.edgeCandidates());
+    PCollection<Struct> edgeRows =
+        pipeline.apply(
+            Create.of(
+                Struct.newBuilder()
+                    .set(MissingEdgeNodesUtils.SUBJECT_ID)
+                    .to("subject")
+                    .set(MissingEdgeNodesUtils.PREDICATE)
+                    .to("predicate")
+                    .set(MissingEdgeNodesUtils.OBJECT_ID)
+                    .to("object")
+                    .set(MissingEdgeNodesUtils.PROVENANCE)
+                    .to("provenance")
+                    .build(),
+                Struct.newBuilder()
+                    .set(MissingEdgeNodesUtils.SUBJECT_ID)
+                    .to("")
+                    .set(MissingEdgeNodesUtils.PREDICATE)
+                    .to("predicate2")
+                    .set(MissingEdgeNodesUtils.OBJECT_ID)
+                    .to("")
+                    .set(MissingEdgeNodesUtils.PROVENANCE)
+                    .to("provenance2")
+                    .build()));
 
-    PAssert.that(candidates)
-        .containsInAnyOrder(
-            Arrays.asList(
-                KV.of("subject", MissingEdgeNodesUtils.SUBJECT_ID),
-                KV.of("predicate", MissingEdgeNodesUtils.PREDICATE),
-                KV.of("object", MissingEdgeNodesUtils.OBJECT_ID),
-                KV.of("provenance", MissingEdgeNodesUtils.PROVENANCE),
-                KV.of("predicate2", MissingEdgeNodesUtils.PREDICATE),
-                KV.of("provenance2", MissingEdgeNodesUtils.PROVENANCE)));
+    PAssert.that(
+            edgeRows.apply(MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.SUBJECT_ID)))
+        .containsInAnyOrder(Arrays.asList("subject"));
+    PAssert.that(
+            edgeRows.apply(MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.PREDICATE)))
+        .containsInAnyOrder(Arrays.asList("predicate", "predicate2"));
+    PAssert.that(
+            edgeRows.apply(MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.OBJECT_ID)))
+        .containsInAnyOrder(Arrays.asList("object"));
+    PAssert.that(
+            edgeRows.apply(MissingEdgeNodesUtils.extractColumn(MissingEdgeNodesUtils.PROVENANCE)))
+        .containsInAnyOrder(Arrays.asList("provenance", "provenance2"));
 
     pipeline.run();
   }
 
   @Test
-  public void findMissingCandidatesFiltersExistingNodesAndKeepsDistinctTypes() {
+  public void findMissingCandidatesUsesDistinctTypedStreams() {
     options.setStableUniqueNames(PipelineOptions.CheckEnabled.OFF);
     options.setRunner(DirectRunner.class);
 
+    PCollection<String> objectIds =
+        pipeline
+            .apply("Create object ids", Create.of("missing", "missing"))
+            .apply(MissingEdgeNodesUtils.distinctValues());
+    PCollection<String> provenances =
+        pipeline
+            .apply("Create provenances", Create.of("missing", "missing2"))
+            .apply(MissingEdgeNodesUtils.distinctValues());
     PCollection<KV<String, String>> edgeCandidates =
-        pipeline.apply(
-            "Create edge candidates",
-            Create.<KV<String, String>>of(
-                KV.of("exists", MissingEdgeNodesUtils.SUBJECT_ID),
-                KV.of("missing", MissingEdgeNodesUtils.OBJECT_ID),
-                KV.of("missing", MissingEdgeNodesUtils.PROVENANCE),
-                KV.of("missing", MissingEdgeNodesUtils.PROVENANCE)));
+        PCollectionList.of(
+                objectIds.apply(
+                    MissingEdgeNodesUtils.toCandidates(MissingEdgeNodesUtils.OBJECT_ID)))
+            .and(
+                provenances.apply(
+                    MissingEdgeNodesUtils.toCandidates(MissingEdgeNodesUtils.PROVENANCE)))
+            .apply(Flatten.pCollections());
     PCollection<KV<String, String>> nodeKeys =
-        pipeline.apply("Create node keys", Create.<KV<String, String>>of(KV.of("exists", "node")));
+        pipeline.apply(
+            "Create node keys", Create.<KV<String, String>>of(KV.of("missing2", "node")));
 
     PCollection<KV<String, String>> missing =
-        MissingEdgeNodesUtils.findMissingCandidates(
-            edgeCandidates.apply(MissingEdgeNodesUtils.distinctCandidates()), nodeKeys);
+        MissingEdgeNodesUtils.findMissingCandidates(edgeCandidates, nodeKeys);
 
     PAssert.that(missing)
         .containsInAnyOrder(
@@ -91,7 +102,7 @@ public class MissingEdgeNodesUtilsTest {
   }
 
   @Test
-  public void formatCsvRowsEscapesSpecialCharacters() {
+  public void formatCsvEscapesSpecialCharacters() {
     options.setStableUniqueNames(PipelineOptions.CheckEnabled.OFF);
     options.setRunner(DirectRunner.class);
 
@@ -112,6 +123,14 @@ public class MissingEdgeNodesUtilsTest {
                 "\"has,comma\",predicate",
                 "\"has\"\"quote\",object_id",
                 "\"has\nnewline\",provenance"));
+
+    PCollection<String> values =
+        pipeline
+            .apply("Create one-column values", Create.of("plain", "has,comma", "has\"quote"))
+            .apply(MissingEdgeNodesUtils.formatCsvValues());
+
+    PAssert.that(values)
+        .containsInAnyOrder(Arrays.asList("plain", "\"has,comma\"", "\"has\"\"quote\""));
 
     pipeline.run();
   }

--- a/pipeline/missing-edge-nodes/src/test/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtilsTest.java
+++ b/pipeline/missing-edge-nodes/src/test/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtilsTest.java
@@ -8,10 +8,8 @@ import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
-import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionList;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -69,22 +67,33 @@ public class MissingEdgeNodesUtilsTest {
     options.setStableUniqueNames(PipelineOptions.CheckEnabled.OFF);
     options.setRunner(DirectRunner.class);
 
-    PCollection<String> objectIds =
-        pipeline
-            .apply("Create object ids", Create.of("missing", "missing"))
-            .apply(MissingEdgeNodesUtils.distinctValues());
-    PCollection<String> provenances =
-        pipeline
-            .apply("Create provenances", Create.of("missing", "missing2"))
-            .apply(MissingEdgeNodesUtils.distinctValues());
+    PCollection<Struct> edgeRows =
+        pipeline.apply(
+            Create.of(
+                Struct.newBuilder()
+                    .set(MissingEdgeNodesUtils.SUBJECT_ID)
+                    .to("subj1")
+                    .set(MissingEdgeNodesUtils.PREDICATE)
+                    .to("pred1")
+                    .set(MissingEdgeNodesUtils.OBJECT_ID)
+                    .to("missing")
+                    .set(MissingEdgeNodesUtils.PROVENANCE)
+                    .to("missing")
+                    .build(),
+                Struct.newBuilder()
+                    .set(MissingEdgeNodesUtils.SUBJECT_ID)
+                    .to("subj2")
+                    .set(MissingEdgeNodesUtils.PREDICATE)
+                    .to("pred2")
+                    .set(MissingEdgeNodesUtils.OBJECT_ID)
+                    .to("missing")
+                    .set(MissingEdgeNodesUtils.PROVENANCE)
+                    .to("missing2")
+                    .build()));
     PCollection<KV<String, String>> edgeCandidates =
-        PCollectionList.of(
-                objectIds.apply(
-                    MissingEdgeNodesUtils.toCandidates(MissingEdgeNodesUtils.OBJECT_ID)))
-            .and(
-                provenances.apply(
-                    MissingEdgeNodesUtils.toCandidates(MissingEdgeNodesUtils.PROVENANCE)))
-            .apply(Flatten.pCollections());
+        edgeRows
+            .apply(MissingEdgeNodesUtils.extractCandidates())
+            .apply(MissingEdgeNodesUtils.distinctValues());
     PCollection<KV<String, String>> nodeKeys =
         pipeline
             .apply("Create node ids", Create.of("missing2"))
@@ -96,8 +105,31 @@ public class MissingEdgeNodesUtilsTest {
     PAssert.that(missing)
         .containsInAnyOrder(
             Arrays.asList(
+                KV.of("subj1", MissingEdgeNodesUtils.SUBJECT_ID),
+                KV.of("subj2", MissingEdgeNodesUtils.SUBJECT_ID),
+                KV.of("pred1", MissingEdgeNodesUtils.PREDICATE),
+                KV.of("pred2", MissingEdgeNodesUtils.PREDICATE),
                 KV.of("missing", MissingEdgeNodesUtils.OBJECT_ID),
                 KV.of("missing", MissingEdgeNodesUtils.PROVENANCE)));
+
+    pipeline.run();
+  }
+
+  @Test
+  public void filterAndExtractKeysKeepsOnlyRequestedType() {
+    options.setStableUniqueNames(PipelineOptions.CheckEnabled.OFF);
+    options.setRunner(DirectRunner.class);
+
+    PCollection<String> objectIds =
+        pipeline
+            .apply(
+                Create.<KV<String, String>>of(
+                    KV.of("subject", MissingEdgeNodesUtils.SUBJECT_ID),
+                    KV.of("object", MissingEdgeNodesUtils.OBJECT_ID),
+                    KV.of("predicate", MissingEdgeNodesUtils.PREDICATE)))
+            .apply(MissingEdgeNodesUtils.filterAndExtractKeys(MissingEdgeNodesUtils.OBJECT_ID));
+
+    PAssert.that(objectIds).containsInAnyOrder(Arrays.asList("object"));
 
     pipeline.run();
   }

--- a/pipeline/missing-edge-nodes/src/test/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtilsTest.java
+++ b/pipeline/missing-edge-nodes/src/test/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtilsTest.java
@@ -150,6 +150,34 @@ public class MissingEdgeNodesUtilsTest {
   }
 
   @Test
+  public void countTypedValuesPassesThroughElements() {
+    options.setStableUniqueNames(PipelineOptions.CheckEnabled.OFF);
+    options.setRunner(DirectRunner.class);
+
+    PCollection<KV<String, String>> values =
+        pipeline
+            .apply(
+                Create.<KV<String, String>>of(
+                    KV.of("subject", MissingEdgeNodesUtils.SUBJECT_ID),
+                    KV.of("predicate", MissingEdgeNodesUtils.PREDICATE),
+                    KV.of("object", MissingEdgeNodesUtils.OBJECT_ID),
+                    KV.of("provenance", MissingEdgeNodesUtils.PROVENANCE)))
+            .apply(
+                MissingEdgeNodesUtils.countTypedValues(
+                    "test_subject_ids", "test_predicates", "test_object_ids", "test_provenances"));
+
+    PAssert.that(values)
+        .containsInAnyOrder(
+            Arrays.asList(
+                KV.of("subject", MissingEdgeNodesUtils.SUBJECT_ID),
+                KV.of("predicate", MissingEdgeNodesUtils.PREDICATE),
+                KV.of("object", MissingEdgeNodesUtils.OBJECT_ID),
+                KV.of("provenance", MissingEdgeNodesUtils.PROVENANCE)));
+
+    pipeline.run();
+  }
+
+  @Test
   public void formatCsvEscapesSpecialCharacters() {
     options.setStableUniqueNames(PipelineOptions.CheckEnabled.OFF);
     options.setRunner(DirectRunner.class);

--- a/pipeline/missing-edge-nodes/src/test/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtilsTest.java
+++ b/pipeline/missing-edge-nodes/src/test/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtilsTest.java
@@ -103,6 +103,21 @@ public class MissingEdgeNodesUtilsTest {
   }
 
   @Test
+  public void countStringValuesPassesThroughElements() {
+    options.setStableUniqueNames(PipelineOptions.CheckEnabled.OFF);
+    options.setRunner(DirectRunner.class);
+
+    PCollection<String> values =
+        pipeline
+            .apply(Create.of("a", "b"))
+            .apply(MissingEdgeNodesUtils.countStringValues("test_distinct_values"));
+
+    PAssert.that(values).containsInAnyOrder(Arrays.asList("a", "b"));
+
+    pipeline.run();
+  }
+
+  @Test
   public void formatCsvEscapesSpecialCharacters() {
     options.setStableUniqueNames(PipelineOptions.CheckEnabled.OFF);
     options.setRunner(DirectRunner.class);

--- a/pipeline/missing-edge-nodes/src/test/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtilsTest.java
+++ b/pipeline/missing-edge-nodes/src/test/java/org/datacommons/ingestion/missingnodes/MissingEdgeNodesUtilsTest.java
@@ -86,8 +86,9 @@ public class MissingEdgeNodesUtilsTest {
                     MissingEdgeNodesUtils.toCandidates(MissingEdgeNodesUtils.PROVENANCE)))
             .apply(Flatten.pCollections());
     PCollection<KV<String, String>> nodeKeys =
-        pipeline.apply(
-            "Create node keys", Create.<KV<String, String>>of(KV.of("missing2", "node")));
+        pipeline
+            .apply("Create node ids", Create.of("missing2"))
+            .apply(MissingEdgeNodesUtils.nodeKeys());
 
     PCollection<KV<String, String>> missing =
         MissingEdgeNodesUtils.findMissingCandidates(edgeCandidates, nodeKeys);

--- a/pipeline/pom.xml
+++ b/pipeline/pom.xml
@@ -21,6 +21,7 @@
     <module>data</module>
     <module>differ</module>
     <module>ingestion</module>
+    <module>missing-edge-nodes</module>
     <module>spanner</module>
     <module>util</module>
   </modules>


### PR DESCRIPTION
 ## Summary
  - Add a migration-only Dataflow pipeline to find Edge identifiers missing from Node.subject_id
  - Write missing dcids as `dcid,type`
  - Optionally write deduplicated audit outputs for Node subject IDs and Edge subject/predicate/object/provenance values

  ## Outputs
  - `missing-edge-node-dcids/part-*.csv`
  - `distinct-node-subject-ids/part-*.csv`
  - `distinct-edge-subject-ids/part-*.csv`
  - `distinct-predicates/part-*.csv`
  - `distinct-object-ids/part-*.csv`
  - `distinct-provenances/part-*.csv`
