### PR TITLE
[Ingestion ] Fixes the backwards compatibility of update_import_version calls

### DIFF
--- a/pipeline/workflow/ingestion-helper/clients/spanner.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner.py
@@ -118,6 +118,7 @@ class SpannerClient:
                                                  "us-central1",
                                                  model=model)
 
+
     def acquire_lock(self, workflow_id: str, timeout: int) -> bool:
         """Attempts to acquire the global ingestion lock.
 
@@ -457,28 +458,40 @@ class SpannerClient:
             f"Updating ImportVersionHistory table for workflow {workflow_id}")
 
         def _insert(transaction: Transaction):
-            version_history_columns = [
-                "ImportName", "Version", "UpdateTimestamp",
-                "WorkflowExecutionID", "Status", "ExecutionTime", "NodeCount",
-                "EdgeCount", "ObservationCount", "Comment"
-            ]
-            m = metrics if metrics else {}
-            version_history_values = []
-            for import_json in import_list_json:
-                version_history_values.append([
-                    import_json['importName'], import_json['latestVersion'],
-                    spanner.COMMIT_TIMESTAMP, workflow_id,
-                    status,
-                    m.get('execution_time'),
-                    m.get('node_count'),
-                    m.get('edge_count'),
-                    m.get('obs_count'),
-                    "ingestion-workflow:" + workflow_id
-                ])
+            enable_unique_version_schema = os.environ.get('ENABLE_UNIQUE_INGESTION_RUNS', 'false').lower() == 'true'
+            if enable_unique_version_schema:
+                # Schema from 7/10
+                columns = [
+                    "ImportName", "Version", "UpdateTimestamp",
+                    "WorkflowExecutionID", "Status", "ExecutionTime", "NodeCount",
+                    "EdgeCount", "ObservationCount", "Comment"
+                ]
+                m = metrics if metrics else {}
+                version_history_values = []
+                for import_json in import_list_json:
+                    version_history_values.append([
+                        import_json['importName'], import_json['latestVersion'],
+                        spanner.COMMIT_TIMESTAMP, workflow_id,
+                        status,
+                        m.get('execution_time'),
+                        m.get('node_count'),
+                        m.get('edge_count'),
+                        m.get('obs_count'),
+                        "ingestion-workflow:" + workflow_id
+                    ])
+            else:
+                # TODO(gmechali): Delete this branch after schema is applied to prod.
+                columns = ["ImportName", "Version", "UpdateTimestamp", "Comment"]
+                version_history_values = []
+                for import_json in import_list_json:
+                    version_history_values.append([
+                        import_json['importName'], import_json['latestVersion'],
+                        spanner.COMMIT_TIMESTAMP, "ingestion-workflow:" + workflow_id
+                    ])
 
             if version_history_values:
                 transaction.insert(table="ImportVersionHistory",
-                                   columns=version_history_columns,
+                                   columns=columns,
                                    values=version_history_values)
 
         try:
@@ -569,21 +582,28 @@ class SpannerClient:
         logging.info(f"Updating version history for {import_name} to {version}")
 
         def _record(transaction: Transaction):
-            columns = [
-                "ImportName", "Version", "UpdateTimestamp",
-                "WorkflowExecutionID", "Status", "ExecutionTime", "NodeCount",
-                "EdgeCount", "ObservationCount", "Comment"
-            ]
-            m = metrics if metrics else {}
-            values = [[
-                import_name, version, spanner.COMMIT_TIMESTAMP, workflow_id,
-                status,
-                m.get('execution_time'),
-                m.get('node_count'),
-                m.get('edge_count'),
-                m.get('obs_count'),
-                comment
-            ]]
+            enable_unique_version_schema = os.environ.get('ENABLE_UNIQUE_INGESTION_RUNS', 'false').lower() == 'true'
+            if enable_unique_version_schema:
+                columns = [
+                    "ImportName", "Version", "UpdateTimestamp",
+                    "WorkflowExecutionID", "Status", "ExecutionTime", "NodeCount",
+                    "EdgeCount", "ObservationCount", "Comment"
+                ]
+                m = metrics if metrics else {}
+                values = [[
+                    import_name, version, spanner.COMMIT_TIMESTAMP, workflow_id,
+                    status,
+                    m.get('execution_time'),
+                    m.get('node_count'),
+                    m.get('edge_count'),
+                    m.get('obs_count'),
+                    comment
+                ]]
+            else:
+                # TODO(gmechali): Delete this branch after schema is applied to prod.
+                columns = ["ImportName", "Version", "UpdateTimestamp", "Comment"]
+                values = [[import_name, version, spanner.COMMIT_TIMESTAMP, comment]]
+
             transaction.insert(table="ImportVersionHistory",
                                columns=columns,
                                values=values)

--- a/pipeline/workflow/ingestion-helper/clients/spanner.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner.py
@@ -457,8 +457,9 @@ class SpannerClient:
         logging.info(
             f"Updating ImportVersionHistory table for workflow {workflow_id}")
 
+        enable_unique_version_schema = os.environ.get('ENABLE_UNIQUE_INGESTION_RUNS', 'false').lower() == 'true'
+
         def _insert(transaction: Transaction):
-            enable_unique_version_schema = os.environ.get('ENABLE_UNIQUE_INGESTION_RUNS', 'false').lower() == 'true'
             if enable_unique_version_schema:
                 # Schema from 7/10
                 columns = [
@@ -581,8 +582,9 @@ class SpannerClient:
         import_name = import_name.split(':')[-1]
         logging.info(f"Updating version history for {import_name} to {version}")
 
+        enable_unique_version_schema = os.environ.get('ENABLE_UNIQUE_INGESTION_RUNS', 'false').lower() == 'true'
+
         def _record(transaction: Transaction):
-            enable_unique_version_schema = os.environ.get('ENABLE_UNIQUE_INGESTION_RUNS', 'false').lower() == 'true'
             if enable_unique_version_schema:
                 columns = [
                     "ImportName", "Version", "UpdateTimestamp",

--- a/pipeline/workflow/ingestion-helper/clients/spanner_test.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner_test.py
@@ -682,6 +682,7 @@ class TestSpannerClient(unittest.TestCase):
         self.assertEqual(values[comp_time_idx], spanner.COMMIT_TIMESTAMP)
 
     @patch('google.cloud.spanner.Client')
+    @patch.dict(os.environ, {"ENABLE_UNIQUE_INGESTION_RUNS": "true"})
     def test_update_import_version_history(self, mock_spanner_client):
         mock_instance = MagicMock()
         mock_db = MagicMock()
@@ -711,6 +712,7 @@ class TestSpannerClient(unittest.TestCase):
         ]])
 
     @patch('google.cloud.spanner.Client')
+    @patch.dict(os.environ, {"ENABLE_UNIQUE_INGESTION_RUNS": "true"})
     def test_update_version_history(self, mock_spanner_client):
         mock_instance = MagicMock()
         mock_db = MagicMock()
@@ -736,6 +738,59 @@ class TestSpannerClient(unittest.TestCase):
         self.assertEqual(kwargs['values'], [[
             "test_import", "v1.2.3", spanner.COMMIT_TIMESTAMP, "wf-789",
             None, None, None, None, None, "ingestion-workflow:wf-789"
+        ]])
+
+    @patch('google.cloud.spanner.Client')
+    @patch.dict(os.environ, {"ENABLE_UNIQUE_INGESTION_RUNS": "false"})
+    def test_update_import_version_history_old_schema(self, mock_spanner_client):
+        mock_instance = MagicMock()
+        mock_db = MagicMock()
+        mock_spanner_client.return_value.instance.return_value = mock_instance
+        mock_instance.database.return_value = mock_db
+
+        mock_transaction = MagicMock()
+        def run_in_transaction_side_effect(callback, *args, **kwargs):
+            return callback(mock_transaction, *args, **kwargs)
+        mock_db.run_in_transaction.side_effect = run_in_transaction_side_effect
+
+        client = SpannerClient("project", "instance", "database")
+        import_list = [{"importName": "test_import", "latestVersion": "v1.2.3"}]
+        client.update_import_version_history(import_list, workflow_id="wf-123")
+
+        mock_transaction.insert.assert_called_once()
+        _, kwargs = mock_transaction.insert.call_args
+        self.assertEqual(kwargs['table'], 'ImportVersionHistory')
+        self.assertEqual(kwargs['columns'], [
+            "ImportName", "Version", "UpdateTimestamp", "Comment"
+        ])
+        self.assertEqual(kwargs['values'], [[
+            "test_import", "v1.2.3", spanner.COMMIT_TIMESTAMP, "ingestion-workflow:wf-123"
+        ]])
+
+    @patch('google.cloud.spanner.Client')
+    @patch.dict(os.environ, {"ENABLE_UNIQUE_INGESTION_RUNS": "false"})
+    def test_update_version_history_old_schema(self, mock_spanner_client):
+        mock_instance = MagicMock()
+        mock_db = MagicMock()
+        mock_spanner_client.return_value.instance.return_value = mock_instance
+        mock_instance.database.return_value = mock_db
+
+        mock_transaction = MagicMock()
+        def run_in_transaction_side_effect(callback, *args, **kwargs):
+            return callback(mock_transaction, *args, **kwargs)
+        mock_db.run_in_transaction.side_effect = run_in_transaction_side_effect
+
+        client = SpannerClient("project", "instance", "database")
+        client.update_version_history("test_import", "v1.2.3", "ingestion-workflow:wf-789", workflow_id="wf-789")
+
+        mock_transaction.insert.assert_called_once()
+        _, kwargs = mock_transaction.insert.call_args
+        self.assertEqual(kwargs['table'], 'ImportVersionHistory')
+        self.assertEqual(kwargs['columns'], [
+            "ImportName", "Version", "UpdateTimestamp", "Comment"
+        ])
+        self.assertEqual(kwargs['values'], [[
+            "test_import", "v1.2.3", spanner.COMMIT_TIMESTAMP, "ingestion-workflow:wf-789"
         ]])
 
 if __name__ == '__main__':


### PR DESCRIPTION
The previous PR made a mistake on backwards compatibility, one of the changes required a new column.

This PR ensures this is fully backwards compatible. Later this week, we will update the Schema, turn on ENABLE_UNIQUE_INGESTION_RUNS and get rid of the else branches in this code + in mixer.