### PR TITLE
Implement deletions for aggregations

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/__init__.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/__init__.py
@@ -29,6 +29,7 @@ from .super_enum_aggregation_generator import SuperEnumAggregationGenerator
 from .entity_aggregation_generator import EntityAggregationGenerator, EntityAggregationConfig
 from .orchestrator import AggregationOrchestrator, AggregationRunResult, ImportExecutionResult
 from .validator import validate_config
+from .deleter import AggregationDeleter
 
 __all__ = [
     'BigQueryExecutor',
@@ -43,6 +44,7 @@ __all__ = [
     'EntityAggregationGenerator',
     'EntityAggregationConfig',
     'AggregationOrchestrator',
+    'AggregationDeleter',
     'AggregationRunResult',
     'ImportExecutionResult',
     'validate_config',

--- a/pipeline/workflow/aggregation-helper/aggregation/aggregation_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/aggregation_test.py
@@ -24,20 +24,32 @@ from aggregation import BigQueryExecutor
 from aggregation import LinkedEdgeGenerator
 from aggregation import ProvenanceSummaryGenerator
 from aggregation import PlaceAggregationGenerator
-from aggregation.sql_utils import _escape_sql_literal
+from aggregation.common import (
+    BASE_PROVENANCE_PREFIX,
+    _escape_sql_literal,
+    get_provenance_prefix,
+    get_provenance_name
+)
 
 
-class TestSQLUtils(unittest.TestCase):
+class TestCommonUtils(unittest.TestCase):
 
     def test_escape_sql_literal(self):
-        self.assertEqual(_escape_sql_literal("simple"), "simple")
-        self.assertEqual(_escape_sql_literal("back\\slash"),
-                         "back\\\\\\\\slash")
-        self.assertEqual(_escape_sql_literal("double\"quote"),
-                         "double\\\"quote")
+        self.assertEqual(_escape_sql_literal("normal"), "normal")
+        self.assertEqual(_escape_sql_literal(r"back\slash"), r"back\\\\slash")
+        self.assertEqual(_escape_sql_literal('double"quote'), r'double\"quote')
         self.assertEqual(_escape_sql_literal("single'quote"), "single''quote")
-        self.assertEqual(_escape_sql_literal("mixed\\'\""),
-                         "mixed\\\\\\\\''\\\"")
+
+    def test_base_provenance_prefix(self):
+        self.assertEqual(BASE_PROVENANCE_PREFIX, "dc/base/")
+
+    def test_get_provenance_prefix(self):
+        self.assertEqual(get_provenance_prefix(is_base_dc=True), "dc/base/")
+        self.assertEqual(get_provenance_prefix(is_base_dc=False), "")
+
+    def test_get_provenance_name(self):
+        self.assertEqual(get_provenance_name("USFed_Census", is_base_dc=True), "dc/base/USFed_Census")
+        self.assertEqual(get_provenance_name("USFed_Census", is_base_dc=False), "USFed_Census")
 
 
 @patch('aggregation.bq_executor.bigquery.Client')

--- a/pipeline/workflow/aggregation-helper/aggregation/common.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/common.py
@@ -12,6 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+BASE_PROVENANCE_PREFIX = "dc/base/"
+
+
+def get_provenance_prefix(is_base_dc: bool) -> str:
+    """Returns the provenance prefix ('dc/base/' if base DC, else empty string)."""
+    return BASE_PROVENANCE_PREFIX if is_base_dc else ""
+
+
+def get_provenance_name(import_name: str, is_base_dc: bool) -> str:
+    """Returns the full provenance name (e.g. 'dc/base/USFed_Census' or 'USFed_Census')."""
+    return f"{get_provenance_prefix(is_base_dc)}{import_name}"
+
 
 def _escape_sql_literal(val: str) -> str:
     r"""

--- a/pipeline/workflow/aggregation-helper/aggregation/deleter.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/deleter.py
@@ -18,6 +18,8 @@ import logging
 from typing import List
 from google.cloud import spanner
 
+from .common import get_provenance_name
+
 class AggregationDeleter:
     """Handles deletion of aggregated data in Spanner."""
 
@@ -51,8 +53,7 @@ class AggregationDeleter:
 
         logging.info(f"Deleting existing aggregated data for imports: {imports_to_delete}")
 
-        prefix = "dc/base/" if self.is_base_dc else ""
-        provenance_names = [f"{prefix}{name}" for name in imports_to_delete]
+        provenance_names = [get_provenance_name(name, self.is_base_dc) for name in imports_to_delete]
         
         db = self.spanner_database
         edge_params = {"provenances": provenance_names}

--- a/pipeline/workflow/aggregation-helper/aggregation/deleter.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/deleter.py
@@ -14,6 +14,7 @@
 
 """Deletes aggregated data in Spanner using Partitioned DML."""
 
+import concurrent.futures
 import logging
 from typing import List
 from google.cloud import spanner
@@ -41,9 +42,10 @@ class AggregationDeleter:
         return self._spanner_database
 
     def delete_aggregated_data(self, imports_to_delete: List[str]) -> None:
-        """Deletes aggregated data for the specified imports from Spanner.
+        """Deletes aggregated data for the specified imports from Spanner concurrently.
 
         Uses Partitioned DML to execute deletions, which is safe for large volumes.
+        Runs deletions for Edge, TimeSeries, and Cache in parallel using ThreadPoolExecutor.
 
         Args:
             imports_to_delete: List of import names (without dc/base/ prefix) to delete.
@@ -56,32 +58,30 @@ class AggregationDeleter:
         provenance_names = [get_provenance_name(name, self.is_base_dc) for name in imports_to_delete]
         
         db = self.spanner_database
-        edge_params = {"provenances": provenance_names}
-        edge_param_types = {"provenances": spanner.param_types.Array(spanner.param_types.STRING)}
+        params = {"provenances": provenance_names}
+        param_types = {"provenances": spanner.param_types.Array(spanner.param_types.STRING)}
+
+        delete_queries = [
+            ("Edge", "DELETE FROM Edge WHERE provenance IN UNNEST(@provenances)", ""),
+            ("TimeSeries", "DELETE FROM TimeSeries WHERE provenance IN UNNEST(@provenances)", " (and cascaded Observations)"),
+            ("Cache", "DELETE FROM Cache WHERE type = 'ProvenanceSummary' AND provenance IN UNNEST(@provenances)", "")
+        ]
+
+        def _execute_delete(table_name: str, sql: str, extra_desc: str) -> int:
+            rows = db.execute_partitioned_dml(
+                sql, params=params, param_types=param_types
+            )
+            logging.info(f"Deleted {rows} rows from {table_name} table{extra_desc}.")
+            return rows
 
         try:
-            # 1. Delete from Edge
-            edge_delete_sql = "DELETE FROM Edge WHERE provenance IN UNNEST(@provenances)"
-            edge_rows = db.execute_partitioned_dml(
-                edge_delete_sql, params=edge_params, param_types=edge_param_types
-            )
-            logging.info(f"Deleted {edge_rows} rows from Edge table.")
-
-            # 2. Delete from TimeSeries (cascades to Observation)
-            ts_delete_sql = "DELETE FROM TimeSeries WHERE provenance IN UNNEST(@provenances)"
-            ts_rows = db.execute_partitioned_dml(
-                ts_delete_sql, params=edge_params, param_types=edge_param_types
-            )
-            logging.info(f"Deleted {ts_rows} rows from TimeSeries table (and cascaded Observations).")
-
-            # 3. Delete from Cache (type = 'ProvenanceSummary')
-            cache_delete_sql = (
-                "DELETE FROM Cache WHERE type = 'ProvenanceSummary' AND provenance IN UNNEST(@provenances)"
-            )
-            cache_rows = db.execute_partitioned_dml(
-                cache_delete_sql, params=edge_params, param_types=edge_param_types
-            )
-            logging.info(f"Deleted {cache_rows} rows from Cache table.")
+            with concurrent.futures.ThreadPoolExecutor(max_workers=len(delete_queries)) as executor:
+                futures = [
+                    executor.submit(_execute_delete, table, sql, desc)
+                    for table, sql, desc in delete_queries
+                ]
+                for future in concurrent.futures.as_completed(futures):
+                    future.result()  # Propagate any worker thread exceptions to main thread
         except Exception as e:
             logging.error(f"Failed to execute partitioned DML for deletions: {e}")
             raise

--- a/pipeline/workflow/aggregation-helper/aggregation/deleter.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/deleter.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deletes aggregated data in Spanner using Partitioned DML."""
+
+import logging
+from typing import List
+from google.cloud import spanner
+
+class AggregationDeleter:
+    """Handles deletion of aggregated data in Spanner."""
+
+    def __init__(self, project_id: str, instance_id: str, database_id: str, is_base_dc: bool = True):
+        self.project_id = project_id
+        self.instance_id = instance_id
+        self.database_id = database_id
+        self.is_base_dc = is_base_dc
+        self._spanner_database = None
+
+    @property
+    def spanner_database(self):
+        """Lazily initializes and returns the Spanner Database client."""
+        if self._spanner_database is None:
+            spanner_client = spanner.Client(project=self.project_id)
+            instance = spanner_client.instance(self.instance_id)
+            self._spanner_database = instance.database(self.database_id)
+            logging.info(f"Initialized Spanner client for deleter: {self._spanner_database.name}")
+        return self._spanner_database
+
+    def delete_aggregated_data(self, imports_to_delete: List[str]) -> None:
+        """Deletes aggregated data for the specified imports from Spanner.
+
+        Uses Partitioned DML to execute deletions, which is safe for large volumes.
+
+        Args:
+            imports_to_delete: List of import names (without dc/base/ prefix) to delete.
+        """
+        if not imports_to_delete:
+            return
+
+        logging.info(f"Deleting existing aggregated data for imports: {imports_to_delete}")
+
+        prefix = "dc/base/" if self.is_base_dc else ""
+        provenance_names = [f"{prefix}{name}" for name in imports_to_delete]
+        
+        db = self.spanner_database
+        edge_params = {"provenances": provenance_names}
+        edge_param_types = {"provenances": spanner.param_types.Array(spanner.param_types.STRING)}
+
+        try:
+            # 1. Delete from Edge
+            edge_delete_sql = "DELETE FROM Edge WHERE provenance IN UNNEST(@provenances)"
+            edge_rows = db.execute_partitioned_dml(
+                edge_delete_sql, params=edge_params, param_types=edge_param_types
+            )
+            logging.info(f"Deleted {edge_rows} rows from Edge table.")
+
+            # 2. Delete from TimeSeries (cascades to Observation)
+            ts_delete_sql = "DELETE FROM TimeSeries WHERE provenance IN UNNEST(@provenances)"
+            ts_rows = db.execute_partitioned_dml(
+                ts_delete_sql, params=edge_params, param_types=edge_param_types
+            )
+            logging.info(f"Deleted {ts_rows} rows from TimeSeries table (and cascaded Observations).")
+
+            # 3. Delete from Cache (type = 'ProvenanceSummary')
+            cache_delete_sql = (
+                "DELETE FROM Cache WHERE type = 'ProvenanceSummary' AND provenance IN UNNEST(@provenances)"
+            )
+            cache_rows = db.execute_partitioned_dml(
+                cache_delete_sql, params=edge_params, param_types=edge_param_types
+            )
+            logging.info(f"Deleted {cache_rows} rows from Cache table.")
+        except Exception as e:
+            logging.error(f"Failed to execute partitioned DML for deletions: {e}")
+            raise

--- a/pipeline/workflow/aggregation-helper/aggregation/deleter_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/deleter_test.py
@@ -36,26 +36,21 @@ class TestAggregationDeleter(unittest.TestCase):
         imports = ["ImportA", "ImportB"]
         deleter.delete_aggregated_data(imports)
         
-        # Verify execute_partitioned_dml calls
+        # Verify execute_partitioned_dml calls (order-independent due to parallel execution)
         self.assertEqual(mock_db.execute_partitioned_dml.call_count, 3)
         
         expected_provenances = ["dc/base/ImportA", "dc/base/ImportB"]
         expected_params = {"provenances": expected_provenances}
         
-        # Check first call (Edge)
-        call_args = mock_db.execute_partitioned_dml.call_args_list[0]
-        self.assertIn("DELETE FROM Edge", call_args[0][0])
-        self.assertEqual(call_args[1]["params"], expected_params)
+        calls = mock_db.execute_partitioned_dml.call_args_list
+        executed_sqls = [c[0][0] for c in calls]
         
-        # Check second call (TimeSeries)
-        call_args = mock_db.execute_partitioned_dml.call_args_list[1]
-        self.assertIn("DELETE FROM TimeSeries", call_args[0][0])
-        self.assertEqual(call_args[1]["params"], expected_params)
+        self.assertTrue(any("DELETE FROM Edge" in sql for sql in executed_sqls))
+        self.assertTrue(any("DELETE FROM TimeSeries" in sql for sql in executed_sqls))
+        self.assertTrue(any("DELETE FROM Cache" in sql for sql in executed_sqls))
         
-        # Check third call (Cache)
-        call_args = mock_db.execute_partitioned_dml.call_args_list[2]
-        self.assertIn("DELETE FROM Cache", call_args[0][0])
-        self.assertEqual(call_args[1]["params"], expected_params)
+        for c in calls:
+            self.assertEqual(c[1]["params"], expected_params)
 
     @patch('aggregation.deleter.spanner.Client')
     def test_delete_aggregated_data_empty(self, mock_spanner_client):
@@ -86,8 +81,22 @@ class TestAggregationDeleter(unittest.TestCase):
         expected_provenances = ["ImportA"]
         expected_params = {"provenances": expected_provenances}
         
-        call_args = mock_db.execute_partitioned_dml.call_args_list[0]
-        self.assertEqual(call_args[1]["params"], expected_params)
+        calls = mock_db.execute_partitioned_dml.call_args_list
+        for c in calls:
+            self.assertEqual(c[1]["params"], expected_params)
+
+    @patch('aggregation.deleter.spanner.Client')
+    def test_delete_aggregated_data_exception_propagates(self, mock_spanner_client):
+        """Verifies that an exception raised in a worker thread is re-raised by delete_aggregated_data."""
+        mock_db = MagicMock()
+        mock_db.execute_partitioned_dml.side_effect = RuntimeError("Spanner deletion error")
+        mock_spanner_client.return_value.instance.return_value.database.return_value = mock_db
+
+        deleter = AggregationDeleter("proj", "inst", "db")
+
+        with self.assertRaises(RuntimeError):
+            deleter.delete_aggregated_data(["ImportA"])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pipeline/workflow/aggregation-helper/aggregation/deleter_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/deleter_test.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the AggregationDeleter class."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+from google.cloud import spanner
+from aggregation.deleter import AggregationDeleter
+
+class TestAggregationDeleter(unittest.TestCase):
+    @patch('aggregation.deleter.spanner.Client')
+    def test_delete_aggregated_data(self, mock_spanner_client):
+        # Setup mocks
+        mock_db = MagicMock()
+        mock_spanner_client.return_value.instance.return_value.database.return_value = mock_db
+        
+        deleter = AggregationDeleter(
+            project_id="proj",
+            instance_id="inst",
+            database_id="db",
+            is_base_dc=True
+        )
+        
+        imports = ["ImportA", "ImportB"]
+        deleter.delete_aggregated_data(imports)
+        
+        # Verify execute_partitioned_dml calls
+        self.assertEqual(mock_db.execute_partitioned_dml.call_count, 3)
+        
+        expected_provenances = ["dc/base/ImportA", "dc/base/ImportB"]
+        expected_params = {"provenances": expected_provenances}
+        
+        # Check first call (Edge)
+        call_args = mock_db.execute_partitioned_dml.call_args_list[0]
+        self.assertIn("DELETE FROM Edge", call_args[0][0])
+        self.assertEqual(call_args[1]["params"], expected_params)
+        
+        # Check second call (TimeSeries)
+        call_args = mock_db.execute_partitioned_dml.call_args_list[1]
+        self.assertIn("DELETE FROM TimeSeries", call_args[0][0])
+        self.assertEqual(call_args[1]["params"], expected_params)
+        
+        # Check third call (Cache)
+        call_args = mock_db.execute_partitioned_dml.call_args_list[2]
+        self.assertIn("DELETE FROM Cache", call_args[0][0])
+        self.assertEqual(call_args[1]["params"], expected_params)
+
+    @patch('aggregation.deleter.spanner.Client')
+    def test_delete_aggregated_data_empty(self, mock_spanner_client):
+        mock_db = MagicMock()
+        mock_spanner_client.return_value.instance.return_value.database.return_value = mock_db
+        
+        deleter = AggregationDeleter("proj", "inst", "db")
+        deleter.delete_aggregated_data([])
+        
+        mock_db.execute_partitioned_dml.assert_not_called()
+
+    @patch('aggregation.deleter.spanner.Client')
+    def test_delete_aggregated_data_not_base_dc(self, mock_spanner_client):
+        # Setup mocks
+        mock_db = MagicMock()
+        mock_spanner_client.return_value.instance.return_value.database.return_value = mock_db
+        
+        deleter = AggregationDeleter(
+            project_id="proj",
+            instance_id="inst",
+            database_id="db",
+            is_base_dc=False
+        )
+        
+        imports = ["ImportA"]
+        deleter.delete_aggregated_data(imports)
+        
+        expected_provenances = ["ImportA"]
+        expected_params = {"provenances": expected_provenances}
+        
+        call_args = mock_db.execute_partitioned_dml.call_args_list[0]
+        self.assertEqual(call_args[1]["params"], expected_params)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/base.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/base.py
@@ -168,7 +168,8 @@ class AggregationIntegrationTestBase(unittest.TestCase):
         active_imports: List[str],
         dry_run: bool = False,
         run_sequential: bool = True,
-        poll_interval: int = 3
+        poll_interval: int = 3,
+        skip_deletions: bool = False
     ) -> AggregationRunResult:
         """Helper to run AggregationOrchestrator with the given calculation configuration.
 
@@ -192,7 +193,7 @@ class AggregationIntegrationTestBase(unittest.TestCase):
                 run_sequential=run_sequential,
                 poll_interval=poll_interval
             )
-            return orchestrator.run(active_imports=active_imports, dry_run=dry_run)
+            return orchestrator.run(active_imports=active_imports, dry_run=dry_run, skip_deletions=skip_deletions)
         finally:
             if tmp_path and os.path.exists(tmp_path):
                 os.remove(tmp_path)

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/deletions_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/deletions_test.py
@@ -1,0 +1,284 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration E2E tests for aggregation deletions in Spanner.
+
+Covers:
+- AggregationOrchestrator deletions (verifying that existing aggregated data is
+  deleted before running new aggregations, and that the skip_deletions flag
+  properly bypasses this behavior).
+
+NOTE: This script is intended for local testing purposes only and is NOT
+currently part of the CI pipeline.
+
+WARNING: Running these tests will DELETE all existing data in the target
+database tables (Cache, Observation, TimeSeries, Edge, and Node) as part of
+the setUp and tearDown phases. Do NOT run this against any database whose
+data you do not want to lose (e.g., production, staging, or active development databases)!
+
+Before running this script, you MUST ensure configuration variables (in `base.py`
+or set via environment variables such as PROJECT_ID, SPANNER_INSTANCE_ID,
+SPANNER_DATABASE_ID, and BQ_CONNECTION_ID) point to your specific test environment.
+
+How to run:
+1. Ensure your local environment is authenticated (gcloud auth application-default login).
+2. Set the environment variables or verify the config in `aggregation/e2e_tests/base.py`.
+3. Run the following command from `import/pipeline/workflow/aggregation-helper`:
+    uv run pytest aggregation/e2e_tests/deletions_test.py -s
+"""
+
+import unittest
+import logging
+from google.cloud import spanner
+from aggregation.e2e_tests.base import (
+    AggregationIntegrationTestBase,
+    PROJECT_ID,
+    SPANNER_INSTANCE_ID,
+    SPANNER_DATABASE_ID,
+)
+
+class AggregationDeletionsIntegrationTest(AggregationIntegrationTestBase):
+    """Integration E2E tests for verification of aggregation deletions."""
+
+    def test_deletions_default_behavior(self):
+        """Tests that existing aggregated data is deleted by default before run."""
+        import_name = 'USFed_DeletionsTest'
+        output_import_name = f'{import_name}_AggState'
+        
+        # 1. Setup Place Topology
+        self.add_node('geoId/06', 'California', types=['State'])
+        self.add_edge('geoId/06', 'typeOf', 'State', import_name)
+        self.add_node('geoId/06075', 'San Francisco County', types=['County'])
+        self.add_edge('geoId/06075', 'typeOf', 'County', import_name)
+        self.add_edge('geoId/06075', 'containedInPlace', 'geoId/06', import_name)
+        
+        # 2. Setup Raw Data (will be aggregated)
+        self.add_observation('Count_Person', 'geoId/06075', '2020', 100.0, import_name=import_name)
+        
+        # 3. Setup Stale Aggregated Data (should be deleted)
+        # We add an observation for a dummy place 'geoId/99' that is NOT in the raw data
+        # under the output import provenance.
+        self.add_observation('Count_Person', 'geoId/99', '2010', 500.0, import_name=output_import_name)
+        # Add a stale edge under output import provenance
+        self.add_edge('geoId/99', 'typeOf', 'State', output_import_name)
+        
+        self.flush_to_spanner()
+        
+        # Verify stale data exists before run
+        with self.database.snapshot(multi_use=True) as snapshot:
+            stale_obs = list(snapshot.execute_sql(
+                "SELECT value FROM Observation WHERE entity1 = 'geoId/99' AND variable_measured = 'Count_Person'"
+            ))
+            self.assertEqual(len(stale_obs), 1)
+            self.assertEqual(float(stale_obs[0][0]), 500.0)
+            
+            stale_edge = list(snapshot.execute_sql(
+                "SELECT object_id FROM Edge WHERE subject_id = 'geoId/99' AND predicate = 'typeOf'"
+            ))
+            self.assertEqual(len(stale_edge), 1)
+
+        # 4. Run Orchestrator (skip_deletions=False by default)
+        calculations = [
+            {
+                "name": "Deletions Test Rollup",
+                "type": "PLACE_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "place_aggregation": {
+                    "from_place_types": "County",
+                    "to_place_types": "State",
+                    "allow_multiple_to_places": False
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name], skip_deletions=False)
+        self.assertTrue(res.success)
+        
+        # 5. Verify Spanner State after run
+        with self.database.snapshot(multi_use=True) as snapshot:
+            # A. New aggregated data SHOULD exist (geoId/06, value 100)
+            new_obs = list(snapshot.execute_sql(
+                "SELECT value FROM Observation WHERE entity1 = 'geoId/06' AND variable_measured = 'Count_Person' AND date = '2020'"
+            ))
+            self.assertEqual(len(new_obs), 1)
+            self.assertEqual(float(new_obs[0][0]), 100.0)
+            
+            # B. Stale aggregated data SHOULD BE GONE (deleted by deleter)
+            stale_obs_after = list(snapshot.execute_sql(
+                "SELECT value FROM Observation WHERE entity1 = 'geoId/99'"
+            ))
+            self.assertEqual(len(stale_obs_after), 0)
+            
+            stale_edge_after = list(snapshot.execute_sql(
+                "SELECT object_id FROM Edge WHERE subject_id = 'geoId/99'"
+            ))
+            self.assertEqual(len(stale_edge_after), 0)
+            
+            # C. Raw data SHOULD STILL EXIST
+            raw_obs = list(snapshot.execute_sql(
+                "SELECT value FROM Observation WHERE entity1 = 'geoId/06075' AND variable_measured = 'Count_Person'"
+            ))
+            self.assertEqual(len(raw_obs), 1)
+            self.assertEqual(float(raw_obs[0][0]), 100.0)
+
+    def test_deletions_skip_behavior(self):
+        """Tests that existing aggregated data is NOT deleted when skip_deletions=True."""
+        import_name = 'USFed_DeletionsSkipTest'
+        output_import_name = f'{import_name}_AggState'
+        
+        # 1. Setup Place Topology
+        self.add_node('geoId/06', 'California', types=['State'])
+        self.add_edge('geoId/06', 'typeOf', 'State', import_name)
+        self.add_node('geoId/06075', 'San Francisco County', types=['County'])
+        self.add_edge('geoId/06075', 'typeOf', 'County', import_name)
+        self.add_edge('geoId/06075', 'containedInPlace', 'geoId/06', import_name)
+        
+        # 2. Setup Raw Data
+        self.add_observation('Count_Person', 'geoId/06075', '2020', 100.0, import_name=import_name)
+        
+        # 3. Setup Stale Aggregated Data
+        self.add_observation('Count_Person', 'geoId/99', '2010', 500.0, import_name=output_import_name)
+        self.add_edge('geoId/99', 'typeOf', 'State', output_import_name)
+        
+        self.flush_to_spanner()
+        
+        # 4. Run Orchestrator (skip_deletions=True)
+        calculations = [
+            {
+                "name": "Deletions Skip Test Rollup",
+                "type": "PLACE_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "place_aggregation": {
+                    "from_place_types": "County",
+                    "to_place_types": "State",
+                    "allow_multiple_to_places": False
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name], skip_deletions=True)
+        self.assertTrue(res.success)
+        
+        # 5. Verify Spanner State after run
+        with self.database.snapshot(multi_use=True) as snapshot:
+            # A. New aggregated data SHOULD exist
+            new_obs = list(snapshot.execute_sql(
+                "SELECT value FROM Observation WHERE entity1 = 'geoId/06' AND variable_measured = 'Count_Person' AND date = '2020'"
+            ))
+            self.assertEqual(len(new_obs), 1)
+            self.assertEqual(float(new_obs[0][0]), 100.0)
+            
+            # B. Stale aggregated data SHOULD STILL EXIST (skipped deletion)
+            stale_obs_after = list(snapshot.execute_sql(
+                "SELECT value FROM Observation WHERE entity1 = 'geoId/99'"
+            ))
+            self.assertEqual(len(stale_obs_after), 1)
+            self.assertEqual(float(stale_obs_after[0][0]), 500.0)
+            
+            stale_edge_after = list(snapshot.execute_sql(
+                "SELECT object_id FROM Edge WHERE subject_id = 'geoId/99'"
+            ))
+            self.assertEqual(len(stale_edge_after), 1)
+
+    def test_deletions_scoped(self):
+        """Tests that deletions only target output imports of active/expanded imports."""
+        import_a = 'USFed_DeletionsTestA'
+        output_a = f'{import_a}_AggState'
+        import_b = 'USFed_DeletionsTestB'
+        output_b = f'{import_b}_AggState'
+        
+        # 1. Setup Place Topology (using a shared topology import name to avoid duplicate edges)
+        topo_import = 'USGeo_Topology'
+        self.add_node('geoId/06', 'California', types=['State'])
+        self.add_edge('geoId/06', 'typeOf', 'State', topo_import)
+        self.add_node('geoId/06075', 'San Francisco County', types=['County'])
+        self.add_edge('geoId/06075', 'typeOf', 'County', topo_import)
+        self.add_edge('geoId/06075', 'containedInPlace', 'geoId/06', topo_import)
+        
+        # 2. Setup Raw Data for both A and B (using distinct facet_ids to avoid key conflicts)
+        self.add_observation('Count_Person', 'geoId/06075', '2020', 100.0, import_name=import_a, facet_id='facet_a')
+        self.add_observation('Count_Person', 'geoId/06075', '2020', 200.0, import_name=import_b, facet_id='facet_b')
+        
+        # 3. Setup Stale Aggregated Data for both A and B
+        self.add_observation('Count_Person', 'geoId/99', '2010', 500.0, import_name=output_a, facet_id='facet_out_a')
+        self.add_edge('geoId/99', 'typeOf', 'State', output_a)
+        
+        self.add_observation('Count_Person', 'geoId/88', '2010', 600.0, import_name=output_b, facet_id='facet_out_b')
+        self.add_edge('geoId/88', 'typeOf', 'State', output_b)
+        
+        self.flush_to_spanner()
+        
+        # 4. Run Orchestrator with ONLY import_a active
+        calculations = [
+            {
+                "name": "Rollup A",
+                "type": "PLACE_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_a],
+                "output_import": output_a,
+                "place_aggregation": {
+                    "from_place_types": "County",
+                    "to_place_types": "State",
+                    "allow_multiple_to_places": False
+                }
+            },
+            {
+                "name": "Rollup B",
+                "type": "PLACE_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_b],
+                "output_import": output_b,
+                "place_aggregation": {
+                    "from_place_types": "County",
+                    "to_place_types": "State",
+                    "allow_multiple_to_places": False
+                }
+            }
+        ]
+        
+        # Run only for import_a
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_a], skip_deletions=False)
+        self.assertTrue(res.success)
+        
+        # 5. Verify Spanner State
+        with self.database.snapshot(multi_use=True) as snapshot:
+            # A. New aggregated data for A SHOULD exist
+            obs_a = list(snapshot.execute_sql(
+                f"SELECT value FROM Observation WHERE entity1 = 'geoId/06' AND variable_measured = 'Count_Person' AND facet_id IN (SELECT facet_id FROM TimeSeries WHERE provenance = 'dc/base/{output_a}')"
+            ))
+            self.assertEqual(len(obs_a), 1)
+            self.assertEqual(float(obs_a[0][0]), 100.0)
+            
+            # B. Stale aggregated data for A SHOULD BE GONE
+            stale_obs_a = list(snapshot.execute_sql(
+                "SELECT value FROM Observation WHERE entity1 = 'geoId/99'"
+            ))
+            self.assertEqual(len(stale_obs_a), 0)
+            
+            # C. Stale aggregated data for B SHOULD STILL EXIST (since import_b was not active)
+            stale_obs_b = list(snapshot.execute_sql(
+                "SELECT value FROM Observation WHERE entity1 = 'geoId/88'"
+            ))
+            self.assertEqual(len(stale_obs_b), 1)
+            self.assertEqual(float(stale_obs_b[0][0]), 600.0)
+            
+            # D. New aggregated data for B SHOULD NOT exist
+            new_obs_b = list(snapshot.execute_sql(
+                f"SELECT value FROM Observation WHERE entity1 = 'geoId/06' AND variable_measured = 'Count_Person' AND facet_id IN (SELECT facet_id FROM TimeSeries WHERE provenance = 'dc/base/{output_b}')"
+            ))
+            self.assertEqual(len(new_obs_b), 0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pipeline/workflow/aggregation-helper/aggregation/entity_aggregation_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/entity_aggregation_generator.py
@@ -18,7 +18,7 @@ import re
 from typing import Dict, List, Tuple
 from google.cloud import bigquery
 from .bq_executor import BigQueryExecutor
-from .sql_utils import _escape_sql_literal
+from .common import _escape_sql_literal, get_provenance_name
 
 
 class EntityAggregationConfig:
@@ -144,11 +144,10 @@ class EntityAggregationGenerator:
         connection_id = self.executor.connection_id
         dest = self.executor.get_spanner_destination_uri()
         
-        prefix = "dc/base/" if self.is_base_dc else ""
-        output_provenance = f"{prefix}{config.output_import}"
+        output_provenance = get_provenance_name(config.output_import, self.is_base_dc)
         
         safe_input_imports = [_escape_sql_literal(name) for name in config.input_imports]
-        input_provenances = [f"'{prefix}{name}'" for name in safe_input_imports]
+        input_provenances = [f"'{get_provenance_name(name, self.is_base_dc)}'" for name in safe_input_imports]
         input_provenances_str = ", ".join(input_provenances)
 
         entity_types_str = ", ".join([f"'{_escape_sql_literal(t)}'" for t in config.entity_types])

--- a/pipeline/workflow/aggregation-helper/aggregation/linked_edge_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/linked_edge_generator.py
@@ -18,7 +18,7 @@ from typing import List, Optional
 from google.cloud import bigquery
 
 from .bq_executor import BigQueryExecutor
-from .sql_utils import _escape_sql_literal
+from .common import BASE_PROVENANCE_PREFIX, _escape_sql_literal
 
 
 class LinkedEdgeGenerator:
@@ -56,10 +56,10 @@ class LinkedEdgeGenerator:
 
         dest = self.executor.get_spanner_destination_uri()
         safe_names = [_escape_sql_literal(name) for name in import_names]
-        prefix = "dc/base/" if self.is_base_dc else ""
+        prefix = BASE_PROVENANCE_PREFIX if self.is_base_dc else ""
         provenances = [f"'{prefix}{name}'" for name in safe_names]
         provenance_filter = f" AND provenance IN ({', '.join(provenances)})"
-        gen_graphs_prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+        gen_graphs_prov = f'{BASE_PROVENANCE_PREFIX}GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
 
         query = f"""  # nosec
         -- Pull base edges needed for memberOf aggregation

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -33,6 +33,7 @@ from .stat_var_series_aggregator import StatVarSeriesAggregator
 from .entity_aggregation_generator import EntityAggregationGenerator, EntityAggregationConfig
 from .super_enum_aggregation_generator import SuperEnumAggregationGenerator
 from .validator import validate_config
+from .deleter import AggregationDeleter
 
 _OUTPUT_IMPORT_KEY = "output_import"
 
@@ -115,6 +116,12 @@ class AggregationOrchestrator:
         )
         self.is_base_dc = is_base_dc
         self.poll_interval = poll_interval
+        self.deleter = AggregationDeleter(
+            project_id=project_id,
+            instance_id=instance_id,
+            database_id=database_id,
+            is_base_dc=is_base_dc
+        )
 
         # Resolve paths for config directory and schema
         curr_dir = os.path.dirname(os.path.abspath(__file__))
@@ -131,7 +138,7 @@ class AggregationOrchestrator:
         else:
             self.calculations = validate_config(target_config, schema_file_path)
 
-    def run(self, active_imports: List[str], dry_run: bool = True) -> AggregationRunResult:
+    def run(self, active_imports: List[str], dry_run: bool = True, skip_deletions: bool = False) -> AggregationRunResult:
         """Executes aggregations independently for each active import.
 
         Blocks and synchronizes stage progression for each import:
@@ -140,13 +147,23 @@ class AggregationOrchestrator:
         Args:
             active_imports: List of active import dataset names to process.
             dry_run: If True, logs imports and active stages without executing BigQuery jobs.
+            skip_deletions: If True, skips deleting existing aggregated data.
 
         Returns:
             AggregationRunResult containing status per import.
         """
         expanded_imports = self._expand_active_imports(active_imports)
+        
+        if not skip_deletions:
+            self._delete_previous_aggregations(
+                imports=expanded_imports,
+                dry_run=dry_run
+            )
+        else:
+            logging.info("Skipping deletion of existing aggregated data as skip_deletions=True.")
+
         logging.info(
-            f"Starting Aggregation Orchestrator run (dry_run={dry_run}) for active imports: {active_imports} (expanded: {expanded_imports})"
+            f"Starting Aggregation Orchestrator run (dry_run={dry_run}, skip_deletions={skip_deletions}) for active imports: {active_imports} (expanded: {expanded_imports})"
         )
         run_result = AggregationRunResult()
 
@@ -195,6 +212,36 @@ class AggregationOrchestrator:
                 )
 
         return run_result
+
+    def _delete_previous_aggregations(
+        self,
+        imports: List[str],
+        dry_run: bool = True
+    ) -> None:
+        """Deletes existing aggregated data for the specified imports before running aggregations.
+
+        Args:
+            imports: List of import names to process for deletion.
+            dry_run: If True, only logs what would be deleted.
+        """
+
+        to_delete = set()
+        for single_import in imports:
+            for calc in self.calculations:
+                if self._calc_applies_to_import(calc, single_import):
+                    output = calc.get("output_import")
+                    if output:
+                        to_delete.add(output)
+
+        if not to_delete:
+            logging.info("No existing aggregated data resolved for deletion.")
+            return
+
+        to_delete_list = sorted(list(to_delete))
+        if dry_run:
+            logging.info(f"[Dry Run] Would delete aggregated data for imports: {to_delete_list}")
+        else:
+            self.deleter.delete_aggregated_data(to_delete_list)
 
     def _get_active_stages_for_import(self, single_import: str) -> List[int]:
         """Returns a sorted list of unique active stage numbers for a single import.

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
@@ -135,8 +135,11 @@ class TestOrchestratorExecution(unittest.TestCase):
     def setUp(self):
         self.deleter_patcher = patch('aggregation.orchestrator.AggregationDeleter')
         self.mock_deleter = self.deleter_patcher.start()
+        self.addCleanup(self.deleter_patcher.stop)
 
         self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
         config_path = os.path.join(self.tmpdir.name, "config.yaml")
         with open(config_path, "w") as f:
             f.write(VALID_CONFIG_YAML)
@@ -148,10 +151,6 @@ class TestOrchestratorExecution(unittest.TestCase):
             database_id="db",
             config_file_path=config_path
         )
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
-        self.deleter_patcher.stop()
 
     def test_run_dry_run_true(self, mock_entity_gen, mock_calc_gen, mock_sv_agg, mock_place_gen, mock_executor_cls):
         """Tests that run with dry_run=True logs stages without submitting BigQuery jobs."""
@@ -280,8 +279,11 @@ class TestOrchestratorChainedExecution(unittest.TestCase):
     def setUp(self):
         self.deleter_patcher = patch('aggregation.orchestrator.AggregationDeleter')
         self.mock_deleter = self.deleter_patcher.start()
+        self.addCleanup(self.deleter_patcher.stop)
 
         self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
         config_path = os.path.join(self.tmpdir.name, "config.yaml")
         with open(config_path, "w") as f:
             f.write(CHAINED_CONFIG_YAML)
@@ -293,10 +295,6 @@ class TestOrchestratorChainedExecution(unittest.TestCase):
             database_id="db",
             config_file_path=config_path
         )
-
-    def tearDown(self):
-        self.tmpdir.cleanup()
-        self.deleter_patcher.stop()
 
     def test_run_chained_dry_run_false(self, mock_place_gen, mock_executor_cls):
         """Tests that run with dry_run=False submits BigQuery jobs across chained stages."""

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
@@ -133,6 +133,9 @@ class TestOrchestratorExecution(unittest.TestCase):
     """Tests stage execution, verifying job submission and synchronization."""
 
     def setUp(self):
+        self.deleter_patcher = patch('aggregation.orchestrator.AggregationDeleter')
+        self.mock_deleter = self.deleter_patcher.start()
+
         self.tmpdir = tempfile.TemporaryDirectory()
         config_path = os.path.join(self.tmpdir.name, "config.yaml")
         with open(config_path, "w") as f:
@@ -148,6 +151,7 @@ class TestOrchestratorExecution(unittest.TestCase):
 
     def tearDown(self):
         self.tmpdir.cleanup()
+        self.deleter_patcher.stop()
 
     def test_run_dry_run_true(self, mock_entity_gen, mock_calc_gen, mock_sv_agg, mock_place_gen, mock_executor_cls):
         """Tests that run with dry_run=True logs stages without submitting BigQuery jobs."""
@@ -158,6 +162,7 @@ class TestOrchestratorExecution(unittest.TestCase):
 
         mock_place_gen.return_value.aggregate_places.assert_not_called()
         mock_sv_agg.return_value.aggregate_stat_vars.assert_not_called()
+        self.mock_deleter.return_value.delete_aggregated_data.assert_not_called()
 
     def test_run_dry_run_false(self, mock_entity_gen, mock_calc_gen, mock_sv_agg, mock_place_gen, mock_executor_cls):
         """Tests that run with dry_run=False submits BigQuery jobs across stages."""
@@ -192,6 +197,30 @@ class TestOrchestratorExecution(unittest.TestCase):
             skip_all_sources_present_check=True
         )
 
+        # Verify deleter was called with expected outputs
+        self.mock_deleter.return_value.delete_aggregated_data.assert_called_once_with(
+            ["USFed_Census_AggState", "USFed_Census_StatVarAgg"]
+        )
+
+    def test_run_skip_deletions(self, mock_entity_gen, mock_calc_gen, mock_sv_agg, mock_place_gen, mock_executor_cls):
+        """Tests that run with skip_deletions=True does not call deleter."""
+        mock_job1 = MagicMock()
+        mock_job1.job_id = "job-place-1"
+        mock_place_gen.return_value.aggregate_places.return_value = mock_job1
+
+        mock_job2 = MagicMock()
+        mock_job2.job_id = "job-sv-1"
+        mock_sv_agg.return_value.aggregate_stat_vars.return_value = [mock_job2]
+
+        self.orchestrator.executor = MagicMock()
+        self.orchestrator.executor.get_jobs_status.return_value = {"status": "DONE"}
+
+        result = self.orchestrator.run(active_imports=["USFed_Census"], dry_run=False, skip_deletions=True)
+        self.assertTrue(result.success)
+
+        # Verify deleter was NOT called
+        self.mock_deleter.return_value.delete_aggregated_data.assert_not_called()
+
     def test_execute_stage(self, mock_entity_gen, mock_calc_gen, mock_sv_agg, mock_place_gen, mock_executor_cls):
         """Tests manual execution of a specific stage."""
         mock_job1 = MagicMock()
@@ -207,6 +236,7 @@ class TestOrchestratorExecution(unittest.TestCase):
             allow_multiple_to_places=False
         )
         self.assertEqual(jobs, [mock_job1])
+        self.mock_deleter.return_value.delete_aggregated_data.assert_not_called()
 
     def test_execute_stage_entity_aggregation(self, mock_entity_gen, mock_calc_gen, mock_sv_agg, mock_place_gen, mock_executor_cls):
         """Tests manual execution of ENTITY_AGGREGATION stage."""
@@ -217,6 +247,7 @@ class TestOrchestratorExecution(unittest.TestCase):
         jobs = self.orchestrator.execute_stage(3, ["EarthquakeUSGS"])
         self.assertEqual(jobs, [mock_job])
         mock_entity_gen.return_value.aggregate_entities.assert_called_once()
+        self.mock_deleter.return_value.delete_aggregated_data.assert_not_called()
 
 
 CHAINED_CONFIG_YAML = textwrap.dedent("""\
@@ -247,6 +278,9 @@ class TestOrchestratorChainedExecution(unittest.TestCase):
     """Tests chained stage execution, verifying job submission and synchronization."""
 
     def setUp(self):
+        self.deleter_patcher = patch('aggregation.orchestrator.AggregationDeleter')
+        self.mock_deleter = self.deleter_patcher.start()
+
         self.tmpdir = tempfile.TemporaryDirectory()
         config_path = os.path.join(self.tmpdir.name, "config.yaml")
         with open(config_path, "w") as f:
@@ -262,6 +296,7 @@ class TestOrchestratorChainedExecution(unittest.TestCase):
 
     def tearDown(self):
         self.tmpdir.cleanup()
+        self.deleter_patcher.stop()
 
     def test_run_chained_dry_run_false(self, mock_place_gen, mock_executor_cls):
         """Tests that run with dry_run=False submits BigQuery jobs across chained stages."""
@@ -289,6 +324,11 @@ class TestOrchestratorChainedExecution(unittest.TestCase):
         
         # Verify that both stage 1 and stage 2 calculations are triggered (call_count = 2).
         self.assertEqual(mock_place_gen.return_value.aggregate_places.call_count, 2)
+
+        # Verify deleter was called with all expected outputs in the chain
+        self.mock_deleter.return_value.delete_aggregated_data.assert_called_once_with(
+            ["USFed_Census_AggState", "USFed_Census_AggState_AggCountry"]
+        )
 
 
 if __name__ == '__main__':

--- a/pipeline/workflow/aggregation-helper/aggregation/place_aggregation_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/place_aggregation_generator.py
@@ -19,7 +19,7 @@ from typing import List, Optional
 from google.cloud import bigquery
 
 from .bq_executor import BigQueryExecutor
-from .sql_utils import _escape_sql_literal
+from .common import _escape_sql_literal, get_provenance_name
 
 
 class PlaceAggregationGenerator:
@@ -68,10 +68,7 @@ class PlaceAggregationGenerator:
         safe_names = [_escape_sql_literal(name) for name in import_names]
         
         # Filter TimeSeries by provenance (mapping to import names)
-        if self.is_base_dc:
-            provenance_names = [f"dc/base/{name}" for name in safe_names]
-        else:
-            provenance_names = safe_names
+        provenance_names = [get_provenance_name(name, self.is_base_dc) for name in safe_names]
         provenance_str = ", ".join([f"'{name}'" for name in provenance_names])
 
         # Escape types just in case

--- a/pipeline/workflow/aggregation-helper/aggregation/provenance_summary_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/provenance_summary_generator.py
@@ -18,7 +18,7 @@ from typing import List, Optional
 from google.cloud import bigquery
 
 from .bq_executor import BigQueryExecutor
-from .sql_utils import _escape_sql_literal
+from .common import _escape_sql_literal, get_provenance_name
 
 
 class ProvenanceSummaryGenerator:
@@ -54,8 +54,7 @@ class ProvenanceSummaryGenerator:
 
         safe_names = [_escape_sql_literal(name) for name in import_names]
         # Format provenances for the SQL IN clause (matching TimeSeries.provenance)
-        prefix = "dc/base/" if self.is_base_dc else ""
-        provenances = [f"'{prefix}{name}'" for name in safe_names]
+        provenances = [f"'{get_provenance_name(name, self.is_base_dc)}'" for name in safe_names]
         provenances_str = ", ".join(provenances)
 
         query = f"""  # nosec

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_aggregator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_aggregator.py
@@ -19,7 +19,7 @@ from typing import List, Optional
 from google.cloud import bigquery
 
 from .bq_executor import BigQueryExecutor
-from .sql_utils import _escape_sql_literal
+from .common import _escape_sql_literal, get_provenance_name
 
 logging.getLogger().setLevel(logging.INFO)
 
@@ -111,11 +111,10 @@ class StatVarAggregator:
         safe_sources = [_escape_sql_literal(sv) for sv in source_svs]
         safe_imports = [_escape_sql_literal(name) for name in import_names]
 
-        prefix = "dc/base/" if self.is_base_dc else ""
         sources_str = ", ".join([f"'{sv}'" for sv in safe_sources])
-        imports_str = ", ".join([f"'{prefix}{name}'" for name in safe_imports])
+        imports_str = ", ".join([f"'{get_provenance_name(name, self.is_base_dc)}'" for name in safe_imports])
         
-        output_provenance = f"{prefix}{output_import_name}"
+        output_provenance = get_provenance_name(output_import_name, self.is_base_dc)
         safe_output_provenance = _escape_sql_literal(output_provenance)
 
         new_method_sql = """
@@ -201,11 +200,10 @@ class StatVarAggregator:
         safe_sources = [_escape_sql_literal(sv) for sv in source_svs]
         safe_imports = [_escape_sql_literal(name) for name in import_names]
 
-        prefix = "dc/base/" if self.is_base_dc else ""
         sources_str = ", ".join([f"'{sv}'" for sv in safe_sources])
-        imports_str = ", ".join([f"'{prefix}{name}'" for name in safe_imports])
+        imports_str = ", ".join([f"'{get_provenance_name(name, self.is_base_dc)}'" for name in safe_imports])
 
-        output_provenance = f"{prefix}{output_import_name}"
+        output_provenance = get_provenance_name(output_import_name, self.is_base_dc)
         safe_output_provenance = _escape_sql_literal(output_provenance)
 
         # Filter condition for completeness check

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_calculation_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_calculation_generator.py
@@ -19,7 +19,7 @@ from typing import List, Dict
 from google.cloud import bigquery
 
 from .bq_executor import BigQueryExecutor
-from .sql_utils import _escape_sql_literal
+from .common import _escape_sql_literal, get_provenance_name
 
 
 class StatVarCalculationGenerator:
@@ -67,12 +67,11 @@ class StatVarCalculationGenerator:
         dest = self.executor.get_spanner_destination_uri()
 
         # Format input provenances
-        prefix = "dc/base/" if self.is_base_dc else ""
         safe_imports = [_escape_sql_literal(name) for name in import_names]
-        provenance_names = [f"{prefix}{name}" for name in safe_imports]
+        provenance_names = [get_provenance_name(name, self.is_base_dc) for name in safe_imports]
         provenance_str = ", ".join([f"'{name}'" for name in provenance_names])
 
-        output_provenance = f"{prefix}{output_import_name}"
+        output_provenance = get_provenance_name(output_import_name, self.is_base_dc)
         safe_output_provenance = _escape_sql_literal(output_provenance)
 
         # Collect all unique input SV patterns to filter Spanner Observations early.

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from google.cloud import bigquery
 from .bq_executor import BigQueryExecutor
-from .sql_utils import _escape_sql_literal
+from .common import BASE_PROVENANCE_PREFIX, _escape_sql_literal
 
 class StatVarGroupGenerator:
     """Iteratively generates StatVarGroup nodes and hierarchical edges from MCF schemas."""
@@ -33,7 +33,7 @@ class StatVarGroupGenerator:
         self.generated_provenance = (
           generated_provenance
           if generated_provenance is not None
-          else ('dc/base/GeneratedGraphs' if is_base_dc else 'GeneratedGraphs')
+          else (f'{BASE_PROVENANCE_PREFIX}GeneratedGraphs' if is_base_dc else 'GeneratedGraphs')
         )
         self.should_filter_basic_population_type = should_filter_basic_population_type
 

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_series_aggregator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_series_aggregator.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List
 from google.cloud import bigquery
 
 from .bq_executor import BigQueryExecutor
-from .sql_utils import _escape_sql_literal
+from .common import _escape_sql_literal, get_provenance_name
 
 logging.getLogger().setLevel(logging.INFO)
 
@@ -81,10 +81,9 @@ class StatVarSeriesAggregator:
         connection_id = self.executor.connection_id
         dest = self.executor.get_spanner_destination_uri()
 
-        prefix = "dc/base/" if self.is_base_dc else ""
         safe_inputs = [_escape_sql_literal(name) for name in input_imports]
-        input_provenance_str = ", ".join([f"'{prefix}{name}'" for name in safe_inputs])
-        output_provenance = f"{prefix}{output_import}"
+        input_provenance_str = ", ".join([f"'{get_provenance_name(name, self.is_base_dc)}'" for name in safe_inputs])
+        output_provenance = get_provenance_name(output_import, self.is_base_dc)
         safe_output_provenance = _escape_sql_literal(output_provenance)
 
         # Build SQL fragments for each active function

--- a/pipeline/workflow/aggregation-helper/aggregation/super_enum_aggregation_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/super_enum_aggregation_generator.py
@@ -18,7 +18,7 @@ from typing import Any, List, Optional
 from google.cloud import spanner
 from google.cloud import bigquery
 from .bq_executor import BigQueryExecutor
-from .sql_utils import _escape_sql_literal
+from .common import BASE_PROVENANCE_PREFIX, _escape_sql_literal
 
 def get_dc_base32_encode_sql() -> str:
     """Returns the SQL definition for the DC_BASE32_ENCODE UDF.
@@ -154,8 +154,8 @@ class SuperEnumAggregationGenerator:
 
         safe_names = [_escape_sql_literal(name) for name in import_names]
         if self.is_base_dc:
-            provenance_names = [f"dc/base/{name}" for name in safe_names]
-            prefix = "dc/base/"
+            provenance_names = [f"{BASE_PROVENANCE_PREFIX}{name}" for name in safe_names]
+            prefix = BASE_PROVENANCE_PREFIX
         else:
             provenance_names = safe_names
             prefix = ""

--- a/pipeline/workflow/aggregation-helper/main.py
+++ b/pipeline/workflow/aggregation-helper/main.py
@@ -38,6 +38,12 @@ def main():
         default=True,
         help="Run in dry-run mode without executing jobs (use --no-dry_run to execute)."
     )
+    parser.add_argument(
+        "--skip_deletions",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Skip deleting existing aggregated data before running new aggregations."
+    )
 
     args = parser.parse_args()
 
@@ -77,8 +83,12 @@ def main():
         location=location,
     )
 
-    logging.info(f"Executing AggregationOrchestrator pipeline (dry_run={args.dry_run}) for imports: {import_list}")
-    run_result = orchestrator.run(active_imports=import_list, dry_run=args.dry_run)
+    logging.info(f"Executing AggregationOrchestrator pipeline (dry_run={args.dry_run}, skip_deletions={args.skip_deletions}) for imports: {import_list}")
+    run_result = orchestrator.run(
+        active_imports=import_list,
+        dry_run=args.dry_run,
+        skip_deletions=args.skip_deletions
+    )
 
     if not run_result.success:
         logging.error(


### PR DESCRIPTION
This PR implements deletions that will delete previously aggregated data before new aggregations are generated.

The deletions will happen on these tables:
- `Edge`
- `TimeSeries` (It will cascade to `Observation` table automatically)
- `Cache`