### PR TITLE
Fix: run aggregation helper in non-dry-run mode

### DIFF
--- a/pipeline/workflow/spanner-ingestion-workflow.yaml
+++ b/pipeline/workflow/spanner-ingestion-workflow.yaml
@@ -136,6 +136,7 @@ run_aggregation_job:
                 - args:
                     - "--import_list"
                     - ${json.encode_to_string(import_list)}
+                    - "--no-dry_run"
           connector_params:
             timeout: 21600
         result: aggregation_response


### PR DESCRIPTION
The aggregation helper job was defaulting to dry-run mode, and the workflow was not passing the flag to disable it. This PR adds the --no-dry_run flag.

TAG=agy
CONV=214c54d3-a616-4dfa-981f-11c6405acefc