### PR TITLE
Improve performance of "provenance summary" generation query

### DIFF
--- a/pipeline/workflow/ingestion-helper/aggregation/e2e_tests/aggregation_e2e_test.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/e2e_tests/aggregation_e2e_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Integration E2E tests for Data Commons aggregations.
+r"""Integration E2E tests for Data Commons aggregations.
 
 Covers:
 - LinkedEdgeGenerator (Linked Edges)
@@ -35,7 +35,7 @@ How to run:
 1. Ensure your local environment is authenticated (gcloud auth application-default login).
 2. Set the environment variables or edit the config below.
 3. Run the following command from the `import/pipeline/workflow/ingestion-helper` directory:
-   uv run pytest aggregation/e2e_tests/aggregation_e2e_test.py -s
+    GOOGLE_API_USE_CLIENT_CERTIFICATE=false UV_NO_CONFIG=1 UV_INDEX_URL=https://pypi.org/simple \uv run pytest aggregation/e2e_tests/aggregation_e2e_test.py -s
 """
 
 import os
@@ -717,6 +717,46 @@ class ProvenanceSummaryGeneratorIntegrationTest(AggregationIntegrationTestBase):
             # geoId/99 (Dangling: name should be None or empty, but must not crash)
             self.assertEqual(top_places[1]['dcid'], 'geoId/99')
             self.assertIsNone(top_places[1]['name']) # BigQuery LEFT JOIN returns NULL for missing name
+
+    def test_provenance_summary_aggregation_multiple_imports(self):
+        """Tests run_all with multiple imports at once."""
+        import_1 = 'Import_Alpha'
+        import_2 = 'Import_Beta'
+        
+        self.add_node('geoId/06', 'California', types=['State'])
+        self.add_edge('geoId/06', 'typeOf', 'State', import_1)
+        self.add_edge('geoId/06', 'typeOf', 'State', import_2)
+        
+        self.add_timeseries('Count_Person', 'geoId/06', 'Census', 'P1Y', '1', '1', import_1)
+        self.add_observation('Count_Person', 'geoId/06', '2020', 100.0, import_name=import_1)
+        
+        self.add_timeseries('Count_HousingUnit', 'geoId/06', 'Census', 'P1Y', '1', '1', import_2)
+        self.add_observation('Count_HousingUnit', 'geoId/06', '2020', 50.0, import_name=import_2)
+        
+        self.flush_to_spanner()
+        
+        generator = self.get_generator()
+        jobs = generator.run_all([import_1, import_2])
+        self.assertEqual(len(jobs), 1)
+        
+        with self.database.snapshot() as snapshot:
+            query = """
+                SELECT type, key, provenance, value
+                FROM Cache
+                WHERE type = 'ProvenanceSummary'
+                ORDER BY provenance, key
+            """
+            results = list(snapshot.execute_sql(query))
+            self.assertEqual(len(results), 2)
+            
+            prov_1 = f'dc/base/{import_1}' if self.is_base_dc else import_1
+            prov_2 = f'dc/base/{import_2}' if self.is_base_dc else import_2
+            
+            self.assertEqual(results[0][2], prov_1)
+            self.assertEqual(results[0][1], 'Count_Person')
+            
+            self.assertEqual(results[1][2], prov_2)
+            self.assertEqual(results[1][1], 'Count_HousingUnit')
 
 
 class ProvenanceSummaryGeneratorCustomDcTest(ProvenanceSummaryGeneratorIntegrationTest):

--- a/pipeline/workflow/ingestion-helper/aggregation/e2e_tests/aggregation_e2e_test.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/e2e_tests/aggregation_e2e_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r"""Integration E2E tests for Data Commons aggregations.
+"""Integration E2E tests for Data Commons aggregations.
 
 Covers:
 - LinkedEdgeGenerator (Linked Edges)
@@ -35,7 +35,7 @@ How to run:
 1. Ensure your local environment is authenticated (gcloud auth application-default login).
 2. Set the environment variables or edit the config below.
 3. Run the following command from the `import/pipeline/workflow/ingestion-helper` directory:
-    GOOGLE_API_USE_CLIENT_CERTIFICATE=false UV_NO_CONFIG=1 UV_INDEX_URL=https://pypi.org/simple \uv run pytest aggregation/e2e_tests/aggregation_e2e_test.py -s
+    uv run pytest aggregation/e2e_tests/aggregation_e2e_test.py -s
 """
 
 import os

--- a/pipeline/workflow/ingestion-helper/aggregation/provenance_summary_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/provenance_summary_generator.py
@@ -60,6 +60,8 @@ class ProvenanceSummaryGenerator:
 
         query = f"""  # nosec
         DECLARE place_dcids_str STRING;
+        DECLARE place_count INT64;
+        DECLARE sample_dcids_str STRING;
 
         -- Step 1: Fetch joined TimeSeries and Observation data from Spanner
         -- We filter by provenance (which corresponds to import_name with prefix)
@@ -96,31 +98,32 @@ class ProvenanceSummaryGenerator:
         CREATE OR REPLACE TEMPORARY TABLE `temp_dataset_places` AS
         SELECT DISTINCT observation_about FROM `temp_obs_flat`;
 
-        -- Step 3: Construct filtered IN clause string for Spanner pushdown of place IDs
-        SET place_dcids_str = (
-          SELECT IFNULL(STRING_AGG(FORMAT("'%s'", REPLACE(observation_about, "'", "\\'")), ','), "''")
-          FROM `temp_dataset_places`
-        );
+        SET place_count = (SELECT COUNT(*) FROM `temp_dataset_places`);
 
-        -- Step 4: Fetch ONLY place types for places in this dataset directly from Spanner
-        EXECUTE IMMEDIATE FORMAT('''
+        -- Step 3: Fetch place types for places in this dataset directly from Spanner
+        -- If place_count <= 10000, push down IN filter; otherwise stream all typeOf edges
+        IF place_count <= 10000 THEN
+          SET place_dcids_str = (
+            SELECT IFNULL(STRING_AGG(FORMAT("'%s'", REPLACE(observation_about, "'", "\\'")), ','), "''")
+            FROM `temp_dataset_places`
+          );
+
+          EXECUTE IMMEDIATE FORMAT('''
+            CREATE OR REPLACE TEMPORARY TABLE `temp_type_edges_filtered` AS
+            SELECT subject_id, object_id as place_type
+            FROM EXTERNAL_QUERY("{connection_id}",
+              "SELECT subject_id, object_id FROM Edge WHERE predicate = 'typeOf' AND subject_id IN (%s)"
+            );
+          ''', place_dcids_str);
+        ELSE
           CREATE OR REPLACE TEMPORARY TABLE `temp_type_edges_filtered` AS
           SELECT subject_id, object_id as place_type
           FROM EXTERNAL_QUERY("{connection_id}",
-            "SELECT subject_id, object_id FROM Edge WHERE predicate = 'typeOf' AND subject_id IN (%s)"
+            "SELECT subject_id, object_id FROM Edge WHERE predicate = 'typeOf'"
           );
-        ''', place_dcids_str);
+        END IF;
 
-        -- Step 5: Fetch ONLY place names for places in this dataset directly from Spanner
-        EXECUTE IMMEDIATE FORMAT('''
-          CREATE OR REPLACE TEMPORARY TABLE `temp_node_names_filtered` AS
-          SELECT subject_id, name
-          FROM EXTERNAL_QUERY("{connection_id}",
-            "SELECT subject_id, name FROM Node WHERE subject_id IN (%s)"
-          );
-        ''', place_dcids_str);
-
-        -- Step 6: Join observations with filtered place_type only
+        -- Step 4: Join observations with filtered place_type only
         CREATE OR REPLACE TEMPORARY TABLE `temp_prepared` AS
         SELECT 
           raw.*,
@@ -128,6 +131,42 @@ class ProvenanceSummaryGenerator:
           edges.place_type
         FROM `temp_obs_flat` raw
         LEFT JOIN `temp_type_edges_filtered` edges ON raw.observation_about = edges.subject_id;
+
+        -- Step 5: Extract top 3 sample place DCIDs per summary group
+        CREATE OR REPLACE TEMPORARY TABLE `temp_top_place_dcids` AS
+        WITH distinct_places AS (
+          SELECT DISTINCT
+            variable_measured,
+            provenance,
+            facet_id,
+            place_type,
+            observation_about as dcid
+          FROM `temp_prepared`
+          WHERE place_type IS NOT NULL
+        )
+        SELECT
+          variable_measured,
+          provenance,
+          facet_id,
+          place_type,
+          ARRAY_AGG(dcid ORDER BY dcid LIMIT 3) as top_dcids
+        FROM distinct_places
+        GROUP BY variable_measured, provenance, facet_id, place_type;
+
+        -- Step 6: Fetch ONLY place names for the selected top sample places from Spanner
+        SET sample_dcids_str = (
+          SELECT IFNULL(STRING_AGG(DISTINCT FORMAT("'%s'", REPLACE(dcid, "'", "\\'")), ','), "''")
+          FROM `temp_top_place_dcids`
+          CROSS JOIN UNNEST(top_dcids) as dcid
+        );
+
+        EXECUTE IMMEDIATE FORMAT('''
+          CREATE OR REPLACE TEMPORARY TABLE `temp_node_names_filtered` AS
+          SELECT subject_id, name
+          FROM EXTERNAL_QUERY("{connection_id}",
+            "SELECT subject_id, name FROM Node WHERE subject_id IN (%s)"
+          );
+        ''', sample_dcids_str);
 
         -- Step 7: Aggregate Place Type Summaries and attach names to top 3 sample places
         CREATE OR REPLACE TEMPORARY TABLE `temp_place_type_summary` AS
@@ -144,26 +183,6 @@ class ProvenanceSummaryGenerator:
           WHERE place_type IS NOT NULL
           GROUP BY variable_measured, provenance, facet_id, place_type
         ),
-        distinct_places AS (
-          SELECT DISTINCT
-            variable_measured,
-            provenance,
-            facet_id,
-            place_type,
-            observation_about as dcid
-          FROM `temp_prepared`
-          WHERE place_type IS NOT NULL
-        ),
-        top_place_dcids AS (
-          SELECT
-            variable_measured,
-            provenance,
-            facet_id,
-            place_type,
-            ARRAY_AGG(dcid ORDER BY dcid LIMIT 3) as top_dcids
-          FROM distinct_places
-          GROUP BY variable_measured, provenance, facet_id, place_type
-        ),
         aggregated_places AS (
           SELECT
             tp.variable_measured,
@@ -174,7 +193,7 @@ class ProvenanceSummaryGenerator:
               STRUCT(dcid, names.name)
               ORDER BY dcid
             ) as top_places
-          FROM top_place_dcids tp
+          FROM `temp_top_place_dcids` tp
           CROSS JOIN UNNEST(tp.top_dcids) as dcid
           LEFT JOIN `temp_node_names_filtered` names ON dcid = names.subject_id
           GROUP BY tp.variable_measured, tp.provenance, tp.facet_id, tp.place_type

--- a/pipeline/workflow/ingestion-helper/aggregation/provenance_summary_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/provenance_summary_generator.py
@@ -174,8 +174,8 @@ class ProvenanceSummaryGenerator:
               STRUCT(dcid, names.name)
               ORDER BY dcid
             ) as top_places
-          FROM top_place_dcids tp,
-          UNNEST(tp.top_dcids) as dcid
+          FROM top_place_dcids tp
+          CROSS JOIN UNNEST(tp.top_dcids) as dcid
           LEFT JOIN `temp_node_names_filtered` names ON dcid = names.subject_id
           GROUP BY tp.variable_measured, tp.provenance, tp.facet_id, tp.place_type
         )

--- a/pipeline/workflow/ingestion-helper/aggregation/provenance_summary_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/provenance_summary_generator.py
@@ -59,6 +59,8 @@ class ProvenanceSummaryGenerator:
         provenances_str = ", ".join(provenances)
 
         query = f"""  # nosec
+        DECLARE place_dcids_str STRING;
+
         -- Step 1: Fetch joined TimeSeries and Observation data from Spanner
         -- We filter by provenance (which corresponds to import_name with prefix)
         CREATE OR REPLACE TEMPORARY TABLE `temp_obs_flat` AS
@@ -90,30 +92,44 @@ class ProvenanceSummaryGenerator:
              JOIN Observation USING (variable_measured, entity1, extra_entities_id, facet_id)
              WHERE provenance IN ({provenances_str}) ''');
 
-        -- Step 2: Fetch ALL Node names (Narrow selection to reduce data transfer)
-        CREATE OR REPLACE TEMPORARY TABLE `temp_node_names` AS
-        SELECT subject_id, name 
-        FROM EXTERNAL_QUERY("{connection_id}",
-          "SELECT subject_id, name FROM Node WHERE name IS NOT NULL");
+        -- Step 2: Extract distinct place IDs in this dataset
+        CREATE OR REPLACE TEMPORARY TABLE `temp_dataset_places` AS
+        SELECT DISTINCT observation_about FROM `temp_obs_flat`;
 
-        -- Step 3: Fetch ALL typeOf edges (Narrow selection)
-        CREATE OR REPLACE TEMPORARY TABLE `temp_type_edges` AS
-        SELECT subject_id, object_id as place_type
-        FROM EXTERNAL_QUERY("{connection_id}",
-          "SELECT subject_id, object_id FROM Edge WHERE predicate = 'typeOf'");
+        -- Step 3: Construct filtered IN clause string for Spanner pushdown of place IDs
+        SET place_dcids_str = (
+          SELECT IFNULL(STRING_AGG(FORMAT("'%s'", REPLACE(observation_about, "'", "\\'")), ','), "''")
+          FROM `temp_dataset_places`
+        );
 
-        -- Step 4: Join and Flatten in BigQuery
+        -- Step 4: Fetch ONLY place types for places in this dataset directly from Spanner
+        EXECUTE IMMEDIATE FORMAT('''
+          CREATE OR REPLACE TEMPORARY TABLE `temp_type_edges_filtered` AS
+          SELECT subject_id, object_id as place_type
+          FROM EXTERNAL_QUERY("{connection_id}",
+            "SELECT subject_id, object_id FROM Edge WHERE predicate = 'typeOf' AND subject_id IN (%s)"
+          );
+        ''', place_dcids_str);
+
+        -- Step 5: Fetch ONLY place names for places in this dataset directly from Spanner
+        EXECUTE IMMEDIATE FORMAT('''
+          CREATE OR REPLACE TEMPORARY TABLE `temp_node_names_filtered` AS
+          SELECT subject_id, name
+          FROM EXTERNAL_QUERY("{connection_id}",
+            "SELECT subject_id, name FROM Node WHERE subject_id IN (%s)"
+          );
+        ''', place_dcids_str);
+
+        -- Step 6: Join observations with filtered place_type only
         CREATE OR REPLACE TEMPORARY TABLE `temp_prepared` AS
         SELECT 
           raw.*,
           IF(raw.provenance LIKE 'dc/base/%', SUBSTR(raw.provenance, 9), raw.provenance) as import_name,
-          nodes.name as place_name,
           edges.place_type
         FROM `temp_obs_flat` raw
-        LEFT JOIN `temp_node_names` nodes ON raw.observation_about = nodes.subject_id
-        LEFT JOIN `temp_type_edges` edges ON raw.observation_about = edges.subject_id;
+        LEFT JOIN `temp_type_edges_filtered` edges ON raw.observation_about = edges.subject_id;
 
-        -- Step 5: Aggregate Place Type Summaries (with distinct top_places)
+        -- Step 6: Aggregate Place Type Summaries and attach names to top 3 sample places
         CREATE OR REPLACE TEMPORARY TABLE `temp_place_type_summary` AS
         WITH place_stats AS (
           SELECT
@@ -134,23 +150,34 @@ class ProvenanceSummaryGenerator:
             provenance,
             facet_id,
             place_type,
-            observation_about as dcid,
-            place_name as name
+            observation_about as dcid
           FROM `temp_prepared`
           WHERE place_type IS NOT NULL
         ),
-        aggregated_places AS (
+        top_place_dcids AS (
           SELECT
             variable_measured,
             provenance,
             facet_id,
             place_type,
-            ARRAY_AGG(
-              STRUCT(dcid, name)
-              ORDER BY dcid LIMIT 3
-            ) as top_places
+            ARRAY_AGG(dcid ORDER BY dcid LIMIT 3) as top_dcids
           FROM distinct_places
           GROUP BY variable_measured, provenance, facet_id, place_type
+        ),
+        aggregated_places AS (
+          SELECT
+            tp.variable_measured,
+            tp.provenance,
+            tp.facet_id,
+            tp.place_type,
+            ARRAY_AGG(
+              STRUCT(dcid, names.name)
+              ORDER BY dcid
+            ) as top_places
+          FROM top_place_dcids tp,
+          UNNEST(tp.top_dcids) as dcid
+          LEFT JOIN `temp_node_names_filtered` names ON dcid = names.subject_id
+          GROUP BY tp.variable_measured, tp.provenance, tp.facet_id, tp.place_type
         )
         SELECT
           ps.variable_measured,

--- a/pipeline/workflow/ingestion-helper/aggregation/provenance_summary_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/provenance_summary_generator.py
@@ -129,7 +129,7 @@ class ProvenanceSummaryGenerator:
         FROM `temp_obs_flat` raw
         LEFT JOIN `temp_type_edges_filtered` edges ON raw.observation_about = edges.subject_id;
 
-        -- Step 6: Aggregate Place Type Summaries and attach names to top 3 sample places
+        -- Step 7: Aggregate Place Type Summaries and attach names to top 3 sample places
         CREATE OR REPLACE TEMPORARY TABLE `temp_place_type_summary` AS
         WITH place_stats AS (
           SELECT
@@ -191,7 +191,7 @@ class ProvenanceSummaryGenerator:
         FROM place_stats ps
         JOIN aggregated_places ap USING (variable_measured, provenance, facet_id, place_type);
 
-        -- Step 6: Final aggregation and export to Cache
+        -- Step 8: Final aggregation and export to Cache
         EXPORT DATA
           OPTIONS( uri="{dest}",
             format='CLOUD_SPANNER',


### PR DESCRIPTION
This PR improves the performance of "provenance summary" generation query.

Broadly, the performance improvements are due to:

- Some early filtering on Spanner side so that less data is streamed to BigQuery.
- On Bigquery side:
  - I created temp tables to buffer the streamed data instead of loading it into memory directly.
  - I applied further filters on BQ before applying joins to reduce intermediate processing.

To measure the improvements, I did some benchmarking on staging DB with Jetski's help on 3 different imports of varying sizes. Below are the results:

| Scale Category | Dataset Name | Time Series Count | Total Observations | BigQuery Data Processed | Total Execution Time |
| :---- | :---- | :---- | :---- | :---- | :---- |
| Small | Adolescent\_Birth\_Rate | 439 | 7,403 | 18.3 MB | 159.75s (\~2.6 min) |
| Medium | BEAGDPv2 | 84,123 | \~2.1 Million | 579 MB | 151.60s (\~2.5 min) |
| Very Large | BLS\_QCEW | 58,446,698 | \~640 Million | 2.77 TB | 869.76s (\~14.4 min) |

I also benchmarked the processing of all 3 imports at once, and it took ~23.2 minutes.