### PR TITLE
Remove hyphens from PVs when generating SVG dcids

### DIFF
--- a/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
@@ -306,7 +306,7 @@ class StatVarGroupGenerator:
             CAST(NULL AS STRING) AS node2,
             '' AS node2name,
             IF(ARRAY_LENGTH(Constraints.pvs) > 0, 
-              CONCAT(namespace, 'g/', PopType.object_id, '_', REPLACE(REPLACE(ARRAY_TO_STRING(Constraints.pvs, '_'), ' ', ''), '=', '-')), 
+              CONCAT(namespace, 'g/', PopType.object_id, '_', REPLACE(REPLACE(REPLACE(ARRAY_TO_STRING(Constraints.pvs, '_'), ' ', ''), '-', ''), '=', '-')),
               IF(NOT (should_filter_basic_population_type AND IsBasicPopulationType(PopType.object_id)),
                 CONCAT(namespace, 'g/', PopType.object_id), CAST(NULL AS STRING))
             ) AS node3,
@@ -381,7 +381,10 @@ class StatVarGroupGenerator:
               node3 AS node1,
               -- Remove one PV from node1 to produce node2.
               CONCAT(namespace, 'g/', populationType, '_', ARRAY_TO_STRING(ARRAY(
-                SELECT IF(unnest_idx = target_idx, REPLACE(SPLIT(unnested, ' = ')[OFFSET(0)], ' ', ''), REPLACE(REPLACE(unnested, ' ', ''), '=', '-'))
+                SELECT IF(unnest_idx = target_idx, 
+                  REPLACE(SPLIT(unnested, ' = ')[OFFSET(0)], ' ', ''), 
+                  REPLACE(REPLACE(REPLACE(unnested, ' ', ''), '-', ''), '=', '-')
+                )
                 FROM UNNEST(attributes) AS unnested WITH OFFSET AS unnest_idx
               ), '_')) AS node2,
               CONCAT(FormatName(populationType), ' With ', ARRAY_TO_STRING(ARRAY(
@@ -391,7 +394,7 @@ class StatVarGroupGenerator:
               -- Remove corresponding P from node2 to produce node3.
               IF(ARRAY_LENGTH(attributes) > 1, 
                 CONCAT(namespace, 'g/', populationType, '_', ARRAY_TO_STRING(ARRAY( 
-                  SELECT REPLACE(REPLACE(a, ' ', ''), '=', '-') 
+                  SELECT REPLACE(REPLACE(REPLACE(a, ' ', ''), '-', ''), '=', '-') 
                   FROM UNNEST(attributes) AS a WITH OFFSET AS a_idx WHERE a_idx != target_idx 
                 ), '_')),
                 IF(NOT (should_filter_basic_population_type AND IsBasicPopulationType(populationType)), 

--- a/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/ingestion-helper/aggregation/stat_var_group_generator.py
@@ -381,15 +381,15 @@ class StatVarGroupGenerator:
               node3 AS node1,
               -- Remove one PV from node1 to produce node2.
               CONCAT(namespace, 'g/', populationType, '_', ARRAY_TO_STRING(ARRAY(
-                SELECT IF(unnest_idx = target_idx, 
-                  REPLACE(SPLIT(unnested, ' = ')[OFFSET(0)], ' ', ''), 
-                  REPLACE(REPLACE(REPLACE(unnested, ' ', ''), '-', ''), '=', '-')
+                SELECT IF(a_idx = target_idx, 
+                  REPLACE(REPLACE(SPLIT(a, ' = ')[OFFSET(0)], ' ', ''), '-', ''),
+                  REPLACE(REPLACE(REPLACE(a, ' ', ''), '-', ''), '=', '-')
                 )
-                FROM UNNEST(attributes) AS unnested WITH OFFSET AS unnest_idx
+                FROM UNNEST(attributes) AS a WITH OFFSET AS a_idx
               ), '_')) AS node2,
               CONCAT(FormatName(populationType), ' With ', ARRAY_TO_STRING(ARRAY(
-                SELECT IF(unnest_idx = target_idx, SPLIT(unnested, ' = ')[OFFSET(0)], unnested)
-                FROM UNNEST(attributes) AS unnested WITH OFFSET AS unnest_idx
+                SELECT IF(a_idx = target_idx, SPLIT(a, ' = ')[OFFSET(0)], a)
+                FROM UNNEST(attributes) AS a WITH OFFSET AS a_idx
               ), ', ')) AS node2name,
               -- Remove corresponding P from node2 to produce node3.
               IF(ARRAY_LENGTH(attributes) > 1, 


### PR DESCRIPTION
Some pv schema contains hyphens, which were getting added to the SVG names

This was causing some issues when parsing the SVG in NL, which expects each SVG portion to only have one p and one v (https://github.com/datacommonsorg/website/blob/d50cb5c968309e1fed98c51791ad94737e84f3af/server/lib/nl/common/variable.py#L97)

So this PR removes the hyphens from the dcid (they're still kept in the name). This is consistent with what's done in Prophet.

The updated hierarchy has been backfilled into the staging db and the failing page now loads (https://dev.datacommons.org/explore#q=Tell%20me%20about%20the%20economy%20in%20Brazil) 