### PR TITLE
Refactor E2E tests for aggregations to run through AggregationOrchestrator

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/base.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/base.py
@@ -15,17 +15,19 @@
 
 import os
 import sys
+import tempfile
 import unittest
 import logging
 import json
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Dict, List
+import yaml
 from google.cloud import spanner
 from google.cloud import bigquery
 
 # Add aggregation-helper to sys.path (two levels up from this file)
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-from aggregation import BigQueryExecutor
+from aggregation import BigQueryExecutor, AggregationOrchestrator, AggregationRunResult
 
 # Configuration
 PROJECT_ID = os.environ.get('PROJECT_ID', 'datcom-ci')
@@ -159,3 +161,38 @@ class AggregationIntegrationTestBase(unittest.TestCase):
                     values=self.mock_observations
                 )
             self.mock_observations = []
+
+    def run_orchestrator(
+        self,
+        calculations: List[Dict[str, Any]],
+        active_imports: List[str],
+        dry_run: bool = False,
+        run_sequential: bool = True,
+        poll_interval: int = 3
+    ) -> AggregationRunResult:
+        """Helper to run AggregationOrchestrator with the given calculation configuration.
+
+        Serializes the calculation definitions to a temporary YAML file so that validate_config()
+        verifies schema compliance when the orchestrator initializes, then runs the pipeline.
+        """
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as tmp_file:
+            yaml.dump({"calculations": calculations}, tmp_file)
+            tmp_path = tmp_file.name
+
+        try:
+            orchestrator = AggregationOrchestrator(
+                connection_id=BQ_CONNECTION_ID,
+                project_id=PROJECT_ID,
+                instance_id=SPANNER_INSTANCE_ID,
+                database_id=SPANNER_DATABASE_ID,
+                location=BQ_LOCATION,
+                is_base_dc=self.is_base_dc,
+                config_file_path=tmp_path,
+                run_sequential=run_sequential,
+                poll_interval=poll_interval
+            )
+            return orchestrator.run(active_imports=active_imports, dry_run=dry_run)
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/base.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/base.py
@@ -175,11 +175,12 @@ class AggregationIntegrationTestBase(unittest.TestCase):
         Serializes the calculation definitions to a temporary YAML file so that validate_config()
         verifies schema compliance when the orchestrator initializes, then runs the pipeline.
         """
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as tmp_file:
-            yaml.dump({"calculations": calculations}, tmp_file)
-            tmp_path = tmp_file.name
-
+        tmp_path = None
         try:
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as tmp_file:
+                tmp_path = tmp_file.name
+                yaml.dump({"calculations": calculations}, tmp_file)
+
             orchestrator = AggregationOrchestrator(
                 connection_id=BQ_CONNECTION_ID,
                 project_id=PROJECT_ID,
@@ -193,6 +194,6 @@ class AggregationIntegrationTestBase(unittest.TestCase):
             )
             return orchestrator.run(active_imports=active_imports, dry_run=dry_run)
         finally:
-            if os.path.exists(tmp_path):
+            if tmp_path and os.path.exists(tmp_path):
                 os.remove(tmp_path)
 

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/entity_aggregation_generator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/entity_aggregation_generator_test.py
@@ -55,17 +55,6 @@ from aggregation import BigQueryExecutor, EntityAggregationGenerator, EntityAggr
 class EntityAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
     """Integration E2E tests for EntityAggregationGenerator."""
 
-    def get_generator(self) -> EntityAggregationGenerator:
-        executor = BigQueryExecutor(
-            BQ_CONNECTION_ID,
-            PROJECT_ID,
-            SPANNER_INSTANCE_ID,
-            SPANNER_DATABASE_ID,
-            location=BQ_LOCATION,
-            run_sequential=True
-        )
-        return EntityAggregationGenerator(executor, is_base_dc=self.is_base_dc)
-
     def test_aggregate_earthquakes(self):
         """Tests aggregation of EarthquakeEvents with magnitude constraint and multiple date formats."""
         import_name = 'EarthquakeUSGS'
@@ -101,21 +90,24 @@ class EntityAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        # 2. Run generator
-        config = EntityAggregationConfig(
-            entity_types=['EarthquakeEvent'],
-            location_props=['affectedPlace'],
-            date_prop='occurrenceTime',
-            agg_date_formats=['YYYY', 'YYYY-MM'],
-            constraints=[{'property': 'magnitude', 'min': 7, 'unit': 'M'}],
-            output_import=output_import,
-            input_imports=[import_name]
-        )
-
-        generator = self.get_generator()
-        jobs = generator.aggregate_entities([config])
-        self.assertEqual(len(jobs), 1)
-        jobs[0].result()
+        calculations = [
+            {
+                "name": "Earthquakes Aggregation",
+                "type": "ENTITY_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import,
+                "entity_aggregation": {
+                    "entity_types": ["EarthquakeEvent"],
+                    "location_props": ["affectedPlace"],
+                    "date_prop": "occurrenceTime",
+                    "agg_date_formats": ["YYYY", "YYYY-MM"],
+                    "constraints": [{"property": "magnitude", "min": 7, "unit": "M"}],
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify results in Spanner
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -236,21 +228,24 @@ class EntityAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        # 2. Run generator (date_prop is omitted -> defaults to current date)
-        config = EntityAggregationConfig(
-            entity_types=['EarthquakeEvent'],
-            location_props=['affectedPlace'],
-            date_prop='', 
-            agg_date_formats=['YYYY', 'YYYY-MM'],
-            constraints=[{'property': 'cause', 'wildcard': True}],
-            output_import=output_import,
-            input_imports=[import_name]
-        )
-
-        generator = self.get_generator()
-        jobs = generator.aggregate_entities([config])
-        self.assertEqual(len(jobs), 1)
-        jobs[0].result()
+        calculations = [
+            {
+                "name": "Wildcards and Default Date Aggregation",
+                "type": "ENTITY_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import,
+                "entity_aggregation": {
+                    "entity_types": ["EarthquakeEvent"],
+                    "location_props": ["affectedPlace"],
+                    "date_prop": "",
+                    "agg_date_formats": ["YYYY", "YYYY-MM"],
+                    "constraints": [{"property": "cause", "wildcard": True}],
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # Get current dates for assertion
         current_year = datetime.utcnow().strftime('%Y')
@@ -368,24 +363,27 @@ class EntityAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        # 2. Run generator
-        config = EntityAggregationConfig(
-            entity_types=['EarthquakeEvent'],
-            location_props=['affectedPlace'],
-            date_prop='occurrenceTime',
-            agg_date_formats=['YYYY'],
-            constraints=[
-                {'property': 'magnitude', 'min': 3, 'max': 5, 'unit': 'M'},
-                {'property': 'magnitudeType', 'value': 'MagnitudeMl'}
-            ],
-            output_import=output_import,
-            input_imports=[import_name]
-        )
-
-        generator = self.get_generator()
-        jobs = generator.aggregate_entities([config])
-        self.assertEqual(len(jobs), 1)
-        jobs[0].result()
+        calculations = [
+            {
+                "name": "Multiple Constraints and Bounds Aggregation",
+                "type": "ENTITY_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import,
+                "entity_aggregation": {
+                    "entity_types": ["EarthquakeEvent"],
+                    "location_props": ["affectedPlace"],
+                    "date_prop": "occurrenceTime",
+                    "agg_date_formats": ["YYYY"],
+                    "constraints": [
+                        {"property": "magnitude", "min": 3, "max": 5, "unit": "M"},
+                        {"property": "magnitudeType", "value": "MagnitudeMl"}
+                    ],
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify results in Spanner
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -458,24 +456,27 @@ class EntityAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        # 2. Run generator with two alternative brackets on the same property `magnitude`
-        config = EntityAggregationConfig(
-            entity_types=['EarthquakeEvent'],
-            location_props=['affectedPlace'],
-            date_prop='occurrenceTime',
-            agg_date_formats=['YYYY'],
-            constraints=[
-                {'property': 'magnitude', 'min': 3, 'max': 4, 'unit': 'M'},
-                {'property': 'magnitude', 'min': 4, 'max': 5, 'unit': 'M'}
-            ],
-            output_import=output_import,
-            input_imports=[import_name]
-        )
-
-        generator = self.get_generator()
-        jobs = generator.aggregate_entities([config])
-        self.assertEqual(len(jobs), 1)
-        jobs[0].result()
+        calculations = [
+            {
+                "name": "Multiple Slices Same Property Aggregation",
+                "type": "ENTITY_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import,
+                "entity_aggregation": {
+                    "entity_types": ["EarthquakeEvent"],
+                    "location_props": ["affectedPlace"],
+                    "date_prop": "occurrenceTime",
+                    "agg_date_formats": ["YYYY"],
+                    "constraints": [
+                        {"property": "magnitude", "min": 3, "max": 4, "unit": "M"},
+                        {"property": "magnitude", "min": 4, "max": 5, "unit": "M"}
+                    ],
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify both slices in Spanner
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -551,21 +552,24 @@ class EntityAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        # 2. Run generator
-        config = EntityAggregationConfig(
-            entity_types=['EarthquakeEvent'],
-            location_props=['affectedPlace'],
-            date_prop='occurrenceTime',
-            agg_date_formats=['YYYY'],
-            constraints=[],
-            output_import=output_import,
-            input_imports=[import_name]
-        )
-
-        generator = self.get_generator()
-        jobs = generator.aggregate_entities([config])
-        self.assertEqual(len(jobs), 1)
-        jobs[0].result()
+        calculations = [
+            {
+                "name": "Filters LatLong Aggregation",
+                "type": "ENTITY_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import,
+                "entity_aggregation": {
+                    "entity_types": ["EarthquakeEvent"],
+                    "location_props": ["affectedPlace"],
+                    "date_prop": "occurrenceTime",
+                    "agg_date_formats": ["YYYY"],
+                    "constraints": [],
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify results in Spanner
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -604,21 +608,24 @@ class EntityAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        # 2. Run generator
-        config = EntityAggregationConfig(
-            entity_types=['EarthquakeEvent'],
-            location_props=['affectedPlace'],
-            date_prop='occurrenceTime',
-            agg_date_formats=['YYYY'],
-            constraints=[],
-            output_import=output_import,
-            input_imports=[import_name]
-        )
-
-        generator = self.get_generator()
-        jobs = generator.aggregate_entities([config])
-        self.assertEqual(len(jobs), 1)
-        jobs[0].result()
+        calculations = [
+            {
+                "name": "Missing Date Safeguard Aggregation",
+                "type": "ENTITY_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import,
+                "entity_aggregation": {
+                    "entity_types": ["EarthquakeEvent"],
+                    "location_props": ["affectedPlace"],
+                    "date_prop": "occurrenceTime",
+                    "agg_date_formats": ["YYYY"],
+                    "constraints": [],
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify results in Spanner
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -650,21 +657,24 @@ class EntityAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        # 2. Run generator
-        config = EntityAggregationConfig(
-            entity_types=['EarthquakeEvent'],
-            location_props=['affectedPlace'],
-            date_prop='occurrenceTime',
-            agg_date_formats=['YYYY'],
-            constraints=[],
-            output_import=output_import,
-            input_imports=[import_name]
-        )
-
-        generator = self.get_generator()
-        jobs = generator.aggregate_entities([config])
-        self.assertEqual(len(jobs), 1)
-        jobs[0].result()
+        calculations = [
+            {
+                "name": "Duplicate Edge Resilience Aggregation",
+                "type": "ENTITY_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import,
+                "entity_aggregation": {
+                    "entity_types": ["EarthquakeEvent"],
+                    "location_props": ["affectedPlace"],
+                    "date_prop": "occurrenceTime",
+                    "agg_date_formats": ["YYYY"],
+                    "constraints": [],
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify count is 1.0 (NOT 2.0)
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -697,21 +707,24 @@ class EntityAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        # 2. Run generator with multiple location_props
-        config = EntityAggregationConfig(
-            entity_types=['EarthquakeEvent'],
-            location_props=['affectedPlace', 'location'],
-            date_prop='occurrenceTime',
-            agg_date_formats=['YYYY'],
-            constraints=[],
-            output_import=output_import,
-            input_imports=[import_name]
-        )
-
-        generator = self.get_generator()
-        jobs = generator.aggregate_entities([config])
-        self.assertEqual(len(jobs), 1)
-        jobs[0].result()
+        calculations = [
+            {
+                "name": "Multiple Location Props Aggregation",
+                "type": "ENTITY_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import,
+                "entity_aggregation": {
+                    "entity_types": ["EarthquakeEvent"],
+                    "location_props": ["affectedPlace", "location"],
+                    "date_prop": "occurrenceTime",
+                    "agg_date_formats": ["YYYY"],
+                    "constraints": [],
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify Observation count is 2.0
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -744,21 +757,24 @@ class EntityAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        # 2. Run generator with multiple entity_types
-        config = EntityAggregationConfig(
-            entity_types=['EarthquakeEvent', 'SeismicEvent'],
-            location_props=['affectedPlace'],
-            date_prop='occurrenceTime',
-            agg_date_formats=['YYYY'],
-            constraints=[],
-            output_import=output_import,
-            input_imports=[import_name]
-        )
-
-        generator = self.get_generator()
-        jobs = generator.aggregate_entities([config])
-        self.assertEqual(len(jobs), 1)
-        jobs[0].result()
+        calculations = [
+            {
+                "name": "Multiple Entity Types Aggregation",
+                "type": "ENTITY_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import,
+                "entity_aggregation": {
+                    "entity_types": ["EarthquakeEvent", "SeismicEvent"],
+                    "location_props": ["affectedPlace"],
+                    "date_prop": "occurrenceTime",
+                    "agg_date_formats": ["YYYY"],
+                    "constraints": [],
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify two distinct SVs were created with respective populationTypes
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -805,24 +821,27 @@ class EntityAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        # 2. Run generator with negative range, upper bound, and unitless constraints
-        config = EntityAggregationConfig(
-            entity_types=['ColdTemperatureEvent'],
-            location_props=['affectedPlace'],
-            date_prop='startDate',
-            agg_date_formats=['YYYY'],
-            constraints=[
-                {'property': 'temperature', 'min': -10, 'max': 40, 'unit': 'Celsius'},
-                {'property': 'depth', 'max': 50, 'unit': 'Kilometer'}
-            ],
-            output_import=output_import,
-            input_imports=[import_name]
-        )
-
-        generator = self.get_generator()
-        jobs = generator.aggregate_entities([config])
-        self.assertEqual(len(jobs), 1)
-        jobs[0].result()
+        calculations = [
+            {
+                "name": "Negative Upper and Unitless Bounds Aggregation",
+                "type": "ENTITY_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import,
+                "entity_aggregation": {
+                    "entity_types": ["ColdTemperatureEvent"],
+                    "location_props": ["affectedPlace"],
+                    "date_prop": "startDate",
+                    "agg_date_formats": ["YYYY"],
+                    "constraints": [
+                        {"property": "temperature", "min": -10, "max": 40, "unit": "Celsius"},
+                        {"property": "depth", "max": 50, "unit": "Kilometer"}
+                    ],
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify count is 1.0 (event_1 matched, event_2 excluded)
         with self.database.snapshot(multi_use=True) as snapshot:

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/linked_edge_generator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/linked_edge_generator_test.py
@@ -51,17 +51,6 @@ from aggregation import BigQueryExecutor, LinkedEdgeGenerator
 class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
     """Integration tests for LinkedEdgeGenerator."""
 
-    def get_generator(self) -> LinkedEdgeGenerator:
-        executor = BigQueryExecutor(
-            BQ_CONNECTION_ID,
-            PROJECT_ID,
-            SPANNER_INSTANCE_ID,
-            SPANNER_DATABASE_ID,
-            location=BQ_LOCATION,
-            run_sequential=True
-        )
-        return LinkedEdgeGenerator(executor, is_base_dc=self.is_base_dc)
-
     def test_linked_contained_in_place(self):
         """Tests run_linked_contained_in_place.
         
@@ -79,10 +68,16 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        # 2. Run generator
-        generator = self.get_generator()
-        jobs = generator.run_linked_contained_in_place([import_name])
-        self.assertIsNotNone(jobs)
+        calculations = [
+            {
+                "name": "Linked Edges ContainedInPlace",
+                "type": "LINKED_EDGES",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         # 3. Verify results in Spanner
         with self.database.snapshot() as snapshot:
@@ -118,10 +113,16 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        # 2. Run generator
-        generator = self.get_generator()
-        job = generator.run_linked_member_of([import_name])
-        self.assertIsNotNone(job)
+        calculations = [
+            {
+                "name": "Linked Edges MemberOf",
+                "type": "LINKED_EDGES",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         # 3. Verify results
         with self.database.snapshot() as snapshot:
@@ -156,10 +157,16 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        # 2. Run generator
-        generator = self.get_generator()
-        job = generator.run_linked_member([import_name])
-        self.assertIsNotNone(job)
+        calculations = [
+            {
+                "name": "Linked Edges Member",
+                "type": "LINKED_EDGES",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         # 3. Verify results
         with self.database.snapshot() as snapshot:
@@ -191,10 +198,16 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        # 2. Run generator
-        generator = self.get_generator()
-        jobs = generator.run_linked_contained_in_place([import_name])
-        self.assertIsNotNone(jobs)
+        calculations = [
+            {
+                "name": "Linked Edges Cycle",
+                "type": "LINKED_EDGES",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         # 3. Verify results
         with self.database.snapshot() as snapshot:
@@ -228,10 +241,16 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        # 3. Run generator
-        generator = self.get_generator()
-        jobs = generator.run_linked_contained_in_place([import_name])
-        self.assertIsNotNone(jobs)
+        calculations = [
+            {
+                "name": "Linked Edges Idempotency",
+                "type": "LINKED_EDGES",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         # 4. Verify no new edges were written (only the 1 pre-inserted edge exists)
         with self.database.snapshot() as snapshot:

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/place_aggregation_generator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/place_aggregation_generator_test.py
@@ -53,17 +53,6 @@ from aggregation import BigQueryExecutor, PlaceAggregationGenerator
 class PlaceAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
     """Integration tests for PlaceAggregationGenerator."""
 
-    def get_generator(self) -> PlaceAggregationGenerator:
-        executor = BigQueryExecutor(
-            BQ_CONNECTION_ID,
-            PROJECT_ID,
-            SPANNER_INSTANCE_ID,
-            SPANNER_DATABASE_ID,
-            location=BQ_LOCATION,
-            run_sequential=True
-        )
-        return PlaceAggregationGenerator(executor, is_base_dc=self.is_base_dc)
-
     def add_place(self, place_id, place_type, parent_id=None, name=None, import_name='USFed_ConstantMaturityRates_Test'):
         """Adds a place node and its basic topology (typeOf and containment) to mock lists."""
         self.add_node(place_id, name, types=[place_type])
@@ -101,9 +90,22 @@ class PlaceAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        generator = self.get_generator()
-        job = generator.aggregate_places(import_names=[import_name], source_type='County', destination_type='State')
-        self.assertIsNotNone(job)
+        calculations = [
+            {
+                "name": "County to State Place Rollup",
+                "type": "PLACE_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": f"{import_name}_AggState",
+                "place_aggregation": {
+                    "from_place_types": "County",
+                    "to_place_types": "State",
+                    "allow_multiple_to_places": False
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         with self.database.snapshot(multi_use=True) as snapshot:
             # A. Verify the new parent TimeSeries was dynamically created for Count_Person!
@@ -192,9 +194,22 @@ class PlaceAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        generator = self.get_generator()
-        job = generator.aggregate_places(import_names=[import_name], source_type='State', destination_type='Country')
-        self.assertIsNotNone(job)
+        calculations = [
+            {
+                "name": "State to Country Place Rollup",
+                "type": "PLACE_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": f"{import_name}_AggCountry",
+                "place_aggregation": {
+                    "from_place_types": "State",
+                    "to_place_types": "Country",
+                    "allow_multiple_to_places": False
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         with self.database.snapshot(multi_use=True) as snapshot:
             # A. Verify Country TimeSeries exists
@@ -242,9 +257,22 @@ class PlaceAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        generator = self.get_generator()
-        job = generator.aggregate_places(import_names=[import_name], source_type='Commune', destination_type='Department')
-        self.assertIsNotNone(job)
+        calculations = [
+            {
+                "name": "Commune to Department Place Rollup",
+                "type": "PLACE_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": f"{import_name}_AggDepartment",
+                "place_aggregation": {
+                    "from_place_types": "Commune",
+                    "to_place_types": "Department",
+                    "allow_multiple_to_places": False
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         with self.database.snapshot(multi_use=True) as snapshot:
             # Verify Paris (place/FR_75)
@@ -295,9 +323,22 @@ class PlaceAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        generator = self.get_generator()
-        job = generator.aggregate_places(import_names=[import_name], source_type='County', destination_type='State')
-        self.assertIsNotNone(job)
+        calculations = [
+            {
+                "name": "County to State Place Rollup Multi-Facet",
+                "type": "PLACE_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": f"{import_name}_AggState",
+                "place_aggregation": {
+                    "from_place_types": "County",
+                    "to_place_types": "State",
+                    "allow_multiple_to_places": False
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         with self.database.snapshot(multi_use=True) as snapshot:
             # A. Verify Facet 1 (5yr) was created
@@ -365,9 +406,22 @@ class PlaceAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        generator = self.get_generator()
-        job = generator.aggregate_places(import_names=[import_name], source_type='County', destination_type='State')
-        self.assertIsNotNone(job)
+        calculations = [
+            {
+                "name": "County to State Place Rollup Missing Parent",
+                "type": "PLACE_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": f"{import_name}_AggState",
+                "place_aggregation": {
+                    "from_place_types": "County",
+                    "to_place_types": "State",
+                    "allow_multiple_to_places": False
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         with self.database.snapshot(multi_use=True) as snapshot:
             # California TimeSeries must exist
@@ -418,14 +472,22 @@ class PlaceAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
         # --- TEST 1: allow_multiple_to_places = False (DEFAULT) ---
         # SF (800k) should ONLY roll up to CA (first lexicographically: geoId/06).
         # CA should be 2.4M. NY (geoId/36) should get 0 (no TimeSeries/Observation written for NY).
-        generator = self.get_generator()
-        job1 = generator.aggregate_places(
-            import_names=[import_name], 
-            source_type='County', 
-            destination_type='State',
-            allow_multiple_to_places=False
-        )
-        self.assertIsNotNone(job1)
+        calculations1 = [
+            {
+                "name": "County to State Allow Multiple False",
+                "type": "PLACE_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": f"{import_name}_AggState",
+                "place_aggregation": {
+                    "from_place_types": "County",
+                    "to_place_types": "State",
+                    "allow_multiple_to_places": False
+                }
+            }
+        ]
+        res1 = self.run_orchestrator(calculations=calculations1, active_imports=[import_name])
+        self.assertTrue(res1.success)
 
         with self.database.snapshot(multi_use=True) as snapshot:
             # California TimeSeries and Observation must exist (2.4M)
@@ -479,13 +541,22 @@ class PlaceAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
         # SF (800k) should roll up to BOTH CA and NY.
         # CA should be 2.4M (SF 800k + Alameda 1.6M).
         # NY should be 800k (SF 800k).
-        job2 = generator.aggregate_places(
-            import_names=[import_name], 
-            source_type='County', 
-            destination_type='State',
-            allow_multiple_to_places=True
-        )
-        self.assertIsNotNone(job2)
+        calculations2 = [
+            {
+                "name": "County to State Allow Multiple True",
+                "type": "PLACE_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": f"{import_name}_AggState",
+                "place_aggregation": {
+                    "from_place_types": "County",
+                    "to_place_types": "State",
+                    "allow_multiple_to_places": True
+                }
+            }
+        ]
+        res2 = self.run_orchestrator(calculations=calculations2, active_imports=[import_name])
+        self.assertTrue(res2.success)
 
         with self.database.snapshot(multi_use=True) as snapshot:
             # California (should be 2.4M)
@@ -548,11 +619,37 @@ class PlaceAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
 
-        generator = self.get_generator()
-        
-        # --- ROUND 1: County -> State ---
-        job1 = generator.aggregate_places(import_names=[import_name], source_type='County', destination_type='State')
-        self.assertIsNotNone(job1)
+        calculations = [
+            {
+                "name": "Round 1: County -> State",
+                "type": "PLACE_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": f"{import_name}_AggState",
+                "place_aggregation": {
+                    "from_place_types": "County",
+                    "to_place_types": "State",
+                    "allow_multiple_to_places": False
+                }
+            },
+            {
+                "name": "Round 2: State -> Country",
+                "type": "PLACE_AGGREGATION",
+                "stage": 2,
+                "input_imports": [f"{import_name}_AggState"],
+                "output_import": f"{import_name}_AggState_AggCountry",
+                "place_aggregation": {
+                    "from_place_types": "State",
+                    "to_place_types": "Country",
+                    "allow_multiple_to_places": False
+                }
+            }
+        ]
+        res = self.run_orchestrator(
+            calculations=calculations,
+            active_imports=[import_name, f"{import_name}_AggState"]
+        )
+        self.assertTrue(res.success)
 
         # Verify Round 1 output exists (California should now have a TimeSeries and a 2.4M Observation)
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -583,10 +680,7 @@ class PlaceAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
             self.assertEqual(len(res_ca), 1)
             self.assertAlmostEqual(float(res_ca[0][0]), 2400000.0)
 
-        # --- ROUND 2: State -> Country ---
-        # We must pass the output import name of Round 1 as the input to Round 2!
-        job2 = generator.aggregate_places(import_names=[f"{import_name}_AggState"], source_type='State', destination_type='Country')
-        self.assertIsNotNone(job2)
+        # --- ROUND 2 verification (both rounds were executed sequentially by orchestrator above) ---
 
         # Verify Round 2 output exists (USA should now have a TimeSeries and a 2.4M Observation)
         with self.database.snapshot(multi_use=True) as snapshot:

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/provenance_summary_generator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/provenance_summary_generator_test.py
@@ -53,17 +53,6 @@ from aggregation import BigQueryExecutor, ProvenanceSummaryGenerator
 class ProvenanceSummaryGeneratorIntegrationTest(AggregationIntegrationTestBase):
     """Integration E2E tests for ProvenanceSummaryGenerator."""
 
-    def get_generator(self) -> ProvenanceSummaryGenerator:
-        executor = BigQueryExecutor(
-            BQ_CONNECTION_ID,
-            PROJECT_ID,
-            SPANNER_INSTANCE_ID,
-            SPANNER_DATABASE_ID,
-            location=BQ_LOCATION,
-            run_sequential=True
-        )
-        return ProvenanceSummaryGenerator(executor, is_base_dc=self.is_base_dc)
-
     def test_provenance_summary_aggregation(self):
         """Tests run_provenance_summary_aggregation.
         
@@ -96,10 +85,16 @@ class ProvenanceSummaryGeneratorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        # 2. Run generator
-        generator = self.get_generator()
-        jobs = generator.run_all([import_name])
-        self.assertEqual(len(jobs), 1)
+        calculations = [
+            {
+                "name": "Provenance Summary Aggregation",
+                "type": "PROVENANCE_SUMMARY",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         # 3. Verify results in Spanner Cache table
         with self.database.snapshot() as snapshot:
@@ -183,10 +178,16 @@ class ProvenanceSummaryGeneratorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        # 2. Run generator
-        generator = self.get_generator()
-        jobs = generator.run_all([import_name])
-        self.assertEqual(len(jobs), 1)
+        calculations = [
+            {
+                "name": "Provenance Summary Duplicate Types",
+                "type": "PROVENANCE_SUMMARY",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         # 3. Verify results in Spanner Cache table
         with self.database.snapshot() as snapshot:
@@ -253,9 +254,16 @@ class ProvenanceSummaryGeneratorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        generator = self.get_generator()
-        jobs = generator.run_all([import_name])
-        self.assertEqual(len(jobs), 1)
+        calculations = [
+            {
+                "name": "Provenance Summary Non-Numeric Values",
+                "type": "PROVENANCE_SUMMARY",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         with self.database.snapshot() as snapshot:
             query = """
@@ -328,9 +336,16 @@ class ProvenanceSummaryGeneratorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        generator = self.get_generator()
-        jobs = generator.run_all([import_name])
-        self.assertEqual(len(jobs), 1)
+        calculations = [
+            {
+                "name": "Provenance Summary Dangling Observations",
+                "type": "PROVENANCE_SUMMARY",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         with self.database.snapshot() as snapshot:
             query = """
@@ -397,9 +412,16 @@ class ProvenanceSummaryGeneratorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        generator = self.get_generator()
-        jobs = generator.run_all([import_1, import_2])
-        self.assertEqual(len(jobs), 1)
+        calculations = [
+            {
+                "name": "Provenance Summary Multiple Imports",
+                "type": "PROVENANCE_SUMMARY",
+                "stage": 1,
+                "input_imports": [import_1, import_2]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_1, import_2])
+        self.assertTrue(res.success)
         
         with self.database.snapshot() as snapshot:
             query = """

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_aggregator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_aggregator_test.py
@@ -53,17 +53,6 @@ from aggregation import BigQueryExecutor, StatVarAggregator
 class StatVarAggregatorIntegrationTest(AggregationIntegrationTestBase):
     """Integration E2E tests for StatVarAggregator."""
 
-    def get_aggregator(self) -> StatVarAggregator:
-        executor = BigQueryExecutor(
-            BQ_CONNECTION_ID,
-            PROJECT_ID,
-            SPANNER_INSTANCE_ID,
-            SPANNER_DATABASE_ID,
-            location=BQ_LOCATION,
-            run_sequential=True
-        )
-        return StatVarAggregator(executor, is_base_dc=self.is_base_dc)
-
     def test_aggregate_stat_vars_success(self):
         """Tests successful aggregation when all sources are present."""
         import_name = 'CensusACS5YearSurvey_Test'
@@ -80,16 +69,26 @@ class StatVarAggregatorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        # 2. Run aggregator
-        aggregator = self.get_aggregator()
-        jobs = aggregator.aggregate_stat_vars(
-            ancestor_sv='SV_Parent',
-            source_svs=['SV_A', 'SV_B'],
-            import_names=[import_name],
-            output_import_name=output_import_name,
-            skip_all_sources_present_check=False
-        )
-        self.assertEqual(len(jobs), 1)
+        calculations = [
+            {
+                "name": "StatVar Aggregation Success",
+                "type": "STAT_VAR_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_aggregation": {
+                    "aggregations": [
+                        {
+                            "ancestor_sv_id": "SV_Parent",
+                            "source_sv_ids": ["SV_A", "SV_B"],
+                            "skip_all_sources_present_check": False
+                        }
+                    ]
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         # 3. Verify results in Spanner (using multi_use=True to allow multiple queries)
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -142,16 +141,26 @@ class StatVarAggregatorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        # 2. Run aggregator (strict mode)
-        aggregator = self.get_aggregator()
-        jobs = aggregator.aggregate_stat_vars(
-            ancestor_sv='SV_Parent',
-            source_svs=['SV_A', 'SV_B'],
-            import_names=[import_name],
-            output_import_name=output_import_name,
-            skip_all_sources_present_check=False
-        )
-        self.assertEqual(len(jobs), 1)
+        calculations = [
+            {
+                "name": "StatVar Aggregation Strict Missing",
+                "type": "STAT_VAR_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_aggregation": {
+                    "aggregations": [
+                        {
+                            "ancestor_sv_id": "SV_Parent",
+                            "source_sv_ids": ["SV_A", "SV_B"],
+                            "skip_all_sources_present_check": False
+                        }
+                    ]
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         # 3. Verify no observations are created
         with self.database.snapshot() as snapshot:
@@ -174,16 +183,26 @@ class StatVarAggregatorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        # 2. Run aggregator (lenient mode)
-        aggregator = self.get_aggregator()
-        jobs = aggregator.aggregate_stat_vars(
-            ancestor_sv='SV_Parent',
-            source_svs=['SV_A', 'SV_B'],
-            import_names=[import_name],
-            output_import_name=output_import_name,
-            skip_all_sources_present_check=True
-        )
-        self.assertEqual(len(jobs), 1)
+        calculations = [
+            {
+                "name": "StatVar Aggregation Lenient Missing",
+                "type": "STAT_VAR_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_aggregation": {
+                    "aggregations": [
+                        {
+                            "ancestor_sv_id": "SV_Parent",
+                            "source_svs": ["SV_A", "SV_B"],
+                            "skip_all_sources_present_check": True
+                        }
+                    ]
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         # 3. Verify observation is created with SV_A's value
         with self.database.snapshot() as snapshot:
@@ -217,16 +236,26 @@ class StatVarAggregatorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        # 2. Run aggregator
-        aggregator = self.get_aggregator()
-        jobs = aggregator.aggregate_stat_vars(
-            ancestor_sv='SV_Parent',
-            source_svs=['SV_A', 'SV_B'],
-            import_names=[import_name],
-            output_import_name=output_import_name,
-            skip_all_sources_present_check=False
-        )
-        self.assertEqual(len(jobs), 1)
+        calculations = [
+            {
+                "name": "StatVar Aggregation Multiple Cohorts",
+                "type": "STAT_VAR_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_aggregation": {
+                    "aggregations": [
+                        {
+                            "ancestor_sv_id": "SV_Parent",
+                            "source_sv_ids": ["SV_A", "SV_B"],
+                            "skip_all_sources_present_check": False
+                        }
+                    ]
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         # 3. Verify results in Spanner: should have 2 distinct aggregated TimeSeries and Observations
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -269,16 +298,26 @@ class StatVarAggregatorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        # 2. Run aggregator
-        aggregator = self.get_aggregator()
-        jobs = aggregator.aggregate_stat_vars(
-            ancestor_sv='SV_Parent',
-            source_svs=['SV_A', 'SV_B'],
-            import_names=[import_name],
-            output_import_name=output_import_name,
-            skip_all_sources_present_check=False
-        )
-        self.assertEqual(len(jobs), 1)
+        calculations = [
+            {
+                "name": "StatVar Aggregation Null Method",
+                "type": "STAT_VAR_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_aggregation": {
+                    "aggregations": [
+                        {
+                            "ancestor_sv_id": "SV_Parent",
+                            "source_svs": ["SV_A", "SV_B"],
+                            "skip_all_sources_present_check": False
+                        }
+                    ]
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         # 3. Verify results in Spanner
         with self.database.snapshot(multi_use=True) as snapshot:

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_aggregator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_aggregator_test.py
@@ -194,7 +194,7 @@ class StatVarAggregatorIntegrationTest(AggregationIntegrationTestBase):
                     "aggregations": [
                         {
                             "ancestor_sv_id": "SV_Parent",
-                            "source_svs": ["SV_A", "SV_B"],
+                            "source_sv_ids": ["SV_A", "SV_B"],
                             "skip_all_sources_present_check": True
                         }
                     ]
@@ -309,7 +309,7 @@ class StatVarAggregatorIntegrationTest(AggregationIntegrationTestBase):
                     "aggregations": [
                         {
                             "ancestor_sv_id": "SV_Parent",
-                            "source_svs": ["SV_A", "SV_B"],
+                            "source_sv_ids": ["SV_A", "SV_B"],
                             "skip_all_sources_present_check": False
                         }
                     ]

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_calculation_generator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_calculation_generator_test.py
@@ -54,18 +54,6 @@ from aggregation import BigQueryExecutor
 class StatVarCalculationGeneratorIntegrationTest(AggregationIntegrationTestBase):
     """Integration E2E tests for StatVarCalculationGenerator."""
 
-    def get_generator(self):
-        from aggregation.stat_var_calculation_generator import StatVarCalculationGenerator
-        executor = BigQueryExecutor(
-            BQ_CONNECTION_ID,
-            PROJECT_ID,
-            SPANNER_INSTANCE_ID,
-            SPANNER_DATABASE_ID,
-            location=BQ_LOCATION,
-            run_sequential=True
-        )
-        return StatVarCalculationGenerator(executor, is_base_dc=self.is_base_dc)
-
     def test_calculate_divide_and_multiply(self):
         """Tests DIVIDE and MULTIPLY operations, and application of multipliers."""
         import_name = 'Energy_Import_Test'
@@ -131,13 +119,20 @@ class StatVarCalculationGeneratorIntegrationTest(AggregationIntegrationTestBase)
             }
         ]
 
-        generator = self.get_generator()
-        jobs = generator.calculate_stat_vars(
-            calculations=calculations,
-            import_names=[import_name],
-            output_import_name=output_import_name
-        )
-        self.assertEqual(len(jobs), 1)
+        calculations_config = [
+            {
+                "name": "Divide and Multiply Calculation",
+                "type": "STAT_VAR_CALCULATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_calculation": {
+                    "calculations": calculations
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify results in Spanner
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -232,9 +227,20 @@ class StatVarCalculationGeneratorIntegrationTest(AggregationIntegrationTestBase)
             }
         ]
 
-        generator = self.get_generator()
-        jobs = generator.calculate_stat_vars(calculations, [import_name], output_import_name)
-        self.assertEqual(len(jobs), 1)
+        calculations_config = [
+            {
+                "name": "Add and Subtract Calculation",
+                "type": "STAT_VAR_CALCULATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_calculation": {
+                    "calculations": calculations
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify results in Spanner
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -315,9 +321,20 @@ class StatVarCalculationGeneratorIntegrationTest(AggregationIntegrationTestBase)
             }
         ]
 
-        generator = self.get_generator()
-        jobs = generator.calculate_stat_vars(calculations, [import_name], output_import_name)
-        self.assertEqual(len(jobs), 1)
+        calculations_config = [
+            {
+                "name": "Dynamic Name Resolution Calculation",
+                "type": "STAT_VAR_CALCULATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_calculation": {
+                    "calculations": calculations
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # Expected Dynamically Resolved Names:
         # SV: DifferenceRelativeToObservationalData_ + Mean_ (since SV1 starts with Temperature) + Temperature_SSP5 + _ + ModelX
@@ -374,9 +391,20 @@ class StatVarCalculationGeneratorIntegrationTest(AggregationIntegrationTestBase)
             }
         ]
 
-        generator = self.get_generator()
-        jobs = generator.calculate_stat_vars(calculations, [import_name], output_import_name)
-        self.assertEqual(len(jobs), 1)
+        calculations_config = [
+            {
+                "name": "Facet Filtering Calculation",
+                "type": "STAT_VAR_CALCULATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_calculation": {
+                    "calculations": calculations
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify results
         with self.database.snapshot() as snapshot:
@@ -418,9 +446,20 @@ class StatVarCalculationGeneratorIntegrationTest(AggregationIntegrationTestBase)
             }
         ]
 
-        generator = self.get_generator()
-        jobs = generator.calculate_stat_vars(calculations, [import_name], output_import_name)
-        self.assertEqual(len(jobs), 1)
+        calculations_config = [
+            {
+                "name": "Zero Denominator Calculation",
+                "type": "STAT_VAR_CALCULATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_calculation": {
+                    "calculations": calculations
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify results
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -472,9 +511,20 @@ class StatVarCalculationGeneratorIntegrationTest(AggregationIntegrationTestBase)
             }
         ]
 
-        generator = self.get_generator()
-        jobs = generator.calculate_stat_vars(calculations, [import_name], output_import_name)
-        self.assertEqual(len(jobs), 1)
+        calculations_config = [
+            {
+                "name": "Missing Inputs Alignment Calculation",
+                "type": "STAT_VAR_CALCULATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_calculation": {
+                    "calculations": calculations
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify results
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -517,9 +567,20 @@ class StatVarCalculationGeneratorIntegrationTest(AggregationIntegrationTestBase)
             }
         ]
 
-        generator = self.get_generator()
-        jobs = generator.calculate_stat_vars(calculations, [import_name], output_import_name)
-        self.assertEqual(len(jobs), 1)
+        calculations_config = [
+            {
+                "name": "Extra Entities Alignment Calculation",
+                "type": "STAT_VAR_CALCULATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_calculation": {
+                    "calculations": calculations
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         # 3. Verify results
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -570,10 +631,20 @@ class StatVarCalculationGeneratorIntegrationTest(AggregationIntegrationTestBase)
             }
         ]
 
-        generator = self.get_generator()
-        # We pass both imports as active inputs to the run
-        jobs = generator.calculate_stat_vars(calculations, [import_alpha, import_beta], output_import_name)
-        self.assertEqual(len(jobs), 1)
+        calculations_config = [
+            {
+                "name": "Import Name Regex Filtering Calculation",
+                "type": "STAT_VAR_CALCULATION",
+                "stage": 1,
+                "input_imports": [import_alpha, import_beta],
+                "output_import": output_import_name,
+                "stat_var_calculation": {
+                    "calculations": calculations
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_alpha, import_beta])
+        self.assertTrue(res.success)
 
         # 3. Verify results
         with self.database.snapshot(multi_use=True) as snapshot:

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_group_generator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_group_generator_test.py
@@ -52,21 +52,6 @@ from aggregation import BigQueryExecutor, StatVarGroupGenerator
 class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
     """Integration E2E tests for StatVarGroupGenerator."""
 
-    def get_generator(self) -> StatVarGroupGenerator:
-        executor = BigQueryExecutor(
-            BQ_CONNECTION_ID,
-            PROJECT_ID,
-            SPANNER_INSTANCE_ID,
-            SPANNER_DATABASE_ID,
-            location=BQ_LOCATION,
-            run_sequential=True
-        )
-        return StatVarGroupGenerator(
-            executor,
-            is_base_dc=self.is_base_dc,
-            max_iterations=2
-        )
-
     def test_stat_var_group_generation(self):
         """
         Tests the generation of StatVarGroups and hierarchical edges from SV specs.
@@ -79,9 +64,8 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
           - A basic populationType SV 'Count_Person'.
           - An uncategorized basic SV 'Count_Thing'.
         """
-        generator = self.get_generator()
-        ns = generator.namespace
-        prov = generator.generated_provenance
+        ns = 'dc/' if self.is_base_dc else 'c/'
+        prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
         
         # 1. Setup mock Vertical Node and Spec mappings
         self.add_node(f'{ns}g/TestVertical', 'Test Vertical', value=f'{ns}g/TestVertical', types=['StatVarGroup'])
@@ -134,11 +118,16 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        # 2. Run generator
-        jobs = generator.run_all(import_names=['Schema'])
-        self.assertIsNotNone(jobs)
-        for job in jobs:
-            job.result()
+        calculations = [
+            {
+                "name": "StatVar Groups Generation",
+                "type": "STAT_VAR_GROUPS",
+                "stage": 1,
+                "input_imports": ["Schema"]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=["Schema"])
+        self.assertTrue(res.success)
 
         # 3. Verify results in Spanner
         with self.database.snapshot(multi_use=True) as snapshot:

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_series_aggregator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_series_aggregator_test.py
@@ -53,17 +53,6 @@ from aggregation import BigQueryExecutor, StatVarSeriesAggregator
 class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
     """Integration E2E tests for StatVarSeriesAggregator."""
 
-    def get_aggregator(self) -> StatVarSeriesAggregator:
-        executor = BigQueryExecutor(
-            BQ_CONNECTION_ID,
-            PROJECT_ID,
-            SPANNER_INSTANCE_ID,
-            SPANNER_DATABASE_ID,
-            location=BQ_LOCATION,
-            run_sequential=True
-        )
-        return StatVarSeriesAggregator(executor, is_base_dc=self.is_base_dc)
-
     def test_multiround_aggregation(self):
         """Tests multi-round aggregation: Round 1 (Anomalies) -> Round 2 (Ensembles)."""
         import_name = 'NASA_NEXGDDP_Test'
@@ -93,41 +82,21 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
         self.flush_to_spanner()
 
         # 2. Run aggregator with both Round 1 and Round 2 configs
-        aggregator = self.get_aggregator()
-        calculations = [
+        calculations_config = [
             {
-                "round": 1,
-                "input_imports": [import_name],
-                "output_import": round1_output_import,
-                "aggr_funcs": [
-                    {"max_diff_across_measurement_methods": {}},
-                    {
-                        "diff_relative_to_base_date": {
-                            "dates": ["2015-07"]
-                        }
-                    }
-                ]
-            },
-            {
-                "round": 2,
-                "input_imports": [round1_output_import],
-                "output_import": round2_output_import,
-                "aggr_funcs": [
-                    {
-                        "stats_across_models": {
-                            "sv_regex": "^DifferenceRelativeToBaseDate.*",
-                            "aggregation_ops": [
-                                "OPERATOR_MEDIAN",
-                                "OPERATOR_PERCENTILE10",
-                                "OPERATOR_PERCENTILE90"
-                            ]
-                        }
-                    }
-                ]
+                "name": f"Round {c['round']} Series Aggregation",
+                "type": "STAT_VAR_SERIES_AGGREGATION",
+                "stage": c["round"],
+                "input_imports": c["input_imports"],
+                "output_import": c["output_import"],
+                "stat_var_series_aggregation": {
+                    "aggr_funcs": c["aggr_funcs"]
+                }
             }
+            for c in calculations
         ]
-        
-        aggregator.aggregate_series(calculations)
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name, round1_output_import])
+        self.assertTrue(res.success)
 
         # 3. Verify Round 1 Results in Spanner
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -240,47 +209,51 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
         self.flush_to_spanner()
         
         # 2. Run aggregator
-        aggregator = self.get_aggregator()
-        calculations = [
+        calculations_config = [
             {
-                "round": 1,
+                "name": "Round 1 Series Aggregation",
+                "type": "STAT_VAR_SERIES_AGGREGATION",
+                "stage": 1,
                 "input_imports": [import_name],
                 "output_import": output_import,
-                "aggr_funcs": [
-                    {
-                        "aggr_over_time": {
-                            "time_range": {
-                                "input_obs_period": "P1D",
-                                "output_obs_period": "P1M"
-                            },
-                            "sv_configs": [
-                                {
-                                    "sv_regex": "^Max_Temperature$",
-                                    "aggregation_op": "OPERATOR_MEAN",
-                                    "use_input_sv_for_output": True
-                                }
-                            ]
+                "stat_var_series_aggregation": {
+                    "aggr_funcs": [
+                        {
+                            "aggr_over_time": {
+                                "time_range": {
+                                    "input_obs_period": "P1D",
+                                    "output_obs_period": "P1M"
+                                },
+                                "sv_configs": [
+                                    {
+                                        "sv_regex": "^Max_Temperature$",
+                                        "aggregation_op": "OPERATOR_MEAN",
+                                        "use_input_sv_for_output": True
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "aggr_over_time": {
+                                "time_range": {
+                                    "input_obs_period": "P1D",
+                                    "output_obs_period": "P1Y"
+                                },
+                                "sv_configs": [
+                                    {
+                                        "sv_regex": "^Max_Temperature$",
+                                        "aggregation_op": "OPERATOR_MAX",
+                                        "use_input_sv_for_output": False
+                                    }
+                                ]
+                            }
                         }
-                    },
-                    {
-                        "aggr_over_time": {
-                            "time_range": {
-                                "input_obs_period": "P1D",
-                                "output_obs_period": "P1Y"
-                            },
-                            "sv_configs": [
-                                {
-                                    "sv_regex": "^Max_Temperature$",
-                                    "aggregation_op": "OPERATOR_MAX",
-                                    "use_input_sv_for_output": False
-                                }
-                            ]
-                        }
-                    }
-                ]
+                    ]
+                }
             }
         ]
-        aggregator.aggregate_series(calculations)
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         # 3. Verify Results in Spanner
         prefix = "dc/base/" if self.is_base_dc else ""
@@ -344,34 +317,37 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
         
         self.flush_to_spanner()
         
-        # 2. Run aggregator
-        aggregator = self.get_aggregator()
-        calculations = [
+        calculations_config = [
             {
-                "round": 1,
+                "name": "Threshold Series Aggregation",
+                "type": "STAT_VAR_SERIES_AGGREGATION",
+                "stage": 1,
                 "input_imports": [import_name],
                 "output_import": output_import,
-                "aggr_funcs": [
-                    {
-                        "count_threshold_exception_over_time": {
-                            "time_range": {
-                                "input_obs_period": "P1D",
-                                "output_obs_period": "P1Y"
-                            },
-                            "thresholds": [
-                                {
-                                    "sv_regex": "^Max_Temperature$",
-                                    "threshold_value": 300.0,
-                                    "comparison": "OPERATOR_GE",
-                                    "unit": "Kelvin"
-                                }
-                            ]
+                "stat_var_series_aggregation": {
+                    "aggr_funcs": [
+                        {
+                            "count_threshold_exception_over_time": {
+                                "time_range": {
+                                    "input_obs_period": "P1D",
+                                    "output_obs_period": "P1Y"
+                                },
+                                "thresholds": [
+                                    {
+                                        "sv_regex": "^Max_Temperature$",
+                                        "threshold_value": 300.0,
+                                        "comparison": "OPERATOR_GE",
+                                        "unit": "Kelvin"
+                                    }
+                                ]
+                            }
                         }
-                    }
-                ]
+                    ]
+                }
             }
         ]
-        aggregator.aggregate_series(calculations)
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
         
         # 3. Verify Results in Spanner
         prefix = "dc/base/" if self.is_base_dc else ""
@@ -419,24 +395,28 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        aggregator = self.get_aggregator()
-        calculations = [
+        calculations_config = [
             {
-                "round": 1,
+                "name": "Base Date Range Series Aggregation",
+                "type": "STAT_VAR_SERIES_AGGREGATION",
+                "stage": 1,
                 "input_imports": [import_name],
                 "output_import": output_import,
-                "aggr_funcs": [
-                    {
-                        "diff_relative_to_base_date": {
-                            "date_specs": [
-                                {"start_date": "2015-01", "end_date": "2015-12"}
-                            ]
+                "stat_var_series_aggregation": {
+                    "aggr_funcs": [
+                        {
+                            "diff_relative_to_base_date": {
+                                "date_specs": [
+                                    {"start_date": "2015-01", "end_date": "2015-12"}
+                                ]
+                            }
                         }
-                    }
-                ]
+                    ]
+                }
             }
         ]
-        aggregator.aggregate_series(calculations)
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         with self.database.snapshot(multi_use=True) as snapshot:
             obs_query = """
@@ -462,37 +442,41 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        aggregator = self.get_aggregator()
-        calculations = [
+        calculations_config = [
             {
-                "round": 1,
+                "name": "Min and Sum Series Aggregation",
+                "type": "STAT_VAR_SERIES_AGGREGATION",
+                "stage": 1,
                 "input_imports": [import_name],
                 "output_import": output_import,
-                "aggr_funcs": [
-                    {
-                        "aggr_over_time": {
-                            "time_range": {
-                                "input_obs_period": "P1D",
-                                "output_obs_period": "P1Y"
-                            },
-                            "sv_configs": [
-                                {
-                                    "sv_regex": "^Max_Temperature$",
-                                    "aggregation_op": "OPERATOR_MIN",
-                                    "use_input_sv_for_output": False
+                "stat_var_series_aggregation": {
+                    "aggr_funcs": [
+                        {
+                            "aggr_over_time": {
+                                "time_range": {
+                                    "input_obs_period": "P1D",
+                                    "output_obs_period": "P1Y"
                                 },
-                                {
-                                    "sv_regex": "^Max_Temperature$",
-                                    "aggregation_op": "OPERATOR_SUM",
-                                    "use_input_sv_for_output": False
-                                }
-                            ]
+                                "sv_configs": [
+                                    {
+                                        "sv_regex": "^Max_Temperature$",
+                                        "aggregation_op": "OPERATOR_MIN",
+                                        "use_input_sv_for_output": False
+                                    },
+                                    {
+                                        "sv_regex": "^Max_Temperature$",
+                                        "aggregation_op": "OPERATOR_SUM",
+                                        "use_input_sv_for_output": False
+                                    }
+                                ]
+                            }
                         }
-                    }
-                ]
+                    ]
+                }
             }
         ]
-        aggregator.aggregate_series(calculations)
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         with self.database.snapshot(multi_use=True) as snapshot:
             obs_min_query = """
@@ -530,33 +514,37 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        aggregator = self.get_aggregator()
-        calculations = [
+        calculations_config = [
             {
-                "round": 1,
+                "name": "Threshold Or Less Series Aggregation",
+                "type": "STAT_VAR_SERIES_AGGREGATION",
+                "stage": 1,
                 "input_imports": [import_name],
                 "output_import": output_import,
-                "aggr_funcs": [
-                    {
-                        "count_threshold_exception_over_time": {
-                            "time_range": {
-                                "input_obs_period": "P1D",
-                                "output_obs_period": "P1Y"
-                            },
-                            "thresholds": [
-                                {
-                                    "sv_regex": "^Max_Temperature$",
-                                    "threshold_value": 298.0,
-                                    "comparison": "OPERATOR_LE",
-                                    "unit": "Kelvin"
-                                }
-                            ]
+                "stat_var_series_aggregation": {
+                    "aggr_funcs": [
+                        {
+                            "count_threshold_exception_over_time": {
+                                "time_range": {
+                                    "input_obs_period": "P1D",
+                                    "output_obs_period": "P1Y"
+                                },
+                                "thresholds": [
+                                    {
+                                        "sv_regex": "^Max_Temperature$",
+                                        "threshold_value": 298.0,
+                                        "comparison": "OPERATOR_LE",
+                                        "unit": "Kelvin"
+                                    }
+                                ]
+                            }
                         }
-                    }
-                ]
+                    ]
+                }
             }
         ]
-        aggregator.aggregate_series(calculations)
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
 
         with self.database.snapshot(multi_use=True) as snapshot:
             obs_query = """

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_series_aggregator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_series_aggregator_test.py
@@ -81,19 +81,45 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
-        # 2. Run aggregator with both Round 1 and Round 2 configs
         calculations_config = [
             {
-                "name": f"Round {c['round']} Series Aggregation",
+                "name": "Round 1 Series Aggregation",
                 "type": "STAT_VAR_SERIES_AGGREGATION",
-                "stage": c["round"],
-                "input_imports": c["input_imports"],
-                "output_import": c["output_import"],
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": round1_output_import,
                 "stat_var_series_aggregation": {
-                    "aggr_funcs": c["aggr_funcs"]
+                    "aggr_funcs": [
+                        {"max_diff_across_measurement_methods": {}},
+                        {
+                            "diff_relative_to_base_date": {
+                                "dates": ["2015-07"]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "name": "Round 2 Series Aggregation",
+                "type": "STAT_VAR_SERIES_AGGREGATION",
+                "stage": 2,
+                "input_imports": [round1_output_import],
+                "output_import": round2_output_import,
+                "stat_var_series_aggregation": {
+                    "aggr_funcs": [
+                        {
+                            "stats_across_models": {
+                                "sv_regex": "^DifferenceRelativeToBaseDate.*",
+                                "aggregation_ops": [
+                                    "OPERATOR_MEDIAN",
+                                    "OPERATOR_PERCENTILE10",
+                                    "OPERATOR_PERCENTILE90"
+                                ]
+                            }
+                        }
+                    ]
                 }
             }
-            for c in calculations
         ]
         res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name, round1_output_import])
         self.assertTrue(res.success)

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/super_enum_aggregation_generator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/super_enum_aggregation_generator_test.py
@@ -64,22 +64,6 @@ from aggregation.super_enum_aggregation_generator import (
 class SuperEnumAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
     """Integration E2E tests for SuperEnumAggregationGenerator."""
 
-    def get_generator(self) -> SuperEnumAggregationGenerator:
-        executor = BigQueryExecutor(
-            BQ_CONNECTION_ID,
-            PROJECT_ID,
-            SPANNER_INSTANCE_ID,
-            SPANNER_DATABASE_ID,
-            location=BQ_LOCATION,
-            run_sequential=True
-        )
-        return SuperEnumAggregationGenerator(
-            executor=executor,
-            spanner_client=self.spanner_client,
-            spanner_database=self.database,
-            is_base_dc=self.is_base_dc
-        )
-
     def test_super_enum_aggregation_success(self):
         """Verifies successful aggregation of child enums into a parent enum."""
         import_name = 'CensusACS5YearSurvey_Test'
@@ -116,12 +100,16 @@ class SuperEnumAggregationGeneratorIntegrationTest(AggregationIntegrationTestBas
         
         self.flush_to_spanner()
         
-        # --- 4. RUN GENERATOR ---
-        generator = self.get_generator()
-        jobs = generator.run(import_names=[import_name])
-        self.assertIsNotNone(jobs)
-        for job in jobs:
-            job.result()
+        calculations = [
+            {
+                "name": "Super Enum Aggregation Success",
+                "type": "SUPER_ENUM_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
             
         # --- 5. VERIFY RESULTS ---
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -220,11 +208,16 @@ class SuperEnumAggregationGeneratorIntegrationTest(AggregationIntegrationTestBas
         
         self.flush_to_spanner()
         
-        # --- 4. RUN GENERATOR ---
-        generator = self.get_generator()
-        jobs = generator.run(import_names=[import_name])
-        for job in jobs:
-            job.result()
+        calculations = [
+            {
+                "name": "Super Enum Aggregation Multi-Facet",
+                "type": "SUPER_ENUM_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
             
         # --- 5. VERIFY RESULTS ---
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -291,11 +284,16 @@ class SuperEnumAggregationGeneratorIntegrationTest(AggregationIntegrationTestBas
         
         self.flush_to_spanner()
         
-        # --- 4. RUN GENERATOR ---
-        generator = self.get_generator()
-        jobs = generator.run(import_names=[import_name])
-        for job in jobs:
-            job.result()
+        calculations = [
+            {
+                "name": "Super Enum Aggregation Ignored",
+                "type": "SUPER_ENUM_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
             
         # --- 5. VERIFY RESULTS (No target SV should be created)
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -325,11 +323,16 @@ class SuperEnumAggregationGeneratorIntegrationTest(AggregationIntegrationTestBas
         
         self.flush_to_spanner()
         
-        # --- 4. RUN GENERATOR ---
-        generator = self.get_generator()
-        jobs = generator.run(import_names=[import_name])
-        for job in jobs:
-            job.result()
+        calculations = [
+            {
+                "name": "Super Enum Aggregation Existing Prefix",
+                "type": "SUPER_ENUM_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
             
         # --- 5. VERIFY RESULTS ---
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -370,11 +373,16 @@ class SuperEnumAggregationGeneratorIntegrationTest(AggregationIntegrationTestBas
         
         self.flush_to_spanner()
         
-        # --- 4. RUN GENERATOR ---
-        generator = self.get_generator()
-        jobs = generator.run(import_names=[import_name])
-        for job in jobs:
-            job.result()
+        calculations = [
+            {
+                "name": "Super Enum Aggregation Multi-Entity TimeSeries",
+                "type": "SUPER_ENUM_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
             
         # --- 5. VERIFY RESULTS ---
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -438,11 +446,16 @@ class SuperEnumAggregationGeneratorIntegrationTest(AggregationIntegrationTestBas
         
         self.flush_to_spanner()
         
-        # --- 4. RUN GENERATOR FOR ONLY ALPHA AND BETA (Excluding Ignored) ---
-        generator = self.get_generator()
-        jobs = generator.run(import_names=[import_alpha, import_beta])
-        for job in jobs:
-            job.result()
+        calculations = [
+            {
+                "name": "Super Enum Aggregation Multi-Import Provenance Filtering",
+                "type": "SUPER_ENUM_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_alpha, import_beta]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_alpha, import_beta])
+        self.assertTrue(res.success)
             
         # --- 5. VERIFY RESULTS ---
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -498,11 +511,16 @@ class SuperEnumAggregationGeneratorIntegrationTest(AggregationIntegrationTestBas
         self.add_observation('SV_MultiProp', 'geoId/06', '2020', 100.0, method='CensusACS5yrSurvey', import_name=import_name, facet_id='facet_multi')
         self.flush_to_spanner()
         
-        # 4. Run generator
-        generator = self.get_generator()
-        jobs = generator.run(import_names=[import_name])
-        for job in jobs:
-            job.result()
+        calculations = [
+            {
+                "name": "Super Enum Aggregation Multi-Whitelisted Properties",
+                "type": "SUPER_ENUM_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
             
         # 5. Verify results
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -564,11 +582,16 @@ class SuperEnumAggregationGeneratorIntegrationTest(AggregationIntegrationTestBas
         self.add_observation(source_id, 'geoId/06', '2020', 1234.0, method='CensusACS5yrSurvey', import_name=import_name, facet_id='facet_curated')
         self.flush_to_spanner()
         
-        # 5. Run generator
-        generator = self.get_generator()
-        jobs = generator.run(import_names=[import_name])
-        for job in jobs:
-            job.result()
+        calculations = [
+            {
+                "name": "Super Enum Aggregation Curated StatVar Mapping",
+                "type": "SUPER_ENUM_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
             
         # 6. Verify results
         with self.database.snapshot(multi_use=True) as snapshot:

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -85,7 +85,9 @@ class AggregationOrchestrator:
         location: Optional[str] = None,
         is_base_dc: bool = True,
         config_dir: Optional[str] = None,
-        config_file_path: Optional[str] = None
+        config_file_path: Optional[str] = None,
+        run_sequential: bool = False,
+        poll_interval: int = 15
     ) -> None:
         """Initializes the orchestrator and loads/validates configuration files.
 
@@ -98,6 +100,8 @@ class AggregationOrchestrator:
             is_base_dc: Whether this is running in the base Data Commons environment.
             config_dir: Directory containing aggregation YAML configs (default: configs/).
             config_file_path: Optional path to single config file or directory.
+            run_sequential: Whether to run queries sequentially (default: False).
+            poll_interval: Polling interval in seconds when waiting for jobs (default: 15).
         """
         self.executor = BigQueryExecutor(
             connection_id=connection_id,
@@ -105,9 +109,10 @@ class AggregationOrchestrator:
             instance_id=instance_id,
             database_id=database_id,
             location=location,
-            run_sequential=False
+            run_sequential=run_sequential
         )
         self.is_base_dc = is_base_dc
+        self.poll_interval = poll_interval
 
         # Resolve paths for config directory and schema
         curr_dir = os.path.dirname(os.path.abspath(__file__))
@@ -253,7 +258,7 @@ class AggregationOrchestrator:
                 logging.info(f"Submitted {len(job_ids)} job(s) for Stage {stage_num} (import: '{single_import}'): {job_ids}")
                 self._wait_for_jobs(
                     job_ids=job_ids,
-                    poll_interval=15,
+                    poll_interval=self.poll_interval,
                     step_name=f"{step_type} (Stage {stage_num})",
                     single_import=single_import
                 )

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
@@ -109,6 +109,20 @@ class TestOrchestratorScanning(unittest.TestCase):
         )
         self.assertEqual(len(dir_orchestrator.calculations), 3)
 
+    def test_init_options(self, mock_executor):
+        """Tests that run_sequential and poll_interval parameters are properly set and passed."""
+        custom_orchestrator = AggregationOrchestrator(
+            connection_id="conn",
+            project_id="proj",
+            instance_id="inst",
+            database_id="db",
+            config_dir=self.tmpdir.name,
+            run_sequential=True,
+            poll_interval=5
+        )
+        self.assertEqual(custom_orchestrator.poll_interval, 5)
+        self.assertTrue(custom_orchestrator.executor.run_sequential)
+
 
 @patch('aggregation.orchestrator.BigQueryExecutor')
 @patch('aggregation.orchestrator.PlaceAggregationGenerator')


### PR DESCRIPTION
This PR improves the e2e tests for aggregations by broadening the flow of each test.

Previously, each test would directly call the generator class and validate it's output. Now each test is run through the orchestrator, ensuring each test closely mirrors the full flow of real code.