### PR TITLE
Add namespace table to ingestion helper and update tests

### DIFF
--- a/pipeline/workflow/ingestion-helper/clients/schema.sql
+++ b/pipeline/workflow/ingestion-helper/clients/schema.sql
@@ -106,8 +106,8 @@ CREATE TABLE Namespace (
     IsLocal BOOL NOT NULL,            -- TRUE for local custom namespace, FALSE for remote
     ApiUrl STRING(2048),              -- HTTP endpoint of the remote Mixer (null if local)
     ApiKey STRING(256),               -- Optional API key for authenticating with the remote Mixer
-    Created TIMESTAMP NOT NULL,       -- Creation timestamp
-    Updated TIMESTAMP NOT NULL,       -- Last updated timestamp
+    Created TIMESTAMP NOT NULL OPTIONS ( allow_commit_timestamp = TRUE ), -- Creation timestamp
+    Updated TIMESTAMP NOT NULL OPTIONS ( allow_commit_timestamp = TRUE )  -- Last updated timestamp
 ) PRIMARY KEY (NamespaceId);
 
 CREATE TABLE ImportStatus (

--- a/pipeline/workflow/ingestion-helper/clients/schema.sql
+++ b/pipeline/workflow/ingestion-helper/clients/schema.sql
@@ -105,7 +105,7 @@ CREATE TABLE Namespace (
     Uri STRING(2048) NOT NULL,        -- e.g., "https://example.org/browser/"
     IsLocal BOOL NOT NULL,            -- TRUE for local custom namespace, FALSE for remote
     ApiUrl STRING(2048),              -- HTTP endpoint of the remote Mixer (null if local)
-    ApiKey STRING(256),               -- Optional API key for authenticating with the remote Mixer
+    ApiKey STRING(2048),               -- Optional API key for authenticating with the remote Mixer
     Created TIMESTAMP NOT NULL OPTIONS ( allow_commit_timestamp = TRUE ), -- Creation timestamp
     Updated TIMESTAMP NOT NULL OPTIONS ( allow_commit_timestamp = TRUE )  -- Last updated timestamp
 ) PRIMARY KEY (NamespaceId);

--- a/pipeline/workflow/ingestion-helper/clients/schema.sql
+++ b/pipeline/workflow/ingestion-helper/clients/schema.sql
@@ -99,6 +99,17 @@ CREATE INDEX TimeSeriesByProvenance ON TimeSeries(provenance) OPTIONS (
   columnar_policy = 'enabled'
 );
 
+-- Namespace table for namespaces used by DCP instances
+CREATE TABLE Namespace (
+    NamespaceId STRING(64) NOT NULL,  -- e.g., "dcid", "schema", "myorg"
+    Uri STRING(2048) NOT NULL,        -- e.g., "https://example.org/browser/"
+    IsLocal BOOL NOT NULL,            -- TRUE for local custom namespace, FALSE for remote
+    ApiUrl STRING(2048),              -- HTTP endpoint of the remote Mixer (null if local)
+    ApiKey STRING(256),               -- Optional API key for authenticating with the remote Mixer
+    Created TIMESTAMP NOT NULL,       -- Creation timestamp
+    Updated TIMESTAMP NOT NULL,       -- Last updated timestamp
+) PRIMARY KEY (NamespaceId);
+
 CREATE TABLE ImportStatus (
   ImportName STRING(MAX) NOT NULL,
   LatestVersion STRING(MAX),

--- a/pipeline/workflow/ingestion-helper/clients/spanner.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner.py
@@ -620,7 +620,7 @@ class SpannerClient:
 
         required_tables = [
             "Node", "Edge", "TimeSeries", "Observation", "ImportStatus", "IngestionHistory",
-            "ImportVersionHistory", "IngestionLock", "Cache", self.embedding_table
+            "ImportVersionHistory", "IngestionLock", "Cache", "Namespace", self.embedding_table
         ]
         required_indexes = [
             "InEdge",

--- a/pipeline/workflow/ingestion-helper/clients/spanner.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner.py
@@ -620,7 +620,7 @@ class SpannerClient:
 
         required_tables = [
             "Node", "Edge", "TimeSeries", "Observation", "ImportStatus", "IngestionHistory",
-            "ImportVersionHistory", "IngestionLock", "Cache", "Namespace", self.embedding_table
+            "ImportVersionHistory", "IngestionLock", "Cache", self.embedding_table
         ]
         required_indexes = [
             "InEdge",

--- a/pipeline/workflow/ingestion-helper/clients/spanner_test.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner_test.py
@@ -46,7 +46,7 @@ class TestSpannerClient(unittest.TestCase):
             ["table", "ImportVersionHistory"],
             ["table", "IngestionLock"],
             ["table", "Cache"],
-            ["table", "Namespace"]
+            ["table", "Namespace"],
             ["table", "VariableMetadata"],
             ["index", "NodeEmbeddingIndex"],
             ["index", "InEdge"],

--- a/pipeline/workflow/ingestion-helper/clients/spanner_test.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner_test.py
@@ -46,6 +46,7 @@ class TestSpannerClient(unittest.TestCase):
             ["table", "ImportVersionHistory"],
             ["table", "IngestionLock"],
             ["table", "Cache"],
+            ["table", "Namespace"]
             ["table", "VariableMetadata"],
             ["index", "NodeEmbeddingIndex"],
             ["index", "InEdge"],

--- a/simple/util/filesystem.py
+++ b/simple/util/filesystem.py
@@ -171,7 +171,8 @@ class Dir(_StoreWrapper):
       if not self.fs().exists(new_path):
         self.fs().makedirs(new_path)
       if not self.fs().isdir(new_path):
-        raise ValueError(f"{self.full_path(path)} exists and is not a directory")
+        raise ValueError(
+            f"{self.full_path(path)} exists and is not a directory")
     return Dir(self._store, new_path)
 
   def open_file(self, path: str, create_if_missing: bool = True) -> "File":


### PR DESCRIPTION
Adds new "Namespace" table to Spanner schema in the ingestion helper.

In preparation for the implementation of namespace support in DCP, we are adding a new Namespaces table. For the design spec, see [this doc](https://docs.google.com/document/d/1P4tLdXHJcGzMnTMU8D-mLMn2iD-omWwPRdtf_PGD4OA/edit?tab=t.wfjs67bl2yqu) (Google corp access required).

Changes:
* **Database Schema (`pipeline/workflow/ingestion-helper/clients/schema.sql`)**:
  * Added the `Namespace` table keyed by `NamespaceId` (e.g., `"dcid"`, `"schema"`, `"myorg"`).
  * Added columns to store namespace metadata, including `Uri`, `IsLocal` flag, optional remote Mixer endpoint details (`ApiUrl`, `ApiKey`), and audit timestamps (`Created`, `Updated`).
* **Unit Tests (`pipeline/workflow/ingestion-helper/clients/spanner_test.py`)**:
  * Updated `TestSpannerClient` to include `["table", "Namespace"]` in expected schema verification assertions.
* A lint change to `simple/util/filesystem.py` that came in during a merge with latest master branch. 
 
Left for future PR:
* **Spanner Client (`pipeline/workflow/ingestion-helper/clients/spanner.py`)**:
  * Adding `"Namespace"` to the `required_tables` list in `SpannerClient.check_db_schema()` so database initialization and health checks verify its presence. This requires some care to make sure adding this new table won't break existing databases running init or otherwise use more graceful error handling.
 
Testing Strategy
* Run unit tests for the Spanner client (`uv run pytest clients/spanner_test.py`) to ensure schema validation passes.