### PR TITLE
Fix chained aggregations during orchestration

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/place_aggregation_generator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/place_aggregation_generator_test.py
@@ -647,7 +647,7 @@ class PlaceAggregationGeneratorIntegrationTest(AggregationIntegrationTestBase):
         ]
         res = self.run_orchestrator(
             calculations=calculations,
-            active_imports=[import_name, f"{import_name}_AggState"]
+            active_imports=[import_name]
         )
         self.assertTrue(res.success)
 

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_series_aggregator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_series_aggregator_test.py
@@ -121,7 +121,7 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
                 }
             }
         ]
-        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name, round1_output_import])
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
         self.assertTrue(res.success)
 
         # 3. Verify Round 1 Results in Spanner

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -220,23 +220,13 @@ class AggregationOrchestrator:
         """
         expanded = list(active_imports)
         queue = list(active_imports)
-        visited = set(active_imports)
 
         while queue:
             current_import = queue.pop(0)
             for calc in self.calculations:
-                inputs = calc.get("input_imports") or calc.get("imports", [])
-                
-                applies = False
-                if "*" in inputs:
-                    applies = True
-                elif current_import in inputs:
-                    applies = True
-                
-                if applies:
+                if self._calc_applies_to_import(calc, current_import):
                     output = calc.get("output_import")
-                    if output and output not in visited:
-                        visited.add(output)
+                    if output and output not in expanded:
                         queue.append(output)
                         expanded.append(output)
                         

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -34,6 +34,8 @@ from .entity_aggregation_generator import EntityAggregationGenerator, EntityAggr
 from .super_enum_aggregation_generator import SuperEnumAggregationGenerator
 from .validator import validate_config
 
+_OUTPUT_IMPORT_KEY = "output_import"
+
 
 @dataclass
 class ImportExecutionResult:
@@ -225,7 +227,7 @@ class AggregationOrchestrator:
             current_import = queue.pop(0)
             for calc in self.calculations:
                 if self._calc_applies_to_import(calc, current_import):
-                    output = calc.get("output_import")
+                    output = calc.get(_OUTPUT_IMPORT_KEY)
                     if output and output not in expanded:
                         queue.append(output)
                         expanded.append(output)
@@ -383,7 +385,7 @@ class AggregationOrchestrator:
         """Triggers statistical variable aggregations."""
         stat_cfg = config.get("stat_var_aggregation", {})
         aggregations = stat_cfg.get("aggregations", [])
-        output_import_name = config.get("output_import")
+        output_import_name = config.get(_OUTPUT_IMPORT_KEY)
 
         generator = StatVarAggregator(self.executor, self.is_base_dc)
         jobs = []
@@ -409,7 +411,7 @@ class AggregationOrchestrator:
         """Triggers statistical variable calculations."""
         calc_cfg = config.get("stat_var_calculation", {})
         calculations = calc_cfg.get("calculations", [])
-        output_import_name = config.get("output_import")
+        output_import_name = config.get(_OUTPUT_IMPORT_KEY)
 
         logging.info(f"  -> Stat Var Calculation for imports {applicable_imports}")
         generator = StatVarCalculationGenerator(self.executor, self.is_base_dc)
@@ -448,7 +450,7 @@ class AggregationOrchestrator:
     def _trigger_entity(self, config: Dict[str, Any], applicable_imports: List[str]) -> List[Any]:
         """Triggers entity aggregations."""
         entity_cfg = config.get("entity_aggregation", {})
-        output_import = config.get("output_import", "")
+        output_import = config.get(_OUTPUT_IMPORT_KEY, "")
 
         cfg = EntityAggregationConfig(
             entity_types=entity_cfg.get("entity_types", []),

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -142,12 +142,13 @@ class AggregationOrchestrator:
         Returns:
             AggregationRunResult containing status per import.
         """
+        expanded_imports = self._expand_active_imports(active_imports)
         logging.info(
-            f"Starting Aggregation Orchestrator run (dry_run={dry_run}) for active imports: {active_imports}"
+            f"Starting Aggregation Orchestrator run (dry_run={dry_run}) for active imports: {active_imports} (expanded: {expanded_imports})"
         )
         run_result = AggregationRunResult()
 
-        for single_import in active_imports:
+        for single_import in expanded_imports:
             logging.info(f"=== Starting Aggregation Pipeline for Import: '{single_import}' ===")
             active_stages = self._get_active_stages_for_import(single_import)
 
@@ -208,22 +209,58 @@ class AggregationOrchestrator:
                 stages.add(calc.get("stage", 1))
         return sorted(list(stages))
 
+    def _expand_active_imports(self, active_imports: List[str]) -> List[str]:
+        """Expands the list of active imports to include chained aggregated imports.
+
+        For example, if 'A' is active, and there is a calculation:
+          input_imports: ['A']
+          output_import: 'B'
+        Then 'B' should also be added to the active imports.
+        This process is repeated transitively.
+        """
+        expanded = list(active_imports)
+        queue = list(active_imports)
+        visited = set(active_imports)
+
+        while queue:
+            current_import = queue.pop(0)
+            for calc in self.calculations:
+                inputs = calc.get("input_imports") or calc.get("imports", [])
+                
+                applies = False
+                if "*" in inputs:
+                    applies = True
+                elif current_import in inputs:
+                    applies = True
+                
+                if applies:
+                    output = calc.get("output_import")
+                    if output and output not in visited:
+                        visited.add(output)
+                        queue.append(output)
+                        expanded.append(output)
+                        
+        return expanded
+
+
     def get_active_stages(self, active_imports: List[str]) -> List[int]:
         """Returns a sorted list of unique active stage numbers across active imports."""
+        expanded_imports = self._expand_active_imports(active_imports)
         stages = set()
-        for single_import in active_imports:
+        for single_import in expanded_imports:
             stages.update(self._get_active_stages_for_import(single_import))
         return sorted(list(stages))
 
     def execute_stage(self, stage_num: int, active_imports: List[str]) -> List[str]:
         """Executes a single stage for all active imports asynchronously."""
+        expanded_imports = self._expand_active_imports(active_imports)
         stage_jobs = []
         for calc in self.calculations:
             calc_stage = calc.get("stage", 1)
             if calc_stage != stage_num:
                 continue
 
-            applicable_imports = [imp for imp in active_imports if self._calc_applies_to_import(calc, imp)]
+            applicable_imports = [imp for imp in expanded_imports if self._calc_applies_to_import(calc, imp)]
             if not applicable_imports:
                 continue
 

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
@@ -287,7 +287,7 @@ class TestOrchestratorChainedExecution(unittest.TestCase):
         result = self.orchestrator.run(active_imports=["USFed_Census"], dry_run=False)
         self.assertTrue(result.success)
         
-        # We assert 2, which should fail currently because call_count will be 1.
+        # Verify that both stage 1 and stage 2 calculations are triggered (call_count = 2).
         self.assertEqual(mock_place_gen.return_value.aggregate_places.call_count, 2)
 
 

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
@@ -219,5 +219,77 @@ class TestOrchestratorExecution(unittest.TestCase):
         mock_entity_gen.return_value.aggregate_entities.assert_called_once()
 
 
+CHAINED_CONFIG_YAML = textwrap.dedent("""\
+    calculations:
+      - type: PLACE_AGGREGATION
+        input_imports:
+          - USFed_Census
+        output_import: USFed_Census_AggState
+        stage: 1
+        place_aggregation:
+          from_place_types: County
+          to_place_types: State
+
+      - type: PLACE_AGGREGATION
+        input_imports:
+          - USFed_Census_AggState
+        output_import: USFed_Census_AggState_AggCountry
+        stage: 2
+        place_aggregation:
+          from_place_types: State
+          to_place_types: Country
+""")
+
+
+@patch('aggregation.orchestrator.BigQueryExecutor')
+@patch('aggregation.orchestrator.PlaceAggregationGenerator')
+class TestOrchestratorChainedExecution(unittest.TestCase):
+    """Tests chained stage execution, verifying job submission and synchronization."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        config_path = os.path.join(self.tmpdir.name, "config.yaml")
+        with open(config_path, "w") as f:
+            f.write(CHAINED_CONFIG_YAML)
+
+        self.orchestrator = AggregationOrchestrator(
+            connection_id="conn",
+            project_id="proj",
+            instance_id="inst",
+            database_id="db",
+            config_file_path=config_path
+        )
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_run_chained_dry_run_false(self, mock_place_gen, mock_executor_cls):
+        """Tests that run with dry_run=False submits BigQuery jobs across chained stages."""
+        mock_job1 = MagicMock()
+        mock_job1.job_id = "job-place-1"
+        
+        mock_job2 = MagicMock()
+        mock_job2.job_id = "job-place-2"
+        
+        def aggregate_places_side_effect(import_names, source_type, destination_type, allow_multiple_to_places=False):
+            if import_names == ["USFed_Census"]:
+                return mock_job1
+            elif import_names == ["USFed_Census_AggState"]:
+                return mock_job2
+            return None
+            
+        mock_place_gen.return_value.aggregate_places.side_effect = aggregate_places_side_effect
+
+        self.orchestrator.executor = MagicMock()
+        self.orchestrator.executor.get_jobs_status.return_value = {"status": "DONE"}
+
+        # We run with ONLY 'USFed_Census' active.
+        result = self.orchestrator.run(active_imports=["USFed_Census"], dry_run=False)
+        self.assertTrue(result.success)
+        
+        # We assert 2, which should fail currently because call_count will be 1.
+        self.assertEqual(mock_place_gen.return_value.aggregate_places.call_count, 2)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes a bug where the chained aggregations were not correctly picked up the `AggregationOrchestrator`. The orchestrator was only doing the 1st stage of the chained aggregations and was skipping the subsequent stages.

I added unit tests to prevent regression in the future, and updated to e2e tests accordingly.