### PR TITLE
[DCP SVG ] Seed the DB with c/g/Root and edge to dc/g/Root

### DIFF
--- a/pipeline/workflow/ingestion-helper/clients/spanner.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner.py
@@ -590,13 +590,13 @@ class SpannerClient:
 
             # 2. Seed Edge table (relationships)
             edge_candidates = [
-                ["c/g/Root", "specializationOf", "dc/g/Root", "GeneratedGraphs"],
-                ["c/g/Root", "memberOf", "dc/g/Root", "GeneratedGraphs"],
+                ("c/g/Root", "specializationOf", "dc/g/Root", "GeneratedGraphs"),
+                ("c/g/Root", "memberOf", "dc/g/Root", "GeneratedGraphs"),
             ]
             edge_sql = """
                 SELECT subject_id, predicate, object_id, provenance 
                 FROM Edge 
-                WHERE subject_id = 'c/g/Root' AND object_id = 'dc/g/Root'
+                WHERE subject_id = 'c/g/Root'
             """
             existing_edges = set()
             for row in transaction.execute_sql(edge_sql):
@@ -604,7 +604,7 @@ class SpannerClient:
 
             edges_to_insert = [
                 edge for edge in edge_candidates 
-                if (edge[0], edge[1], edge[2], edge[3]) not in existing_edges
+                if edge not in existing_edges
             ]
 
             if edges_to_insert:

--- a/pipeline/workflow/ingestion-helper/clients/spanner.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner.py
@@ -565,12 +565,14 @@ class SpannerClient:
         logging.info("Seeding database with base nodes...")
 
         def _seed(transaction: Transaction):
+            # 1. Seed Node table
             candidates = {
                 "StatisticalVariable": ["StatisticalVariable", "StatisticalVariable", "StatisticalVariable", ["Class"], spanner.COMMIT_TIMESTAMP],
                 "StatVarGroup": ["StatVarGroup", "StatVarGroup", "StatVarGroup", ["Class"], spanner.COMMIT_TIMESTAMP],
                 "StatVarObservation": ["StatVarObservation", "StatVarObservation", "StatVarObservation", ["Class"], spanner.COMMIT_TIMESTAMP],
                 "Topic": ["Topic", "Topic", "Topic", ["Class"], spanner.COMMIT_TIMESTAMP],
                 "dc/g/Root": ["dc/g/Root", "Data Commons Variables", "dc/g/Root", ["StatVarGroup"], spanner.COMMIT_TIMESTAMP],
+                "c/g/Root": ["c/g/Root", "Custom Variables", "c/g/Root", ["StatVarGroup"], spanner.COMMIT_TIMESTAMP],
             }
             subjects = list(candidates.keys())
             sql = "SELECT subject_id FROM Node WHERE subject_id IN UNNEST(@subjects)"
@@ -585,6 +587,29 @@ class SpannerClient:
             if values:
                 columns = ["subject_id", "name", "value", "types", "last_update_timestamp"]
                 transaction.insert(table="Node", columns=columns, values=values)
+
+            # 2. Seed Edge table (relationships)
+            edge_candidates = [
+                ["c/g/Root", "specializationOf", "dc/g/Root", "GeneratedGraphs"],
+                ["c/g/Root", "memberOf", "dc/g/Root", "GeneratedGraphs"],
+            ]
+            edge_sql = """
+                SELECT subject_id, predicate, object_id, provenance 
+                FROM Edge 
+                WHERE subject_id = 'c/g/Root' AND object_id = 'dc/g/Root'
+            """
+            existing_edges = set()
+            for row in transaction.execute_sql(edge_sql):
+                existing_edges.add((row[0], row[1], row[2], row[3]))
+
+            edges_to_insert = [
+                edge for edge in edge_candidates 
+                if (edge[0], edge[1], edge[2], edge[3]) not in existing_edges
+            ]
+
+            if edges_to_insert:
+                edge_columns = ["subject_id", "predicate", "object_id", "provenance"]
+                transaction.insert(table="Edge", columns=edge_columns, values=edges_to_insert)
 
         try:
             self.database.run_in_transaction(_seed)

--- a/pipeline/workflow/ingestion-helper/clients/spanner_test.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner_test.py
@@ -220,8 +220,8 @@ class TestSpannerClient(unittest.TestCase):
         self.assertEqual(edge_kwargs['columns'], ["subject_id", "predicate", "object_id", "provenance"])
         self.assertEqual(len(edge_kwargs['values']), 2)
         expected_edges = [
-            ["c/g/Root", "specializationOf", "dc/g/Root", "GeneratedGraphs"],
-            ["c/g/Root", "memberOf", "dc/g/Root", "GeneratedGraphs"],
+            ("c/g/Root", "specializationOf", "dc/g/Root", "GeneratedGraphs"),
+            ("c/g/Root", "memberOf", "dc/g/Root", "GeneratedGraphs"),
         ]
         self.assertEqual(edge_kwargs['values'], expected_edges)
 

--- a/pipeline/workflow/ingestion-helper/clients/spanner_test.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner_test.py
@@ -196,19 +196,34 @@ class TestSpannerClient(unittest.TestCase):
         client.seed_database()
 
         # Verify
-        mock_transaction.insert.assert_called_once()
-        args, kwargs = mock_transaction.insert.call_args
-        self.assertEqual(kwargs['table'], 'Node')
-        self.assertEqual(kwargs['columns'], ["subject_id", "name", "value", "types", "last_update_timestamp"])
-        self.assertEqual(len(kwargs['values']), 5)
-        expected_subjects = ["StatisticalVariable", "StatVarGroup", "StatVarObservation", "Topic", "dc/g/Root"]
-        expected_names = ["StatisticalVariable", "StatVarGroup", "StatVarObservation", "Topic", "Data Commons Variables"]
-        actual_subjects = [val[0] for val in kwargs['values']]
-        actual_names = [val[1] for val in kwargs['values']]
-        actual_values = [val[2] for val in kwargs['values']]
+        self.assertEqual(mock_transaction.insert.call_count, 2)
+        
+        # Verify Node table insert
+        node_call = mock_transaction.insert.call_args_list[0]
+        node_kwargs = node_call.kwargs
+        self.assertEqual(node_kwargs['table'], 'Node')
+        self.assertEqual(node_kwargs['columns'], ["subject_id", "name", "value", "types", "last_update_timestamp"])
+        self.assertEqual(len(node_kwargs['values']), 6)
+        expected_subjects = ["StatisticalVariable", "StatVarGroup", "StatVarObservation", "Topic", "dc/g/Root", "c/g/Root"]
+        expected_names = ["StatisticalVariable", "StatVarGroup", "StatVarObservation", "Topic", "Data Commons Variables", "Custom Variables"]
+        actual_subjects = [val[0] for val in node_kwargs['values']]
+        actual_names = [val[1] for val in node_kwargs['values']]
+        actual_values = [val[2] for val in node_kwargs['values']]
         self.assertEqual(actual_subjects, expected_subjects)
         self.assertEqual(actual_names, expected_names)
         self.assertEqual(actual_values, expected_subjects)
+
+        # Verify Edge table insert
+        edge_call = mock_transaction.insert.call_args_list[1]
+        edge_kwargs = edge_call.kwargs
+        self.assertEqual(edge_kwargs['table'], 'Edge')
+        self.assertEqual(edge_kwargs['columns'], ["subject_id", "predicate", "object_id", "provenance"])
+        self.assertEqual(len(edge_kwargs['values']), 2)
+        expected_edges = [
+            ["c/g/Root", "specializationOf", "dc/g/Root", "GeneratedGraphs"],
+            ["c/g/Root", "memberOf", "dc/g/Root", "GeneratedGraphs"],
+        ]
+        self.assertEqual(edge_kwargs['values'], expected_edges)
 
     @patch('google.cloud.spanner.Client')
     def test_seed_database_already_exists(self, mock_spanner_client):
@@ -219,7 +234,23 @@ class TestSpannerClient(unittest.TestCase):
         mock_instance.database.return_value = mock_db
 
         mock_transaction = MagicMock()
-        mock_transaction.execute_sql.return_value = [["StatisticalVariable"], ["StatVarGroup"], ["StatVarObservation"], ["Topic"], ["dc/g/Root"]]
+        
+        def execute_sql_side_effect(sql, *args, **kwargs):
+            if "FROM Edge" in sql:
+                return [
+                    ["c/g/Root", "specializationOf", "dc/g/Root", "GeneratedGraphs"],
+                    ["c/g/Root", "memberOf", "dc/g/Root", "GeneratedGraphs"],
+                ]
+            return [
+                ["StatisticalVariable"],
+                ["StatVarGroup"],
+                ["StatVarObservation"],
+                ["Topic"],
+                ["dc/g/Root"],
+                ["c/g/Root"],
+            ]
+        mock_transaction.execute_sql.side_effect = execute_sql_side_effect
+
         def run_in_transaction_side_effect(callback, *args, **kwargs):
             return callback(mock_transaction, *args, **kwargs)
         mock_db.run_in_transaction.side_effect = run_in_transaction_side_effect


### PR DESCRIPTION
Without this relationship, it's impossible to attach SVGs to the existing hierarchy.

Note: This is the first time we are seeding an edge. The preprocessor used to add the c/g/Root node, but now I think it belongs in seeding. 