### PR TITLE
SVG generation fixes

### DIFF
--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphTransformer.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphTransformer.java
@@ -67,8 +67,7 @@ public class GraphTransformer extends DoFn<McfGraph, McfGraph> {
           "observationProperties",
           // Generated properties
           "linkedMember",
-          "linkedMemberOf",
-          "description");
+          "linkedMemberOf");
 
   @ProcessElement
   public void processElement(@Element McfGraph inputGraph, OutputReceiver<McfGraph> receiver) {

--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphTransformer.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphTransformer.java
@@ -68,8 +68,7 @@ public class GraphTransformer extends DoFn<McfGraph, McfGraph> {
           // Generated properties
           "linkedMember",
           "linkedMemberOf",
-          "description"
-          );
+          "description");
 
   @ProcessElement
   public void processElement(@Element McfGraph inputGraph, OutputReceiver<McfGraph> receiver) {

--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphTransformer.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphTransformer.java
@@ -25,20 +25,51 @@ public class GraphTransformer extends DoFn<McfGraph, McfGraph> {
 
   private static final Set<String> NON_CONSTRAINT_PROPS =
       Set.of(
-          "dcid",
+          // -- Legacy Prophet PropsThatAreNotConstraintProps --
+          // Basic properties
           "typeOf",
-          "name",
-          "description",
+          "dcid",
           "provenance",
+          "isPublic",
+          "localCuratorLevelId",
+          "url",
           "memberOf",
+          "name",
+          "label",
+          "description",
+          "descriptionUrl",
+          "alternateName",
+          "utteranceTemplate",
+          "source",
+          "footnote",
+          // Debug properties
+          "keyString",
+          "resMCFFile",
+          // StatPop / StatVar properties (current + past)
           "populationType",
+          "populationGroup",
+          "location",
+          "childhoodLocation",
+          "constraintProperties",
           "measuredProperty",
           "statType",
-          "measurementQualifier",
           "measurementDenominator",
+          "measurementQualifier",
+          "censusACSTableId",
           "measurementMethod",
-          "constraintProperties",
-          "observationProperties");
+          "scalingFactor",
+          "unit",
+          "isNormalizable",
+          "denominatorForNormalization",
+
+          // -- New properties --
+          // Extensible StatVar properties
+          "observationProperties",
+          // Generated properties
+          "linkedMember",
+          "linkedMemberOf",
+          "description"
+          );
 
   @ProcessElement
   public void processElement(@Element McfGraph inputGraph, OutputReceiver<McfGraph> receiver) {

--- a/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
@@ -276,7 +276,10 @@ class StatVarGroupGenerator:
             FROM StatVarTriple WHERE predicate = 'constraintProperties' GROUP BY subject_id
           ),
           Constraints AS (
-            SELECT T.subject_id, ARRAY_AGG(CONCAT(FormatName(T.predicate), ' = ', FormatName(T.object_id)) ORDER BY T.predicate) AS pvs
+            SELECT 
+              T.subject_id, 
+              ARRAY_AGG(T.predicate ORDER BY T.predicate, T.object_id) AS aligned_cps,
+              ARRAY_AGG(CONCAT(FormatName(T.predicate), ' = ', FormatName(T.object_id)) ORDER BY T.predicate, T.object_id) AS pvs
             FROM StatVarTriple T
             JOIN ConstraintProps ON T.subject_id = ConstraintProps.subject_id
             WHERE predicate IN UNNEST(ConstraintProps.constraintProperties) GROUP BY subject_id 
@@ -296,7 +299,7 @@ class StatVarGroupGenerator:
             PopType.subject_id AS statvar,
             PopType.object_id AS populationType,
             ARRAY<STRING>[] AS constraintProperties,
-            IFNULL(ConstraintProps.constraintProperties, ARRAY<STRING>[]) AS newConstraintProperties,
+            IFNULL(Constraints.aligned_cps, ARRAY<STRING>[]) AS newConstraintProperties,
             IFNULL(Constraints.pvs, ARRAY<STRING>[]) AS attributes,
             0 AS iteration
           FROM PopType


### PR DESCRIPTION
* Ensure constraintProperties and corresponding pv arrays are aligned in SVG generation. (This is to handle a case where there could be multiple pvs for a single constraintProp - this isn't correct schema modeling, but does exist in our schema now)
* Add some additional props to NON_CONSTRAINT_PROPS