### PR TITLE
Add definition to list of non-cprops

### DIFF
--- a/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphTransformer.java
+++ b/pipeline/util/src/main/java/org/datacommons/ingestion/util/GraphTransformer.java
@@ -66,6 +66,7 @@ public class GraphTransformer extends DoFn<McfGraph, McfGraph> {
           // Extensible StatVar properties
           "observationProperties",
           // Generated properties
+          "definition",
           "linkedMember",
           "linkedMemberOf");
 


### PR DESCRIPTION
definition is not a schema property so should not be included in constraintProperties generation, so this PR adds it to the exclusion list