### PR TITLE
Add node counter to mcf import tool

### DIFF
--- a/tool/src/main/java/org/datacommons/tool/Processor.java
+++ b/tool/src/main/java/org/datacommons/tool/Processor.java
@@ -54,6 +54,7 @@ public class Processor {
   private final ExecutorService execService;
   private final LogWrapper logCtx;
   private HttpClient httpClient;
+  private int numMcfNodeSuccesses = 0;
 
   public static Integer process(Args args) throws IOException, TemplateException {
     Integer retVal = 0;
@@ -129,6 +130,12 @@ public class Processor {
       processor.logCtx.setRuntimeMetadata(runtimeMetadata);
     }
 
+    if (args.fileGroup instanceof McfFileGroup) {
+      McfFileGroup mcfGroup = (McfFileGroup) args.fileGroup;
+      if (mcfGroup.getMcfs() != null && !mcfGroup.getMcfs().isEmpty()) {
+        processor.logCtx.incrementInfoCounterBy("NumNodeSuccesses", processor.numMcfNodeSuccesses);
+      }
+    }
     processor.logCtx.persistLog();
     if (args.generateSummaryReport) {
       SummaryReportGenerator.generateReportSummary(
@@ -213,7 +220,9 @@ public class Processor {
     if (existenceChecker != null && type == Mcf.McfType.INSTANCE_MCF) {
       existenceChecker.addLocalGraph(n);
     } else {
-      McfChecker.check(n, existenceChecker, statVarState, logCtx);
+      if (McfChecker.check(n, existenceChecker, statVarState, logCtx)) {
+        numMcfNodeSuccesses += n.getNodesCount();
+      }
     }
     if (args.checkMeasurementResult && type == Mcf.McfType.INSTANCE_MCF) {
       statVarState.addLocalGraph(n);
@@ -398,7 +407,9 @@ public class Processor {
   // Called only when existenceChecker is enabled.
   private void checkNodes() throws IOException, InterruptedException, DCTooManyFailuresException {
     for (Mcf.McfGraph n : nodesForVariousChecks) {
-      McfChecker.check(n, existenceChecker, statVarState, logCtx);
+      if (McfChecker.check(n, existenceChecker, statVarState, logCtx)) {
+        numMcfNodeSuccesses += n.getNodesCount();
+      }
       if (!logCtx.trackStatus(n.getNodesCount(), "nodes checked")) {
         throw new DCTooManyFailuresException("checkNodes encountered too many failures");
       }

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/report.json
@@ -5,7 +5,7 @@
         "NumRowSuccesses": "2",
         "NumPVSuccesses": "11",
         "Existence_NumChecks": "35",
-        "NumNodeSuccesses": "2",
+        "NumNodeSuccesses": "5",
         "Existence_NumDcCalls": "2"
       }
     },

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/localidresolution/output/summary_report.html
@@ -210,7 +210,7 @@
                 </tr>
                 <tr>
                   <td><a href="#counters--LEVEL_INFO--NumNodeSuccesses" name="counters--LEVEL_INFO--NumNodeSuccesses">NumNodeSuccesses</a></td>
-                  <td>2</td>
+                  <td>5</td>
                 </tr>
                 <tr>
                   <td><a href="#counters--LEVEL_INFO--Existence_NumDcCalls" name="counters--LEVEL_INFO--Existence_NumDcCalls">Existence_NumDcCalls</a></td>

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/measurementresult/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/measurementresult/output/report.json
@@ -6,7 +6,7 @@
         "NumPVSuccesses": "105",
         "StatVarState_NumDcCalls": "2",
         "Existence_NumChecks": "125",
-        "NumNodeSuccesses": "15",
+        "NumNodeSuccesses": "16",
         "Existence_NumDcCalls": "4"
       }
     },

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/measurementresult/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/measurementresult/output/summary_report.html
@@ -237,7 +237,7 @@
                 </tr>
                 <tr>
                   <td><a href="#counters--LEVEL_INFO--NumNodeSuccesses" name="counters--LEVEL_INFO--NumNodeSuccesses">NumNodeSuccesses</a></td>
-                  <td>15</td>
+                  <td>16</td>
                 </tr>
                 <tr>
                   <td><a href="#counters--LEVEL_INFO--Existence_NumDcCalls" name="counters--LEVEL_INFO--Existence_NumDcCalls">Existence_NumDcCalls</a></td>

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/report.json
@@ -5,7 +5,7 @@
         "NumRowSuccesses": "10",
         "NumPVSuccesses": "100",
         "Existence_NumChecks": "155",
-        "NumNodeSuccesses": "20",
+        "NumNodeSuccesses": "29",
         "ReconClient_NumApiCalls": "2",
         "Existence_NumDcCalls": "2"
       }

--- a/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/genmcf/resolution/output/summary_report.html
@@ -293,7 +293,7 @@
                 </tr>
                 <tr>
                   <td><a href="#counters--LEVEL_INFO--NumNodeSuccesses" name="counters--LEVEL_INFO--NumNodeSuccesses">NumNodeSuccesses</a></td>
-                  <td>20</td>
+                  <td>29</td>
                 </tr>
                 <tr>
                   <td><a href="#counters--LEVEL_INFO--ReconClient_NumApiCalls" name="counters--LEVEL_INFO--ReconClient_NumApiCalls">ReconClient_NumApiCalls</a></td>

--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/report.json
@@ -5,7 +5,7 @@
         "NumRowSuccesses": "11",
         "NumPVSuccesses": "107",
         "Existence_NumChecks": "272",
-        "NumNodeSuccesses": "15",
+        "NumNodeSuccesses": "18",
         "CSV_MalformedDCIDPVFailures": "4",
         "Existence_NumDcCalls": "2"
       }

--- a/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/allfiletypes/output/summary_report.html
@@ -458,7 +458,7 @@
                 </tr>
                 <tr>
                   <td><a href="#counters--LEVEL_INFO--NumNodeSuccesses" name="counters--LEVEL_INFO--NumNodeSuccesses">NumNodeSuccesses</a></td>
-                  <td>15</td>
+                  <td>18</td>
                 </tr>
                 <tr>
                   <td><a href="#counters--LEVEL_INFO--CSV_MalformedDCIDPVFailures" name="counters--LEVEL_INFO--CSV_MalformedDCIDPVFailures">CSV_MalformedDCIDPVFailures</a></td>

--- a/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/report.json
@@ -3,6 +3,7 @@
     "LEVEL_INFO": {
       "counters": {
         "Existence_NumChecks": "192",
+        "NumNodeSuccesses": "6",
         "Existence_NumDcCalls": "1"
       }
     },

--- a/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/mcfonly/output/summary_report.html
@@ -71,6 +71,9 @@
                   <a href="#counters--LEVEL_INFO--Existence_NumChecks">Existence_NumChecks</a>
                 </li>
                 <li>
+                  <a href="#counters--LEVEL_INFO--NumNodeSuccesses">NumNodeSuccesses</a>
+                </li>
+                <li>
                   <a href="#counters--LEVEL_INFO--Existence_NumDcCalls">Existence_NumDcCalls</a>
                 </li>
               </ul>
@@ -300,6 +303,10 @@
                 <tr>
                   <td><a href="#counters--LEVEL_INFO--Existence_NumChecks" name="counters--LEVEL_INFO--Existence_NumChecks">Existence_NumChecks</a></td>
                   <td>192</td>
+                </tr>
+                <tr>
+                  <td><a href="#counters--LEVEL_INFO--NumNodeSuccesses" name="counters--LEVEL_INFO--NumNodeSuccesses">NumNodeSuccesses</a></td>
+                  <td>6</td>
                 </tr>
                 <tr>
                   <td><a href="#counters--LEVEL_INFO--Existence_NumDcCalls" name="counters--LEVEL_INFO--Existence_NumDcCalls">Existence_NumDcCalls</a></td>

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/report.json
@@ -3,6 +3,7 @@
     "LEVEL_INFO": {
       "counters": {
         "Existence_NumChecks": "159",
+        "NumNodeSuccesses": "4",
         "Existence_NumDcCalls": "1"
       }
     },

--- a/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/nocsv/output/summary_report.html
@@ -71,6 +71,9 @@
                   <a href="#counters--LEVEL_INFO--Existence_NumChecks">Existence_NumChecks</a>
                 </li>
                 <li>
+                  <a href="#counters--LEVEL_INFO--NumNodeSuccesses">NumNodeSuccesses</a>
+                </li>
+                <li>
                   <a href="#counters--LEVEL_INFO--Existence_NumDcCalls">Existence_NumDcCalls</a>
                 </li>
               </ul>
@@ -315,6 +318,10 @@
                 <tr>
                   <td><a href="#counters--LEVEL_INFO--Existence_NumChecks" name="counters--LEVEL_INFO--Existence_NumChecks">Existence_NumChecks</a></td>
                   <td>159</td>
+                </tr>
+                <tr>
+                  <td><a href="#counters--LEVEL_INFO--NumNodeSuccesses" name="counters--LEVEL_INFO--NumNodeSuccesses">NumNodeSuccesses</a></td>
+                  <td>4</td>
                 </tr>
                 <tr>
                   <td><a href="#counters--LEVEL_INFO--Existence_NumDcCalls" name="counters--LEVEL_INFO--Existence_NumDcCalls">Existence_NumDcCalls</a></td>

--- a/tool/src/test/resources/org/datacommons/tool/lint/statchecks/output/report.json
+++ b/tool/src/test/resources/org/datacommons/tool/lint/statchecks/output/report.json
@@ -3,6 +3,7 @@
     "LEVEL_INFO": {
       "counters": {
         "Existence_NumChecks": "126",
+        "NumNodeSuccesses": "18",
         "Existence_NumDcCalls": "1"
       }
     },

--- a/tool/src/test/resources/org/datacommons/tool/lint/statchecks/output/summary_report.html
+++ b/tool/src/test/resources/org/datacommons/tool/lint/statchecks/output/summary_report.html
@@ -71,6 +71,9 @@
                   <a href="#counters--LEVEL_INFO--Existence_NumChecks">Existence_NumChecks</a>
                 </li>
                 <li>
+                  <a href="#counters--LEVEL_INFO--NumNodeSuccesses">NumNodeSuccesses</a>
+                </li>
+                <li>
                   <a href="#counters--LEVEL_INFO--Existence_NumDcCalls">Existence_NumDcCalls</a>
                 </li>
               </ul>
@@ -261,6 +264,10 @@
                 <tr>
                   <td><a href="#counters--LEVEL_INFO--Existence_NumChecks" name="counters--LEVEL_INFO--Existence_NumChecks">Existence_NumChecks</a></td>
                   <td>126</td>
+                </tr>
+                <tr>
+                  <td><a href="#counters--LEVEL_INFO--NumNodeSuccesses" name="counters--LEVEL_INFO--NumNodeSuccesses">NumNodeSuccesses</a></td>
+                  <td>18</td>
                 </tr>
                 <tr>
                   <td><a href="#counters--LEVEL_INFO--Existence_NumDcCalls" name="counters--LEVEL_INFO--Existence_NumDcCalls">Existence_NumDcCalls</a></td>


### PR DESCRIPTION
NumNodeSuccesses counter is used to EMPTY_IMPORT_CHECK validaiton. This counter is currently generated only during CSV processing. We need it for MCF processing flow as well for Schema imports etc.