### PR TITLE
[DCP Ingestion] Fix Entities Importer logic to respect the new columnMappings

### DIFF
--- a/simple/stats/entities_importer.py
+++ b/simple/stats/entities_importer.py
@@ -139,11 +139,12 @@ class EntitiesImporter(Importer):
         if pd.isna(v):
           continue
         if k in self.entity_columns:
-          if "," in v:
-            ids = list(map(lambda x: strip_namespace(x.strip()), str(v).split(",")))
+          v_str = str(v)
+          if "," in v_str:
+            ids = list(map(lambda x: strip_namespace(x.strip()), v_str.split(",")))
             prop_object_ids[k] = ids
           else:
-            prop_object_ids[k] = strip_namespace(str(v))
+            prop_object_ids[k] = strip_namespace(v_str)
         else:
           prop_object_values[k] = v
 

--- a/simple/stats/entities_importer.py
+++ b/simple/stats/entities_importer.py
@@ -18,6 +18,7 @@ import pandas as pd
 from stats import constants
 from stats.data import RowEntity
 from stats.data import Triple
+from stats.data import strip_namespace
 from stats.db import Db
 from stats.importer import Importer
 from stats.nodes import Nodes
@@ -51,6 +52,10 @@ class EntitiesImporter(Importer):
     self.id_column = self.config.id_column(self.input_file)
     # Reassigned when renaming columns.
     self.entity_columns = set(self.config.entity_columns(self.input_file))
+
+    # Initialize reverse column mappings from config
+    column_mappings = self.config.column_mappings(self.input_file)
+    self.reverse_mappings = {v: strip_namespace(k) for k, v in column_mappings.items()}
 
     self.df = pd.DataFrame()
 
@@ -89,11 +94,11 @@ class EntitiesImporter(Importer):
   def _rename_columns(self) -> None:
     renamed = {}
 
-    # Rename property columns to their IDs
+    # Rename property columns to their IDs (using custom mappings if defined)
     property_column_names = self.df.columns
     property_ids = [
-        self.nodes.property(property_column_name).dcid
-        for property_column_name in property_column_names
+        self.reverse_mappings.get(col, self.nodes.property(col).dcid)
+        for col in property_column_names
     ]
 
     for col, id in zip(property_column_names, property_ids):
@@ -113,8 +118,10 @@ class EntitiesImporter(Importer):
 
     # All property columns would've been renamed to their dcids by now.
     # So use the id column's dcid as the id column name.
-    id_column_name = self.nodes.property(
-        self.id_column).dcid if self.id_column else ""
+    id_column_name = ""
+    if self.id_column:
+      id_column_name = self.reverse_mappings.get(
+          self.id_column, self.nodes.property(self.id_column).dcid)
 
     triples: list[Triple] = []
     for index, row in self.df.iterrows():
@@ -122,23 +129,26 @@ class EntitiesImporter(Importer):
       dcid = row[
           id_column_name] if id_column_name else f"{self.row_entity_type}_{index}"
 
+      # Normalize subject ID
+      dcid = strip_namespace(str(dcid))
+
       prop_object_values: dict[str, str] = {}
-      prop_object_ids: dict[str, str] = {}
+      prop_object_ids: dict[str, str | list[str]] = {}
 
       for i, (k, v) in enumerate(row.items()):
         if pd.isna(v):
           continue
         if k in self.entity_columns:
           if "," in v:
-            ids = list(map(lambda x: x.strip(), v.split(",")))
+            ids = list(map(lambda x: strip_namespace(x.strip()), str(v).split(",")))
             prop_object_ids[k] = ids
           else:
-            prop_object_ids[k] = v
+            prop_object_ids[k] = strip_namespace(str(v))
         else:
           prop_object_values[k] = v
 
       row_entity = RowEntity(dcid,
-                             self.row_entity_type,
+                             strip_namespace(self.row_entity_type),
                              provenance_id=self.provenance,
                              prop_object_values=prop_object_values,
                              prop_object_ids=prop_object_ids)

--- a/simple/stats/entities_importer.py
+++ b/simple/stats/entities_importer.py
@@ -17,8 +17,8 @@ import logging
 import pandas as pd
 from stats import constants
 from stats.data import RowEntity
-from stats.data import Triple
 from stats.data import strip_namespace
+from stats.data import Triple
 from stats.db import Db
 from stats.importer import Importer
 from stats.nodes import Nodes
@@ -55,7 +55,9 @@ class EntitiesImporter(Importer):
 
     # Initialize reverse column mappings from config
     column_mappings = self.config.column_mappings(self.input_file)
-    self.reverse_mappings = {v: strip_namespace(k) for k, v in column_mappings.items()}
+    self.reverse_mappings = {
+        v: strip_namespace(k) for k, v in column_mappings.items()
+    }
 
     self.df = pd.DataFrame()
 
@@ -97,7 +99,8 @@ class EntitiesImporter(Importer):
     # Rename property columns to their IDs (using custom mappings if defined)
     property_column_names = self.df.columns
     property_ids = [
-        self.reverse_mappings.get(col, self.nodes.property(col).dcid)
+        self.reverse_mappings.get(col,
+                                  self.nodes.property(col).dcid)
         for col in property_column_names
     ]
 
@@ -121,7 +124,8 @@ class EntitiesImporter(Importer):
     id_column_name = ""
     if self.id_column:
       id_column_name = self.reverse_mappings.get(
-          self.id_column, self.nodes.property(self.id_column).dcid)
+          self.id_column,
+          self.nodes.property(self.id_column).dcid)
 
     triples: list[Triple] = []
     for index, row in self.df.iterrows():
@@ -141,7 +145,8 @@ class EntitiesImporter(Importer):
         if k in self.entity_columns:
           v_str = str(v)
           if "," in v_str:
-            ids = list(map(lambda x: strip_namespace(x.strip()), v_str.split(",")))
+            ids = list(
+                map(lambda x: strip_namespace(x.strip()), v_str.split(",")))
             prop_object_ids[k] = ids
           else:
             prop_object_ids[k] = strip_namespace(v_str)


### PR DESCRIPTION
Fix a pretty significant bug with entity imports. We didnt propagate the column mappings on entity CSVs like we did on the variable_per_import. With this change we now will properly map the entities in the config.json to their respect CSV columns.

Verified by importing a new dataset.