### PR TITLE
Keep JSON-LD subjects intact across shard boundaries

### DIFF
--- a/simple/stats/jsonld_stream_db.py
+++ b/simple/stats/jsonld_stream_db.py
@@ -379,7 +379,7 @@ class JsonLdStreamDb(Db):
       self._obs_records[import_name].clear()
 
   def _generate_node_chunks(self, import_name: str, import_temp_dir: str):
-    """Generates node chunks of size _CHUNK_SIZE, cleaning memory progressively."""
+    """Generates node chunks targeting _CHUNK_SIZE without splitting subjects,  cleaning memory progressively."""
     triples = self._triples.get(import_name, [])
     shard_index = 0
     while triples:
@@ -387,6 +387,13 @@ class JsonLdStreamDb(Db):
       # Pop from the end to avoid O(N) list shifting overhead
       for _ in range(min(_CHUNK_SIZE, len(triples))):
         chunk.append(triples.pop())
+
+      # Keep the subject at the chunk boundary intact. A chunk may exceed the
+      # target size when a subject has triples on both sides of the boundary.
+      boundary_subject = chunk[-1].subject_id
+      while triples and triples[-1].subject_id == boundary_subject:
+        chunk.append(triples.pop())
+
       yield (chunk, shard_index, import_temp_dir, self.ns_map)
       shard_index += 1
     if import_name in self._triples:

--- a/simple/stats/jsonld_stream_db.py
+++ b/simple/stats/jsonld_stream_db.py
@@ -382,14 +382,14 @@ class JsonLdStreamDb(Db):
     """Generates node chunks targeting _CHUNK_SIZE without splitting subjects,  cleaning memory progressively."""
     triples = self._triples.get(import_name, [])
     shard_index = 0
+    # Keep subjects intact when chunking. A chunk may exceed the target size if
+    # a subject has triples on both sides of the boundary.
     while triples:
       chunk = []
       # Pop from the end to avoid O(N) list shifting overhead
       for _ in range(min(_CHUNK_SIZE, len(triples))):
         chunk.append(triples.pop())
 
-      # Keep the subject at the chunk boundary intact. A chunk may exceed the
-      # target size when a subject has triples on both sides of the boundary.
       boundary_subject = chunk[-1].subject_id
       while triples and triples[-1].subject_id == boundary_subject:
         chunk.append(triples.pop())

--- a/simple/tests/stats/jsonld_stream_db_test.py
+++ b/simple/tests/stats/jsonld_stream_db_test.py
@@ -77,6 +77,40 @@ class TestJsonLdStreamDb(unittest.TestCase):
       db.insert_triples(triples, mock_file)
       self.assertEqual(len(db._triples["test_import"]), 1)
 
+  @mock.patch("stats.jsonld_stream_db._CHUNK_SIZE", 4)
+  def test_node_chunks_keep_boundary_subject_together(self):
+    with tempfile.TemporaryDirectory() as temp_dir:
+      temp_store = create_store(temp_dir)
+      db = JsonLdStreamDb(output_dir=temp_store.as_dir(),
+                          import_names=["test_import"],
+                          nodes=self.mock_nodes)
+
+      triples = [
+          Triple("head", "first", object_value="1"),
+          Triple("head", "second", object_value="2"),
+          Triple("boundary", "typeOf", object_id="Thing"),
+          Triple("boundary", "name", object_value="Boundary"),
+          Triple("tail", "first", object_value="1"),
+          Triple("tail", "second", object_value="2"),
+          Triple("tail", "third", object_value="3"),
+      ]
+      mock_file = mock.Mock(path="test_import/nodes.mcf")
+      db.insert_triples(triples, mock_file)
+
+      chunks = list(db._generate_node_chunks("test_import", temp_dir))
+
+      self.assertEqual([len(chunk[0]) for chunk in chunks], [5, 2])
+      self.assertEqual([chunk[1] for chunk in chunks], [0, 1])
+
+      first_chunk_boundary = [
+          triple for triple in chunks[0][0] if triple.subject_id == "boundary"
+      ]
+      second_chunk_subjects = {triple.subject_id for triple in chunks[1][0]}
+      self.assertEqual({triple.predicate for triple in first_chunk_boundary},
+                       {"typeOf", "name"})
+      self.assertNotIn("boundary", second_chunk_subjects)
+      self.assertEqual(db._triples["test_import"], [])
+
   def test_commit_and_close_local(self):
     with tempfile.TemporaryDirectory() as temp_dir:
       temp_store = create_store(temp_dir)


### PR DESCRIPTION
  ## Summary

  - Prevent JSON-LD node sharding from splitting triples for the boundary subject.
  - Allow shards to exceed the target size when needed to keep a contiguous subject block intact.
  - Preserve progressive memory cleanup without sorting or duplicating triples.
  - Add regression coverage for a subject crossing the nominal chunk boundary.