### PR TITLE
Update provenance handling logic

### DIFF
--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphReader.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphReader.java
@@ -107,6 +107,7 @@ public class GraphReader implements Serializable {
       PropertyValues pvs = nodeEntry.getValue();
       if (!GraphUtils.isObservation(pvs)) {
         Map<String, McfGraph.Values> pv = pvs.getPvsMap();
+        String nodeProvenance = getProvenance(pvs, provenance);
         String dcid = GraphUtils.getPropVal(pvs, GraphUtils.Property.dcid.name());
         String subjectId = !dcid.isEmpty() ? dcid : McfUtil.stripNamespace(nodeEntry.getKey());
         for (Map.Entry<String, McfGraph.Values> entry : pv.entrySet()) {
@@ -137,7 +138,7 @@ public class GraphReader implements Serializable {
             Edge.Builder edge = Edge.builder();
             edge.subjectId(subjectId);
             edge.predicate(entry.getKey());
-            edge.provenance(provenance);
+            edge.provenance(nodeProvenance);
             if (val.getType() == ValueType.RESOLVED_REF) {
               edge.objectId(McfUtil.stripNamespace(val.getValue()));
             } else {
@@ -317,9 +318,11 @@ public class GraphReader implements Serializable {
     String unit = GraphUtils.getPropVal(pv, "unit");
     String scalingFactor = GraphUtils.getPropVal(pv, "scalingFactor");
 
+    String provenance = getProvenance(pv, importName);
+
     String facetId =
         TimeSeries.calculateFacetId(
-            importName, measurementMethod, observationPeriod, scalingFactor, unit, isDcAggregate);
+            provenance, measurementMethod, observationPeriod, scalingFactor, unit, isDcAggregate);
 
     return new TimeSeriesKey(
         sv,
@@ -356,6 +359,8 @@ public class GraphReader implements Serializable {
     String scalingFactor = GraphUtils.getPropVal(pv, "scalingFactor");
     String provenanceUrl = GraphUtils.getPropVal(pv, "provenanceUrl");
 
+    String provenance = getProvenance(pv, importName);
+
     return TimeSeries.builder()
         .variableMeasured(sv)
         .entity1(entity1)
@@ -364,7 +369,7 @@ public class GraphReader implements Serializable {
         .measurementMethod(measurementMethod)
         .unit(unit)
         .scalingFactor(scalingFactor)
-        .importName(importName)
+        .importName(provenance)
         .isBaseDc(isBaseDc)
         .isDcAggregate(isDcAggregate)
         .provenanceUrl(provenanceUrl)
@@ -490,5 +495,14 @@ public class GraphReader implements Serializable {
                 edgeCounter.inc(mutations.size());
               }
             }));
+  }
+
+  /**
+   * Fallback logic to handle base DC case where provenance mcf node may not be a part of the data
+   * files of the import.
+   */
+  private static String getProvenance(PropertyValues pv, String fallbackProvenance) {
+    String provenance = GraphUtils.getPropVal(pv, "provenance");
+    return provenance.isEmpty() ? fallbackProvenance : provenance;
   }
 }

--- a/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphReaderTest.java
+++ b/pipeline/util/src/test/java/org/datacommons/ingestion/util/GraphReaderTest.java
@@ -289,7 +289,7 @@ public class GraphReaderTest {
                 .provenance("dc/base/Test")
                 .build());
 
-    List<Edge> actualEdges = GraphReader.graphToEdges(graph, "dc/base/Test");
+    List<Edge> actualEdges = GraphReader.graphToEdges(graph, "dc/base/Default");
 
     // Sort both lists for consistent comparison
     Comparator<Edge> edgeComparator =
@@ -462,6 +462,14 @@ public class GraphReaderTest {
                             .setType(ValueType.RESOLVED_REF)
                             .setValue("sourceCountry"))
                     .build())
+            .putPvs(
+                "provenance",
+                McfGraph.Values.newBuilder()
+                    .addTypedValues(
+                        TypedValue.newBuilder()
+                            .setType(ValueType.RESOLVED_REF)
+                            .setValue("provenance/TestImport"))
+                    .build())
             .build();
 
     TimeSeries expected =
@@ -469,7 +477,7 @@ public class GraphReaderTest {
             .entity1("country/USA")
             .extraEntities(List.of("country/FRA"))
             .variableMeasured("FinancialTrade")
-            .importName("test_import")
+            .importName("provenance/TestImport")
             .isBaseDc(true)
             .build();
 


### PR DESCRIPTION
If the input JSON-LD contains a 'dcid:provenance' field, use it for the observation's provenance and facet ID calculation, instead of falling back to the pipeline's 'importName' argument.