### PR TITLE
[DCP Ingestion - ImportHistory] Modify the schema to support the node/obs counts in ImportVersionHistory

### DIFF
--- a/pipeline/workflow/ingestion-helper/app_test.py
+++ b/pipeline/workflow/ingestion-helper/app_test.py
@@ -253,10 +253,10 @@ class TestMain(unittest.TestCase):
 
         # Verify spanner was called with the overridden comment containing caller
         mock_spanner_client.update_version_history.assert_any_call(
-            "import1", "ver_import1", "version-override:test-caller release-comment"
+            "import1", "ver_import1", "version-override:test-caller release-comment", workflow_id=None, status="STAGING"
         )
         mock_spanner_client.update_version_history.assert_any_call(
-            "import2", "ver_import2", "version-override:test-caller release-comment"
+            "import2", "ver_import2", "version-override:test-caller release-comment", workflow_id=None, status="STAGING"
         )
         self.assertEqual(mock_spanner_client.update_version_history.call_count, 2)
         self.assertEqual(mock_spanner_client.update_import_status.call_count, 2)

--- a/pipeline/workflow/ingestion-helper/clients/schema.sql
+++ b/pipeline/workflow/ingestion-helper/clients/schema.sql
@@ -132,7 +132,14 @@ CREATE TABLE ImportVersionHistory (
   ImportName STRING(MAX) NOT NULL,
   Version STRING(MAX) NOT NULL,
   UpdateTimestamp TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+  WorkflowExecutionID STRING(1024),
+  Status STRING(1024),
+  ExecutionTime INT64,
+  NodeCount INT64,
+  EdgeCount INT64,
+  ObservationCount INT64,
   Comment STRING(MAX),
+  CONSTRAINT FKIngestionHistory FOREIGN KEY (WorkflowExecutionID) REFERENCES IngestionHistory (WorkflowExecutionID),
 ) PRIMARY KEY (ImportName, UpdateTimestamp DESC);
 
 CREATE TABLE IngestionLock (

--- a/pipeline/workflow/ingestion-helper/clients/schema.sql
+++ b/pipeline/workflow/ingestion-helper/clients/schema.sql
@@ -139,7 +139,6 @@ CREATE TABLE ImportVersionHistory (
   EdgeCount INT64,
   ObservationCount INT64,
   Comment STRING(MAX),
-  CONSTRAINT FKIngestionHistory FOREIGN KEY (WorkflowExecutionID) REFERENCES IngestionHistory (WorkflowExecutionID),
 ) PRIMARY KEY (ImportName, UpdateTimestamp DESC);
 
 CREATE TABLE IngestionLock (

--- a/pipeline/workflow/ingestion-helper/clients/spanner.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner.py
@@ -423,13 +423,18 @@ class SpannerClient:
             logging.error(f'Error updating IngestionHistory table (v2): {e}')
             raise
 
-    def update_import_version_history(self, import_list_json: list,
-                                      workflow_id: str):
+    def update_import_version_history(self,
+                                      import_list_json: list,
+                                      workflow_id: str,
+                                      status: str | None = None,
+                                      metrics: dict | None = None):
         """Updates the ImportVersionHistory table.
 
         Args:
             import_list_json: A list of dictionaries containing import details.
             workflow_id: The ID of the workflow.
+            status: The status of the import execution.
+            metrics: Optional dictionary containing execution metrics.
         """
         if not import_list_json:
             return
@@ -439,13 +444,21 @@ class SpannerClient:
 
         def _insert(transaction: Transaction):
             version_history_columns = [
-                "ImportName", "Version", "UpdateTimestamp", "Comment"
+                "ImportName", "Version", "UpdateTimestamp",
+                "WorkflowExecutionID", "Status", "ExecutionTime", "NodeCount",
+                "EdgeCount", "ObservationCount", "Comment"
             ]
+            m = metrics if metrics else {}
             version_history_values = []
             for import_json in import_list_json:
                 version_history_values.append([
                     import_json['importName'], import_json['latestVersion'],
-                    spanner.COMMIT_TIMESTAMP,
+                    spanner.COMMIT_TIMESTAMP, workflow_id,
+                    status,
+                    m.get('execution_time', 0),
+                    m.get('node_count', 0),
+                    m.get('edge_count', 0),
+                    m.get('obs_count', 0),
                     "ingestion-workflow:" + workflow_id
                 ])
 
@@ -521,21 +534,42 @@ class SpannerClient:
                 f'Error updating import status for {import_name}: {e}')
             raise
 
-    def update_version_history(self, import_name: str, version: str,
-                               comment: str):
+    def update_version_history(self,
+                               import_name: str,
+                               version: str,
+                               comment: str,
+                               workflow_id: str | None = None,
+                               status: str | None = None,
+                               metrics: dict | None = None):
         """Updates the version history table.
 
         Args:
             import_name: The name of the import.
             version: The version string.
             comment: The comment for the update.
+            workflow_id: The ID of the workflow execution if applicable.
+            status: The status of the import execution.
+            metrics: Optional dictionary containing execution metrics.
         """
         import_name = import_name.split(':')[-1]
         logging.info(f"Updating version history for {import_name} to {version}")
 
         def _record(transaction: Transaction):
-            columns = ["ImportName", "Version", "UpdateTimestamp", "Comment"]
-            values = [[import_name, version, spanner.COMMIT_TIMESTAMP, comment]]
+            columns = [
+                "ImportName", "Version", "UpdateTimestamp",
+                "WorkflowExecutionID", "Status", "ExecutionTime", "NodeCount",
+                "EdgeCount", "ObservationCount", "Comment"
+            ]
+            m = metrics if metrics else {}
+            values = [[
+                import_name, version, spanner.COMMIT_TIMESTAMP, workflow_id,
+                status,
+                m.get('execution_time', 0),
+                m.get('node_count', 0),
+                m.get('edge_count', 0),
+                m.get('obs_count', 0),
+                comment
+            ]]
             transaction.insert(table="ImportVersionHistory",
                                columns=columns,
                                values=values)

--- a/pipeline/workflow/ingestion-helper/clients/spanner.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner.py
@@ -326,10 +326,10 @@ class SpannerClient:
                 workflow_id,
                 job_id if job_id else "",
                 ingested_imports if ingested_imports else [],
-                m.get('execution_time', 0),
-                m.get('node_count', 0),
-                m.get('edge_count', 0),
-                m.get('obs_count', 0)
+                m.get('execution_time'),
+                m.get('node_count'),
+                m.get('edge_count'),
+                m.get('obs_count')
             ]]
             transaction.insert_or_update(table="IngestionHistory",
                                          columns=columns,
@@ -455,10 +455,10 @@ class SpannerClient:
                     import_json['importName'], import_json['latestVersion'],
                     spanner.COMMIT_TIMESTAMP, workflow_id,
                     status,
-                    m.get('execution_time', 0),
-                    m.get('node_count', 0),
-                    m.get('edge_count', 0),
-                    m.get('obs_count', 0),
+                    m.get('execution_time'),
+                    m.get('node_count'),
+                    m.get('edge_count'),
+                    m.get('obs_count'),
                     "ingestion-workflow:" + workflow_id
                 ])
 
@@ -564,10 +564,10 @@ class SpannerClient:
             values = [[
                 import_name, version, spanner.COMMIT_TIMESTAMP, workflow_id,
                 status,
-                m.get('execution_time', 0),
-                m.get('node_count', 0),
-                m.get('edge_count', 0),
-                m.get('obs_count', 0),
+                m.get('execution_time'),
+                m.get('node_count'),
+                m.get('edge_count'),
+                m.get('obs_count'),
                 comment
             ]]
             transaction.insert(table="ImportVersionHistory",

--- a/pipeline/workflow/ingestion-helper/clients/spanner_test.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner_test.py
@@ -706,7 +706,7 @@ class TestSpannerClient(unittest.TestCase):
         ])
         self.assertEqual(kwargs['values'], [[
             "test_import", "v1.2.3", spanner.COMMIT_TIMESTAMP, "wf-123",
-            None, 0, 0, 0, 0, "ingestion-workflow:wf-123"
+            None, None, None, None, None, "ingestion-workflow:wf-123"
         ]])
 
     @patch('google.cloud.spanner.Client')
@@ -734,7 +734,7 @@ class TestSpannerClient(unittest.TestCase):
         ])
         self.assertEqual(kwargs['values'], [[
             "test_import", "v1.2.3", spanner.COMMIT_TIMESTAMP, "wf-789",
-            None, 0, 0, 0, 0, "ingestion-workflow:wf-789"
+            None, None, None, None, None, "ingestion-workflow:wf-789"
         ]])
 
 if __name__ == '__main__':

--- a/pipeline/workflow/ingestion-helper/clients/spanner_test.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner_test.py
@@ -680,6 +680,63 @@ class TestSpannerClient(unittest.TestCase):
         self.assertEqual(values[failure_idx], True)
         self.assertEqual(values[comp_time_idx], spanner.COMMIT_TIMESTAMP)
 
+    @patch('google.cloud.spanner.Client')
+    def test_update_import_version_history(self, mock_spanner_client):
+        mock_instance = MagicMock()
+        mock_db = MagicMock()
+        mock_spanner_client.return_value.instance.return_value = mock_instance
+        mock_instance.database.return_value = mock_db
+
+        mock_transaction = MagicMock()
+        def run_in_transaction_side_effect(callback, *args, **kwargs):
+            return callback(mock_transaction, *args, **kwargs)
+        mock_db.run_in_transaction.side_effect = run_in_transaction_side_effect
+
+        client = SpannerClient("project", "instance", "database")
+        import_list = [{"importName": "test_import", "latestVersion": "v1.2.3"}]
+        client.update_import_version_history(import_list, workflow_id="wf-123")
+
+        mock_transaction.insert.assert_called_once()
+        _, kwargs = mock_transaction.insert.call_args
+        self.assertEqual(kwargs['table'], 'ImportVersionHistory')
+        self.assertEqual(kwargs['columns'], [
+            "ImportName", "Version", "UpdateTimestamp",
+            "WorkflowExecutionID", "Status", "ExecutionTime", "NodeCount",
+            "EdgeCount", "ObservationCount", "Comment"
+        ])
+        self.assertEqual(kwargs['values'], [[
+            "test_import", "v1.2.3", spanner.COMMIT_TIMESTAMP, "wf-123",
+            None, 0, 0, 0, 0, "ingestion-workflow:wf-123"
+        ]])
+
+    @patch('google.cloud.spanner.Client')
+    def test_update_version_history(self, mock_spanner_client):
+        mock_instance = MagicMock()
+        mock_db = MagicMock()
+        mock_spanner_client.return_value.instance.return_value = mock_instance
+        mock_instance.database.return_value = mock_db
+
+        mock_transaction = MagicMock()
+        def run_in_transaction_side_effect(callback, *args, **kwargs):
+            return callback(mock_transaction, *args, **kwargs)
+        mock_db.run_in_transaction.side_effect = run_in_transaction_side_effect
+
+        client = SpannerClient("project", "instance", "database")
+        client.update_version_history("test_import", "v1.2.3", "ingestion-workflow:wf-789", workflow_id="wf-789")
+
+        mock_transaction.insert.assert_called_once()
+        _, kwargs = mock_transaction.insert.call_args
+        self.assertEqual(kwargs['table'], 'ImportVersionHistory')
+        self.assertEqual(kwargs['columns'], [
+            "ImportName", "Version", "UpdateTimestamp",
+            "WorkflowExecutionID", "Status", "ExecutionTime", "NodeCount",
+            "EdgeCount", "ObservationCount", "Comment"
+        ])
+        self.assertEqual(kwargs['values'], [[
+            "test_import", "v1.2.3", spanner.COMMIT_TIMESTAMP, "wf-789",
+            None, 0, 0, 0, 0, "ingestion-workflow:wf-789"
+        ]])
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/pipeline/workflow/ingestion-helper/routes/imports.py
+++ b/pipeline/workflow/ingestion-helper/routes/imports.py
@@ -63,6 +63,7 @@ class ImportStatusItem(BaseModel):
 class UpdateImportStatusRequest(BaseModel):
     imports: List[ImportStatusItem]
     jobId: Optional[str] = None
+    workflowId: Optional[str] = None
     executionTime: Optional[int] = None
     dataVolume: Optional[int] = None
     nextRefresh: Optional[str] = None
@@ -71,6 +72,8 @@ class UpdateImportVersionRequest(BaseModel):
     imports: List[str]
     version: str
     comment: str
+    workflowId: Optional[str] = None
+    jobId: Optional[str] = None
     override: Optional[bool] = False
     triggerIngestion: Optional[bool] = False
 
@@ -98,19 +101,20 @@ def update_ingestion_status(req: UpdateIngestionStatusRequest, spanner: SpannerC
     status_str = req.status.value if hasattr(req.status, 'value') else req.status
     spanner.update_ingestion_status(ingested_imports, req.workflowId, status_str)
 
+    metrics = None
+    if req.jobId and req.jobId != "N/A":
+        try:
+            metrics = import_utils.get_ingestion_metrics(config.PROJECT_ID, config.LOCATION, req.jobId)
+        except Exception as e:
+            logging.error(f"Failed to fetch metrics for job {req.jobId}: {e}")
+            metrics = None
+
     if not config.ENABLE_UNIQUE_INGESTION_RUNS:
-        metrics = None
-        if req.jobId and req.jobId != "N/A":
-            try:
-                metrics = import_utils.get_ingestion_metrics(config.PROJECT_ID, config.LOCATION, req.jobId)
-            except Exception as e:
-                logging.error(f"Failed to fetch metrics for job {req.jobId}: {e}")
-                metrics = None
         spanner.update_ingestion_history_v1(req.workflowId, req.jobId, ingested_imports, metrics)
     
     if req.status == IngestionState.SUCCESS:
         import_list_dicts = [item.model_dump() for item in req.importList]
-        spanner.update_import_version_history(import_list_dicts, req.workflowId)
+        spanner.update_import_version_history(import_list_dicts, req.workflowId, status=status_str, metrics=metrics)
     return BaseResponse(status=ResponseStatus.OK)
 
 @router.post("/ingestion-history", response_model=BaseResponse)
@@ -183,8 +187,10 @@ def update_import_status(
             storage.update_provenance_file(item.importName, version)
             storage.update_import_summary(params)
             storage.update_version_file(item.importName, version, is_staging=False)
-            comment = f"import-workflow:{req.jobId or ''}"
-            spanner.update_version_history(item.importName, version, comment)
+            wf_id = req.workflowId or req.jobId
+            comment = f"import-workflow:{wf_id or ''}"
+            status_val = item.status.value if hasattr(item.status, 'value') else item.status
+            spanner.update_version_history(item.importName, version, comment, workflow_id=wf_id, status=status_val)
             
         spanner.update_import_status(params)
     return BaseResponse(status=ResponseStatus.OK)
@@ -217,7 +223,8 @@ def update_import_version(
         if params['status'] == 'STAGING':
             storage.update_provenance_file(import_name, version)
             storage.update_version_file(import_name, version, is_staging=False)
-            spanner.update_version_history(import_name, version, comment)
+            wf_id = req.workflowId or req.jobId
+            spanner.update_version_history(import_name, version, comment, workflow_id=wf_id, status="STAGING")
             logging.info(f"Updated import {import_name} to version {version}")
         else:
             logging.info(f"Skipping {import_name} version update")


### PR DESCRIPTION
And adds the workflowID as a key in IVH table to join on IngesitonHistory.

Note that the table counts are not yet fully working. We will need to update Dataflow to pass per-import counts, and propagate them through the workflow. This just lays the foundation for that, and brings the schema changes + API Changes.