### PR TITLE
[aggregation-helper] Add --is_base_dc CLI param to disable for DCP

### DIFF
--- a/pipeline/workflow/aggregation-helper/main.py
+++ b/pipeline/workflow/aggregation-helper/main.py
@@ -48,6 +48,12 @@ def main():
         default=False,
         help="Skip deleting existing aggregated data before running new aggregations."
     )
+    parser.add_argument(
+        "--is_base_dc",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Whether running in base Data Commons environment (default: True, use --no-is_base_dc for DCP)."
+    )
 
     args = parser.parse_args()
 
@@ -90,6 +96,7 @@ def main():
         instance_id=instance_id,
         database_id=database_id,
         location=location,
+        is_base_dc=args.is_base_dc,
         config_file_path=config_path,
         enable_embeddings=enable_embeddings,
         embedding_conn_id=embedding_conn_id,


### PR DESCRIPTION
### Summary
Adds an explicit `--is_base_dc` command-line parameter to `pipeline/workflow/aggregation-helper/main.py` using `argparse.BooleanOptionalAction`.

When executing postprocessing inside a DCP deployment right via Cloud Workflows (`--no-is_base_dc`), this ensures `AggregationOrchestrator` correctly transitions out of Base DC mode (`is_base_dc=False`) right upon startup, preventing legacy prefixing across Spanner queries and enabling clean provenance summary generation in `KeyValueStore`.