### PR TITLE
fix(dcp-preprocessor): enforce source predicate for MCF metadata nodes

### DIFF
--- a/simple/stats/mcf_importer.py
+++ b/simple/stats/mcf_importer.py
@@ -190,9 +190,9 @@ def _register_metadata_nodes(triples: list[Triple], nodes: Nodes) -> None:
     elif pred == "name":
       val = triple.object_value or triple.object_id or ""
       subject_properties[sub_id]["name"] = _clean_literal(val)
-    elif pred in ["sourceLink", "source"]:
-      # Map sourceLink or source to the source ID
-      subject_properties[sub_id]["sourceLink"] = triple.object_id
+    elif pred == "source":
+      # Map source to the source ID
+      subject_properties[sub_id]["source"] = triple.object_id
 
   for sub_id, props in subject_properties.items():
     node_type = props.get("typeOf")
@@ -200,7 +200,7 @@ def _register_metadata_nodes(triples: list[Triple], nodes: Nodes) -> None:
       nodes.register_provenance(id=sub_id,
                                 name=props.get("name", ""),
                                 url=props.get("url", ""),
-                                source_id=props.get("sourceLink", ""))
+                                source_id=props.get("source", ""))
     elif node_type == "Source":
       nodes.register_source(id=sub_id,
                             name=props.get("name", ""),

--- a/simple/stats/mcf_importer.py
+++ b/simple/stats/mcf_importer.py
@@ -190,8 +190,8 @@ def _register_metadata_nodes(triples: list[Triple], nodes: Nodes) -> None:
     elif pred == "name":
       val = triple.object_value or triple.object_id or ""
       subject_properties[sub_id]["name"] = _clean_literal(val)
-    elif pred == "sourceLink":
-      # Map sourceLink to the source ID
+    elif pred in ["sourceLink", "source"]:
+      # Map sourceLink or source to the source ID
       subject_properties[sub_id]["sourceLink"] = triple.object_id
 
   for sub_id, props in subject_properties.items():

--- a/simple/stats/validation.py
+++ b/simple/stats/validation.py
@@ -132,8 +132,7 @@ class MetadataValidator:
       raise ValueError(
           f"Metadata Validation Failed: Linked sources are missing for "
           f"defined provenances:\n" + "\n".join(details) +
-          f"\nPlease specify a source property on these Provenance nodes."
-      )
+          f"\nPlease specify a source property on these Provenance nodes.")
 
   def _clean_dcid(self, val: str) -> str:
     """Normalizes a DCID value by ensuring it starts with 'dcid:' and has no prefix namespaces."""

--- a/simple/stats/validation.py
+++ b/simple/stats/validation.py
@@ -97,7 +97,7 @@ class MetadataValidator:
         if "Provenance" in obj:
           defined_provenances.add(sub)
 
-      elif pred in ["sourceLink", "source"]:
+      elif pred == "source":
         obj = triple.object_id or ""
         if obj:
           provenance_to_source[sub] = self._clean_dcid(obj)
@@ -126,13 +126,13 @@ class MetadataValidator:
 
     if missing_sources:
       details = [
-          f"  - Provenance '{p}' has no linked Source (sourceLink/source property is missing or empty)"
+          f"  - Provenance '{p}' has no linked Source (source property is missing or empty)"
           for p in missing_sources
       ]
       raise ValueError(
           f"Metadata Validation Failed: Linked sources are missing for "
           f"defined provenances:\n" + "\n".join(details) +
-          f"\nPlease specify a sourceLink or source property on these Provenance nodes."
+          f"\nPlease specify a source property on these Provenance nodes."
       )
 
   def _clean_dcid(self, val: str) -> str:

--- a/simple/tests/stats/mcf_importer_test.py
+++ b/simple/tests/stats/mcf_importer_test.py
@@ -106,3 +106,4 @@ class TestMcfImporter(unittest.TestCase):
     _test_import(self, "basic_mcf", is_main_dc=False)
     _test_import(self, "basic_mcf_main_dc", is_main_dc=True)
     _test_import(self, "invalid_mcf", is_main_dc=False, raises_error=True)
+    _test_import(self, "provenance_source", is_main_dc=False)

--- a/simple/tests/stats/runner_test.py
+++ b/simple/tests/stats/runner_test.py
@@ -306,7 +306,7 @@ class TestRunner(unittest.TestCase):
                         "Node: dcid:Provenance1\n"
                         "typeOf: dcs:Provenance\n"
                         "url: \"http://source1.com/provenance1\"\n"
-                        "sourceLink: dcid:Source1\n")
+                        "source: dcid:Source1\n")
       with open(os.path.join(input_dir, "provenance.mcf"), "w") as f:
         f.write(provenance_mcf)
 
@@ -466,7 +466,7 @@ class TestRunner(unittest.TestCase):
                   "typeOf: dcs:Source\n\n"
                   "Node: dcid:oecd\n"
                   "typeOf: dcs:Provenance\n"
-                  "sourceLink: dcid:OecdSource\n")
+                  "source: dcid:OecdSource\n")
       with open(os.path.join(oecd_dir, "oecd.mcf"), "w") as f:
         f.write(oecd_mcf)
 
@@ -507,7 +507,7 @@ class TestRunner(unittest.TestCase):
                  "typeOf: dcs:Source\n\n"
                  "Node: dcid:ilo\n"
                  "typeOf: dcs:Provenance\n"
-                 "sourceLink: dcid:IloSource\n")
+                 "source: dcid:IloSource\n")
       with open(os.path.join(ilo_dir, "ilo.mcf"), "w") as f:
         f.write(ilo_mcf)
 

--- a/simple/tests/stats/test_data/mcf_importer/expected/provenance_source.triples.db.csv
+++ b/simple/tests/stats/test_data/mcf_importer/expected/provenance_source.triples.db.csv
@@ -1,0 +1,8 @@
+subject_id,predicate,object_id,object_value
+TestProvenance,typeOf,Provenance,
+TestProvenance,name,,Test Dataset Provenance
+TestProvenance,source,TestSource,
+TestProvenance,url,,https://example.com/test-dataset
+TestSource,typeOf,Source,
+TestSource,name,,Test Data Source
+TestSource,url,,https://example.com

--- a/simple/tests/stats/test_data/mcf_importer/input/provenance_source.mcf
+++ b/simple/tests/stats/test_data/mcf_importer/input/provenance_source.mcf
@@ -1,0 +1,10 @@
+Node: dcid:TestProvenance
+typeOf: dcs:Provenance
+name: "Test Dataset Provenance"
+source: dcid:TestSource
+url: "https://example.com/test-dataset"
+
+Node: dcid:TestSource
+typeOf: dcs:Source
+name: "Test Data Source"
+url: "https://example.com"

--- a/simple/tests/stats/test_data/variable_per_row_importer/input/multi_entity_custom_dimensions/input.mcf
+++ b/simple/tests/stats/test_data/variable_per_row_importer/input/multi_entity_custom_dimensions/input.mcf
@@ -5,4 +5,4 @@ url: "https://customsource.org"
 Node: dcid:provenance/CustomImport
 typeOf: dcs:Provenance
 url: "https://customsource.org/custom_import"
-sourceLink: dcid:source/CustomSource
+source: dcid:source/CustomSource

--- a/simple/tests/stats/test_data/variable_per_row_importer/input/multi_entity_with_primary/input.mcf
+++ b/simple/tests/stats/test_data/variable_per_row_importer/input/multi_entity_with_primary/input.mcf
@@ -5,4 +5,4 @@ url: "https://customsource.org"
 Node: dcid:provenance/CustomImport
 typeOf: dcs:Provenance
 url: "https://customsource.org/custom_import"
-sourceLink: dcid:source/CustomSource
+source: dcid:source/CustomSource

--- a/simple/tests/stats/test_data/variable_per_row_importer/input/single_entity_official_keys/input.mcf
+++ b/simple/tests/stats/test_data/variable_per_row_importer/input/single_entity_official_keys/input.mcf
@@ -5,4 +5,4 @@ url: "https://customsource.org"
 Node: dcid:provenance/CustomImport
 typeOf: dcs:Provenance
 url: "https://customsource.org/custom_import"
-sourceLink: dcid:source/CustomSource
+source: dcid:source/CustomSource

--- a/simple/tests/stats/validation_test.py
+++ b/simple/tests/stats/validation_test.py
@@ -42,8 +42,7 @@ class TestMetadataValidator(unittest.TestCase):
             # Define Provenance
             Triple("dcid:MyProvenance", "typeOf", object_id="Provenance"),
             # Link Provenance to Source
-            Triple("dcid:MyProvenance", "source",
-                   object_id="dcid:MySource"),
+            Triple("dcid:MyProvenance", "source", object_id="dcid:MySource"),
         ]
     }
 
@@ -117,8 +116,7 @@ class TestMetadataValidator(unittest.TestCase):
     mock_db._triples = {
         "_global": [
             Triple("dcid:MyProvenance", "typeOf", object_id="Provenance"),
-            Triple("dcid:MyProvenance", "source",
-                   object_id="dcid:MySource"),
+            Triple("dcid:MyProvenance", "source", object_id="dcid:MySource"),
         ]
     }
 

--- a/simple/tests/stats/validation_test.py
+++ b/simple/tests/stats/validation_test.py
@@ -42,7 +42,7 @@ class TestMetadataValidator(unittest.TestCase):
             # Define Provenance
             Triple("dcid:MyProvenance", "typeOf", object_id="Provenance"),
             # Link Provenance to Source
-            Triple("dcid:MyProvenance", "sourceLink",
+            Triple("dcid:MyProvenance", "source",
                    object_id="dcid:MySource"),
         ]
     }
@@ -117,7 +117,7 @@ class TestMetadataValidator(unittest.TestCase):
     mock_db._triples = {
         "_global": [
             Triple("dcid:MyProvenance", "typeOf", object_id="Provenance"),
-            Triple("dcid:MyProvenance", "sourceLink",
+            Triple("dcid:MyProvenance", "source",
                    object_id="dcid:MySource"),
         ]
     }


### PR DESCRIPTION
This PR updates the preprocessor to strictly enforce the 'source' predicate on Provenance nodes in MCF files (which matches the graph schema), and completely removes support for the invalid 'sourceLink' property. 

Existing tests using 'sourceLink' in test MCFs have been updated to use 'source'.