### PR TITLE
SVG generation fixes

### DIFF
--- a/pipeline/workflow/ingestion-helper/aggregation/e2e_tests/aggregation_e2e_test.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/e2e_tests/aggregation_e2e_test.py
@@ -1594,6 +1594,7 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
           - A constrained SV 'Count_Student_Female' (gender=Female).
           - A curated SV 'Median_Age_Student'.
           - A basic populationType SV 'Count_Person'.
+          - An uncategorized basic SV 'Count_Thing'.
         """
         generator = self.get_generator()
         ns = generator.namespace
@@ -1604,6 +1605,7 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
         self.add_node(f'{ns}g/TestCustomVertical', 'Test Custom Vertical', types=['StatVarGroup'])
         self.add_node('Student', 'Student', value='Student', types=['Class'])
         self.add_node('Person', 'Person', value='Person', types=['Class'])
+        self.add_node('Thing', 'Thing', value='Thing', types=['Class'])
         
         # Spec mappings
         self.add_edge('Spec_Student', 'typeOf', 'StatVarGroupSpec', 'TestImport')
@@ -1641,6 +1643,12 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
         self.add_edge('Count_Person', 'populationType', 'Person', 'TestImport')
         self.add_edge('Count_Person', 'measuredProperty', 'count', 'TestImport')
         
+        # Uncategorized SV with basic populationType
+        self.add_node('Count_Thing', 'Population', types=['StatisticalVariable'])
+        self.add_edge('Count_Thing', 'typeOf', 'StatisticalVariable', 'TestImport')
+        self.add_edge('Count_Thing', 'populationType', 'Thing', 'TestImport')
+        self.add_edge('Count_Thing', 'measuredProperty', 'count', 'TestImport')
+
         self.flush_to_spanner()
 
         # 2. Run generator
@@ -1697,6 +1705,14 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
             # Verify basic populationType SV attached to ancestor SVGs
             self.assertIn(('Count_Person', 'linkedMemberOf', f'{ns}g/TestVertical', prov), edges)
             self.assertIn(('Count_Person', 'linkedMemberOf', f'{ns}g/Root', prov), edges)
+
+            # Verify uncategorized basic populationType SV attached to Uncategorized_Variables SVG
+            self.assertIn(('Count_Thing', 'memberOf', f'{ns}g/Uncategorized_Variables', prov), edges)
+
+            # Verify uncategorized basic populationType SV attached to ancestor SVGs
+            self.assertIn(('Count_Thing', 'linkedMemberOf', f'{ns}g/Uncategorized_Variables', prov), edges)
+            self.assertIn(('Count_Thing', 'linkedMemberOf', f'{ns}g/Uncategorized', prov), edges)
+            self.assertIn(('Count_Thing', 'linkedMemberOf', f'{ns}g/Root', prov), edges)
             
             # Verify hierarchical specialization of generated SVGs
             self.assertIn((f'{ns}g/Student_Gender-Female', 'specializationOf', f'{ns}g/Student_Gender', prov), edges)

--- a/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
@@ -87,6 +87,7 @@ class StatVarGroupGenerator:
         DECLARE namespace STRING DEFAULT @namespace; -- Namespace for generated DCIDs
         DECLARE generated_provenance STRING DEFAULT @generated_provenance; -- Provenance for generated Edges
         DECLARE uncategorized_svg STRING DEFAULT CONCAT(namespace, 'g/Uncategorized'); -- DCID for uncategorized SVs/SVGs
+        DECLARE uncategorized_sv_svg STRING DEFAULT CONCAT(namespace, 'g/Uncategorized_Variables'); -- DCID for uncategorized SVs
         DECLARE root_svg STRING DEFAULT CONCAT(namespace, 'g/Root'); -- DCID for root SVG
         DECLARE should_filter_basic_population_type BOOL DEFAULT @should_filter; -- Whether to filter basic population type SVGs. Default to true for base DC
 
@@ -251,10 +252,13 @@ class StatVarGroupGenerator:
         );
 
         -- Fetch relevant StatisticalVariable triples.
+        -- For now, avoid any PVs that should have been converted to Quantities.
+        -- This is to avoid generating improper groups.
+        -- TODO: Ensure all Quantities are properly resolved in ingestion.
         CREATE OR REPLACE TEMP TABLE StatVarTriple AS (
           SELECT DISTINCT E.subject_id, E.predicate, E.object_id
           FROM EXTERNAL_QUERY("{conn_id}",
-            "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate IN UNNEST([{sv_predicates_sql}])"
+            "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate IN UNNEST([{sv_predicates_sql}]) AND object_id NOT LIKE '[%'"
           ) E
           JOIN StatVar SV ON SV.subject_id = E.subject_id
         );
@@ -339,10 +343,10 @@ class StatVarGroupGenerator:
             AND (VS.observationProperties IS NULL OR SV.observationProperties = VS.observationProperties)
             AND IFNULL(ARRAY_LENGTH(VS.constraintProperties), 0) = 0
           CROSS JOIN UNNEST([
-            STRUCT('memberOf' AS predicate, IF(IFNULL(ARRAY_LENGTH(VS.vertical), 0) = 0, ARRAY<STRING>[uncategorized_svg], VS.vertical) AS target_array),
+            STRUCT('memberOf' AS predicate, IF(IFNULL(ARRAY_LENGTH(VS.vertical), 0) = 0, ARRAY<STRING>[uncategorized_sv_svg], VS.vertical) AS target_array),
             STRUCT(
               'linkedMemberOf' AS predicate, 
-              IF(IFNULL(ARRAY_LENGTH(VS.linkedVertical), 0) = 0, ARRAY<STRING>[root_svg, uncategorized_svg], VS.linkedVertical) AS target_array
+              IF(IFNULL(ARRAY_LENGTH(VS.linkedVertical), 0) = 0, ARRAY<STRING>[root_svg, uncategorized_svg, uncategorized_sv_svg], VS.linkedVertical) AS target_array
             )
           ]) AS map
           CROSS JOIN UNNEST(map.target_array) AS v
@@ -433,14 +437,14 @@ class StatVarGroupGenerator:
             SELECT DISTINCT node2 AS svg_id, statvar, constraintProperties, populationType
             FROM AllResults
             WHERE iteration > 0
-              AND (should_filter_basic_population_Type AND IsBasicPopulationType(populationType))
+              AND (should_filter_basic_population_type AND IsBasicPopulationType(populationType))
               AND ARRAY_LENGTH(constraintProperties) = 1
             UNION ALL
             -- Non-basic PopTypes: Attach the 0-constraint group (node3) to the vertical.
             SELECT DISTINCT node3 AS svg_id, statvar, ARRAY<STRING>[] AS constraintProperties, populationType
             FROM AllResults
             WHERE node3 IS NOT NULL
-              AND NOT (should_filter_basic_population_Type AND IsBasicPopulationType(populationType))
+              AND NOT (should_filter_basic_population_type AND IsBasicPopulationType(populationType))
               AND ARRAY_LENGTH(attributes) = 0
           ),
           BaseJoined AS (

--- a/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
@@ -345,8 +345,11 @@ class StatVarGroupGenerator:
           CROSS JOIN UNNEST([
             STRUCT('memberOf' AS predicate, IF(IFNULL(ARRAY_LENGTH(VS.vertical), 0) = 0, ARRAY<STRING>[uncategorized_sv_svg], VS.vertical) AS target_array),
             STRUCT(
-              'linkedMemberOf' AS predicate, 
-              IF(IFNULL(ARRAY_LENGTH(VS.linkedVertical), 0) = 0, ARRAY<STRING>[root_svg, uncategorized_svg, uncategorized_sv_svg], VS.linkedVertical) AS target_array
+              'linkedMemberOf' AS predicate,
+              IF(IFNULL(ARRAY_LENGTH(VS.linkedVertical), 0) = 0,
+                ARRAY<STRING>[root_svg, uncategorized_svg, uncategorized_sv_svg],
+                VS.linkedVertical
+              ) AS target_array
             )
           ]) AS map
           CROSS JOIN UNNEST(map.target_array) AS v


### PR DESCRIPTION
* Attach all 0 constraint uncategorized SVs to intermediate Uncategorized_Variables SVG. This matches what is done in prophet and helps clean up the Uncategorized group a bit (the group being so large was causing some issues in NL search)
* Filter out "[" constraint values. These occur for Quantity/QuantityRanges that haven't been resolved properly, so ideally will get fixed in ingestion stage. But just in case, to avoid generating malformed groups, filter these pvs from generation
* Fixes a typo