### PR TITLE
integration test: handle emulator to enable using spanner omni emulator for local and testing

### DIFF
--- a/pipeline/ingestion/pom.xml
+++ b/pipeline/ingestion/pom.xml
@@ -18,16 +18,16 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.apache.beam</groupId>
-                <artifactId>beam-sdks-java-google-cloud-platform-bom</artifactId>
-                <version>${beam.version}</version>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>libraries-bom-protobuf3</artifactId>
+                <version>26.74.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.google.cloud</groupId>
-                <artifactId>libraries-bom</artifactId>
-                <version>26.62.0</version>
+                <groupId>org.apache.beam</groupId>
+                <artifactId>beam-sdks-java-google-cloud-platform-bom</artifactId>
+                <version>${beam.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
@@ -58,6 +58,14 @@ public class GraphIngestionPipeline {
       options.setIsBaseDc(Boolean.parseBoolean(isBaseDcEnv));
     }
 
+    String emulatorHost = options.getEmulatorHost();
+    if (emulatorHost != null && !emulatorHost.isEmpty()) {
+      if ("production".equalsIgnoreCase(System.getenv("ENVIRONMENT"))) {
+        throw new SecurityException(
+            "CRITICAL: Emulator settings detected in production environment!");
+      }
+    }
+
     SpannerClient spannerClient =
         SpannerClient.builder()
             .gcpProjectId(options.getProjectId())
@@ -68,6 +76,7 @@ public class GraphIngestionPipeline {
             .timeSeriesTableName(options.getSpannerTimeSeriesTableName())
             .observationTableName(options.getSpannerObservationTableName())
             .numShards(options.getNumShards())
+            .emulatorHost(emulatorHost)
             .build();
 
     Pipeline pipeline = Pipeline.create(options);

--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/IngestionPipelineOptions.java
@@ -94,4 +94,9 @@ public interface IngestionPipelineOptions extends PipelineOptions {
   boolean getSkipWait();
 
   void setSkipWait(boolean skipWait);
+
+  @Description("Local Spanner emulator host override (e.g. localhost:15000)")
+  String getEmulatorHost();
+
+  void setEmulatorHost(String emulatorHost);
 }

--- a/pipeline/pom.xml
+++ b/pipeline/pom.xml
@@ -28,16 +28,16 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.apache.beam</groupId>
-                <artifactId>beam-sdks-java-google-cloud-platform-bom</artifactId>
-                <version>${beam.version}</version>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>libraries-bom-protobuf3</artifactId>
+                <version>26.74.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.google.cloud</groupId>
-                <artifactId>libraries-bom</artifactId>
-                <version>26.62.0</version>
+                <groupId>org.apache.beam</groupId>
+                <artifactId>beam-sdks-java-google-cloud-platform-bom</artifactId>
+                <version>${beam.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pipeline/workflow/ingestion-helper/clients/spanner.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner.py
@@ -60,15 +60,29 @@ class SpannerClient:
                  models: list[dict] = None,
                  embedding_space: int = 768,
                  embedding_table: str = "NodeEmbedding",
-                 embedding_index: str = "NodeEmbeddingIndex"):
+                 embedding_index: str = "NodeEmbeddingIndex",
+                 emulator_host: str = None):
         """Initializes a Spanner client and connects to a specific database."""
+        client_options = {"api_endpoint": "spanner.googleapis.com"}
+        credentials = None
+        if emulator_host:
+            if os.environ.get("ENVIRONMENT", "").lower() == "production":
+                raise ValueError(
+                    "CRITICAL: Emulator settings detected in production environment!"
+                )
+            from google.auth.credentials import AnonymousCredentials
+
+            credentials = AnonymousCredentials()
+            client_options["api_endpoint"] = emulator_host
+        else:
+            client_options["quota_project_id"] = project_id
+
         spanner_client = spanner.Client(
             project=project_id,
-            client_options={
-                'quota_project_id': project_id,
-                'api_endpoint': 'spanner.googleapis.com'
-            },
-            disable_builtin_metrics=True)
+            credentials=credentials,
+            client_options=client_options,
+            disable_builtin_metrics=True,
+        )
         instance = spanner_client.instance(instance_id)
         database = instance.database(database_id)
         logging.info(f"Successfully initialized database: {database.name}")

--- a/pipeline/workflow/ingestion-helper/config.py
+++ b/pipeline/workflow/ingestion-helper/config.py
@@ -112,4 +112,5 @@ GCS_OUTPUT_PREFIX = os.environ.get('GCS_OUTPUT_PREFIX', '')
 # Env variable to control the updated logic on IngestionHistory table.
 # To be deleted after Base DC workflow is migrated.
 ENABLE_UNIQUE_INGESTION_RUNS = os.environ.get('ENABLE_UNIQUE_INGESTION_RUNS', 'false').lower() == 'true'
+SPANNER_EMULATOR_HOST = os.environ.get('SPANNER_EMULATOR_HOST')
 

--- a/pipeline/workflow/ingestion-helper/dependencies.py
+++ b/pipeline/workflow/ingestion-helper/dependencies.py
@@ -38,7 +38,8 @@ def get_spanner_client() -> SpannerClient:
             models=config.EMBEDDING_MODELS,
             embedding_space=config.EMBEDDING_SPACE,
             embedding_table=config.EMBEDDING_TABLE,
-            embedding_index=config.EMBEDDING_INDEX
+            embedding_index=config.EMBEDDING_INDEX,
+            emulator_host=config.SPANNER_EMULATOR_HOST
         )
     return _spanner_client
 


### PR DESCRIPTION
I'm working on adding an emulator based test for [DCP](https://github.com/datacommonsorg/datacommons/pull/156). 

prior to this PR, it was impossible to run the loader pipeline against a local Spanner emulator (like Spanner Omni) because the loader had no way to receive the emulator's port/endpoint or bypass Google Cloud authentication checks.