### PR TITLE
Add cloud run job for aggregation helper

### DIFF
--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -246,6 +246,56 @@ resource "google_cloud_run_v2_service" "import_helper" {
   depends_on = [google_project_service.services]
 }
 
+resource "google_cloud_run_v2_job" "aggregation_helper" {
+  name     = "aggregation-helper-job"
+  location = var.region
+  project  = var.project_id
+  deletion_protection = false
+
+  template {
+    template {
+      service_account = google_service_account.automation_sa.email
+      containers {
+        image = "${var.artifact_registry_url}/datacommons-aggregation-helper:latest"
+        env {
+          name  = "PROJECT_ID"
+          value = var.project_id
+        }
+        env {
+          name  = "SPANNER_PROJECT_ID"
+          value = var.project_id
+        }
+        env {
+          name  = "SPANNER_INSTANCE_ID"
+          value = var.spanner_instance_id
+        }
+        env {
+          name  = "SPANNER_DATABASE_ID"
+          value = var.spanner_database_id
+        }
+        env {
+          name  = "SPANNER_GRAPH_DATABASE_ID"
+          value = var.spanner_graph_database_id
+        }
+        env {
+          name  = "GCS_BUCKET_ID"
+          value = google_storage_bucket.import_bucket.name
+        }
+        env {
+          name  = "LOCATION"
+          value = var.region
+        }
+        env {
+          name  = "BQ_DATASET_ID"
+          value = var.bq_dataset_id
+        }
+      }
+    }
+  }
+
+  depends_on = [google_project_service.services]
+}
+
 # --- Cloud Workflows ---
 
 resource "google_workflows_workflow" "import_automation_workflow" {

--- a/pipeline/workflow/aggregation-helper/Dockerfile
+++ b/pipeline/workflow/aggregation-helper/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.12-slim
+
+# Allow statements and log messages to immediately appear in the logs
+ENV PYTHONUNBUFFERED True
+
+WORKDIR /app
+
+# Copy local code to the container image
+COPY main.py .
+
+# Run the script
+ENTRYPOINT ["python", "main.py"]

--- a/pipeline/workflow/aggregation-helper/cloudbuild.yaml
+++ b/pipeline/workflow/aggregation-helper/cloudbuild.yaml
@@ -1,0 +1,39 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  # Build the container image
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [
+      'build',
+      '-t', '${_AR_REPO_URL}/${_IMAGE_NAME}:${_TAG}',
+      '-t', '${_AR_REPO_URL}/${_IMAGE_NAME}:${_VERSION}',
+      '.'
+    ]
+
+  # Push the container image tags
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '${_AR_REPO_URL}/${_IMAGE_NAME}:${_TAG}']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '${_AR_REPO_URL}/${_IMAGE_NAME}:${_VERSION}']
+
+substitutions:
+  _AR_REPO_URL: 'us-docker.pkg.dev/datcom-ci/gcr.io'
+  _IMAGE_NAME: 'datacommons-aggregation-helper'
+  _TAG: 'latest'
+  _VERSION: '${SHORT_SHA}'
+
+images:
+  - '${_AR_REPO_URL}/${_IMAGE_NAME}:${_TAG}'
+  - '${_AR_REPO_URL}/${_IMAGE_NAME}:${_VERSION}'

--- a/pipeline/workflow/aggregation-helper/main.py
+++ b/pipeline/workflow/aggregation-helper/main.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Aggregation Helper Cloud Run Job skeleton."""
+
+import argparse
+import json
+import logging
+import sys
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Starting Aggregation Helper Job")
+
+    parser = argparse.ArgumentParser(description="Run aggregation helper job.")
+    parser.add_argument("--import_list", help="JSON string representing the list of imports to process.")
+    
+    args = parser.parse_args()
+
+    if not args.import_list:
+        logging.error("Missing required argument: --import_list")
+        sys.exit(1)
+
+    try:
+        import_list = json.loads(args.import_list)
+        logging.info(f"Received import list: {import_list}")
+    except json.JSONDecodeError as e:
+        logging.error(f"Failed to parse import_list JSON: {e}")
+        sys.exit(1)
+
+    # Dummy logic
+    logging.info("Processing aggregation (dummy)...")
+    for imp in import_list:
+        logging.info(f"Processing import: {imp}")
+    
+    logging.info("Aggregation Helper Job completed successfully.")
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/workflow/build-services.yaml
+++ b/pipeline/workflow/build-services.yaml
@@ -34,6 +34,12 @@ steps:
   dir: 'pipeline/workflow'
   waitFor: ['-']
 
+- id: 'build-aggregation-helper'
+  name: 'gcr.io/cloud-builders/gcloud'
+  args: ['builds', 'submit', 'aggregation-helper', '--config', 'aggregation-helper/cloudbuild.yaml', '--substitutions', '_AR_REPO_URL=${_AR_REPO_URL},_VERSION=${_VERSION}']
+  dir: 'pipeline/workflow'
+  waitFor: ['-']
+
 - id: 'build-dataflow-template'
   name: 'gcr.io/cloud-builders/gcloud'
   args:

--- a/pipeline/workflow/deploy-services.yaml
+++ b/pipeline/workflow/deploy-services.yaml
@@ -41,6 +41,10 @@ steps:
   name: 'gcr.io/cloud-builders/gcloud'
   args: ['run', 'deploy', 'import-helper-service', '--image', '${_AR_REPO_URL}/datacommons-import-helper:${_VERSION}', '--region', '${_LOCATION}', '--project', '${_PROJECT_ID}', '--no-allow-unauthenticated', '--set-env-vars', 'PROJECT_ID=${_PROJECT_ID},LOCATION=${_LOCATION},PROJECT_NUMBER=${_PROJECT_NUMBER},GCS_BUCKET_ID=${_GCS_BUCKET_ID}']
 
+- id: 'aggregation-helper-job'
+  name: 'gcr.io/cloud-builders/gcloud'
+  args: ['run', 'jobs', 'deploy', 'aggregation-helper-job', '--image', '${_AR_REPO_URL}/datacommons-aggregation-helper:${_VERSION}', '--region', '${_LOCATION}', '--project', '${_PROJECT_ID}', '--tasks', '1', '--max-retries', '0', '--task-timeout', '60m', '--set-env-vars', 'PROJECT_ID=${_PROJECT_ID},LOCATION=${_LOCATION},SPANNER_PROJECT_ID=${_SPANNER_PROJECT_ID},SPANNER_INSTANCE_ID=${_SPANNER_INSTANCE_ID},SPANNER_DATABASE_ID=${_SPANNER_DATABASE_ID},SPANNER_GRAPH_DATABASE_ID=${_SPANNER_GRAPH_DATABASE_ID},GCS_BUCKET_ID=${_GCS_BUCKET_ID},BQ_DATASET_ID=${_BQ_DATASET_ID},BQ_SPANNER_CONN_ID=${_BQ_SPANNER_CONN_ID}']
+
 - id: 'import-automation-workflow'
   name: 'gcr.io/cloud-builders/gcloud'
   args: ['workflows', 'deploy', 'import-automation-workflow', '--project', '${_PROJECT_ID}', '--location', '${_LOCATION}', '--source', 'import-automation-workflow.yaml', '--set-env-vars', 'LOCATION=${_LOCATION},GCS_BUCKET_ID=${_GCS_BUCKET_ID},GCS_MOUNT_BUCKET=${_GCS_MOUNT_BUCKET},PROJECT_NUMBER=${_PROJECT_NUMBER}']

--- a/pipeline/workflow/spanner-ingestion-workflow.yaml
+++ b/pipeline/workflow/spanner-ingestion-workflow.yaml
@@ -70,7 +70,8 @@ main:
                 call: run_aggregation_job
                 args:
                   import_list: ${import_info.body}
-                  helper_url: ${helper_url}
+                  project_id: ${project_id}
+                  location: ${location}
             - update_ingestion_status:
                 call: http.post
                 args:
@@ -119,40 +120,20 @@ main:
 
 # This sub-workflow runs aggregation jobs and waits for them to complete.
 run_aggregation_job:
-  params: [import_list, helper_url]
+  params: [import_list, project_id, location]
   steps:
     - run_aggregation:
-        call: http.post
+        call: googleapis.run.v1.namespaces.jobs.run
         args:
-          url: ${helper_url + "/aggregation/run"}
-          timeout: 300
-          auth:
-            type: OIDC
+          name: ${"namespaces/" + project_id + "/jobs/aggregation-helper-job"}
+          location: ${location}
           body:
-            importList: ${import_list}
+            overrides:
+              containerOverrides:
+                - args:
+                    - "--import_list"
+                    - ${json.encode_to_string(import_list)}
         result: aggregation_response
-    - check_aggregation_status_loop:
-        steps:
-          - wait_for_aggregation:
-              call: sys.sleep
-              args:
-                seconds: 300
-          - check_aggregation_status:
-              call: http.post
-              args:
-                url: ${helper_url + "/aggregation/status"}
-                auth:
-                  type: OIDC
-                body:
-                  jobIds: ${aggregation_response.body.jobIds}
-              result: aggregation_status_response
-          - evaluate_aggregation_status:
-              switch:
-                - condition: ${aggregation_status_response.body.status == "DONE"}
-                  return: 'OK'
-                - condition: ${aggregation_status_response.body.status == "FAILED"}
-                  raise: ${aggregation_status_response.body.error}
-              next: check_aggregation_status_loop
 
 # This sub-workflow launches a Dataflow job and waits for it to complete.
 run_dataflow_job:
@@ -205,6 +186,8 @@ run_dataflow_job:
           location: '${location}'
           jobId: '${launch_result.job.id}'
           view: 'JOB_VIEW_SUMMARY'
+          query:
+            fields: 'currentState'
         result: job_status
         next: check_if_done
     - check_if_done:


### PR DESCRIPTION
We currently run aggregations as a cloud run service within the ingestion helper. As we add more aggregations, we need to handle dependency between different aggregations which require multi-step execution. Managing this within a stateless service gets cumbersome as we need to pass the state back-and-forth with the workflow to avoid timeouts. Thus, we are moving aggregations into a separate service that run as a cloud run job. 