### PR TITLE
fix(simple): preserve case of provenance ID in import name

### DIFF
--- a/simple/stats/config.py
+++ b/simple/stats/config.py
@@ -312,7 +312,7 @@ class Config:
     """Returns the normalized import name associated with a given input file."""
     prov_id = self._per_file_config(input_file).get("provenance")
     if prov_id:
-      return strip_namespace(prov_id).lower()
+      return strip_namespace(prov_id)
     raise ValueError(
         f"Could not determine import name: missing 'provenance' configuration for file '{input_file.path}'."
     )


### PR DESCRIPTION
## Description
Preserve the casing of the Provenance ID in the import name. 

Currently, `import_name()` applies `.lower()` to the provenance ID. This causes a mismatch during the post-processing aggregation phase:
1. `LinkedEdgeGenerator` queries `Edge` (expects normalized case).
2. `ProvenanceSummaryGenerator` queries `TimeSeries` (expects case-preserved ID, e.g. `provenance/FrogCensus`).

By preserving the casing, both generators can match their respective rows and successfully generate aggregations.

Co-requisite: https://github.com/datacommonsorg/datacommons/pull/166