### PR TITLE
Add KeyValueStore table to schema for Cache migration

### DIFF
--- a/pipeline/workflow/ingestion-helper/clients/schema.sql
+++ b/pipeline/workflow/ingestion-helper/clients/schema.sql
@@ -190,6 +190,12 @@ CREATE TABLE Cache (
   value JSON,
 ) PRIMARY KEY(type, key, provenance);
 
+CREATE TABLE KeyValueStore (
+  type STRING(1024) NOT NULL,
+  key STRING(1024) NOT NULL,
+  provenance STRING(1024) NOT NULL,
+  value JSON,
+) PRIMARY KEY(type, key, provenance);
 
 
 


### PR DESCRIPTION
Adds the `KeyValueStore` Spanner table to `schema.sql` with an identical schema definition to the existing `Cache` table.

This is the initial preparatory step for renaming `Cache` to `KeyValueStore`, enabling dual writes to both tables during Spanner ingestion.