### PR TITLE
fix: Restrict StatVarGroup generator to specified imports

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_group_generator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_group_generator_test.py
@@ -52,21 +52,7 @@ from aggregation import BigQueryExecutor, StatVarGroupGenerator
 class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
     """Integration E2E tests for StatVarGroupGenerator."""
 
-    def test_stat_var_group_generation(self):
-        """
-        Tests the generation of StatVarGroups and hierarchical edges from SV specs.
-        
-        Setup:
-          - A vertical spec mapping 'Student' population type to a 'TestVertical' SVG.
-          - An unconstrained SV 'Count_Student'.
-          - A constrained SV 'Count_Student_Female' (gender=Female).
-          - A curated SV 'Median_Age_Student'.
-          - A basic populationType SV 'Count_Person'.
-          - An uncategorized basic SV 'Count_Thing'.
-        """
-        ns = 'dc/' if self.is_base_dc else 'c/'
-        prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
-        
+    def _setup_mock_data(self, ns):
         # 1. Setup mock Vertical Node and Spec mappings
         self.add_node(f'{ns}g/TestVertical', 'Test Vertical', value=f'{ns}g/TestVertical', types=['StatVarGroup'])
         self.add_node(f'{ns}g/TestCustomVertical', 'Test Custom Vertical', types=['StatVarGroup'])
@@ -118,15 +104,32 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
         self.flush_to_spanner()
 
+    def test_stat_var_group_generation(self):
+        """
+        Tests the generation of StatVarGroups and hierarchical edges from SV specs.
+        
+        Setup:
+          - A vertical spec mapping 'Student' population type to a 'TestVertical' SVG.
+          - An unconstrained SV 'Count_Student'.
+          - A constrained SV 'Count_Student_Female' (gender=Female).
+          - A curated SV 'Median_Age_Student'.
+          - A basic populationType SV 'Count_Person'.
+          - An uncategorized basic SV 'Count_Thing'.
+        """
+        ns = 'dc/' if self.is_base_dc else 'c/'
+        prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+        
+        self._setup_mock_data(ns)
+
         calculations = [
             {
                 "name": "StatVar Groups Generation",
                 "type": "STAT_VAR_GROUPS",
                 "stage": 1,
-                "input_imports": ["Schema"]
+                "input_imports": ["TestImport"]
             }
         ]
-        res = self.run_orchestrator(calculations=calculations, active_imports=["Schema"])
+        res = self.run_orchestrator(calculations=calculations, active_imports=["TestImport"])
         self.assertTrue(res.success)
 
         # 3. Verify results in Spanner
@@ -193,12 +196,66 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
             # Verify the root SVG attached to the Vertical declared in the Spec
             self.assertIn((f'{ns}g/Student', 'specializationOf', f'{ns}g/TestVertical', prov), edges)
 
-            # Verify curated SVs attached to ancestor SVs based on curated hierarchy
+            # Verify curated SVs from OTHER imports are NOT processed
             self.assertNotIn(('Median_Age_Student', 'memberOf', f'{ns}g/Student', prov), edges)
             self.assertNotIn(('Median_Age_Student', 'linkedMemberOf', f'{ns}g/Student', prov), edges)
             self.assertNotIn(('Median_Age_Student', 'linkedMemberOf', f'{ns}g/TestVertical', prov), edges)
+            self.assertNotIn(('Median_Age_Student', 'linkedMemberOf', f'{ns}g/TestCustomVertical', prov), edges)
+            self.assertNotIn(('Median_Age_Student', 'linkedMemberOf', f'{ns}g/Root', prov), edges)
+
+
+    def test_stat_var_group_generation_only_custom_import(self):
+        """
+        Tests that running for TestCustomImport only processes its data.
+        """
+        ns = 'dc/' if self.is_base_dc else 'c/'
+        prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+        
+        self._setup_mock_data(ns)
+
+        calculations = [
+            {
+                "name": "StatVar Groups Generation",
+                "type": "STAT_VAR_GROUPS",
+                "stage": 1,
+                "input_imports": ["TestCustomImport"]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=["TestCustomImport"])
+        self.assertTrue(res.success)
+
+        # Verify results in Spanner
+        with self.database.snapshot(multi_use=True) as snapshot:
+            # Check newly created SVG nodes (Should NOT generate 'Student' groups as they are in TestImport)
+            node_query = """
+                SELECT subject_id 
+                FROM Node 
+                WHERE 'StatVarGroup' IN UNNEST(types) 
+                  AND subject_id LIKE '%/g/Student%'
+                ORDER BY subject_id
+            """
+            nodes = [r[0] for r in snapshot.execute_sql(node_query)]
+            self.assertEqual(len(nodes), 0)
+
+            # Check linkedMemberOf/memberOf attachments
+            edge_query = """
+                SELECT subject_id, predicate, object_id, provenance
+                FROM Edge 
+                WHERE predicate IN ('memberOf', 'specializationOf', 'linkedMemberOf')
+                ORDER BY subject_id, predicate, object_id
+            """
+            edges = [(r[0], r[1], r[2], r[3]) for r in snapshot.execute_sql(edge_query)]
+
+            # Verify curated SVs from TestCustomImport ARE processed
             self.assertIn(('Median_Age_Student', 'linkedMemberOf', f'{ns}g/TestCustomVertical', prov), edges)
             self.assertIn(('Median_Age_Student', 'linkedMemberOf', f'{ns}g/Root', prov), edges)
+
+            # Verify TestImport SVs are NOT processed (no generated edges for them)
+            self.assertNotIn(('Count_Student', 'memberOf', f'{ns}g/Student', prov), edges)
+            self.assertNotIn(('Count_Student', 'linkedMemberOf', f'{ns}g/Student', prov), edges)
+            self.assertNotIn(('Count_Student_Female', 'memberOf', f'{ns}g/Student_Gender-Female', prov), edges)
+            self.assertNotIn(('Count_Person', 'memberOf', f'{ns}g/TestVertical', prov), edges)
+            self.assertNotIn(('Count_Thing', 'memberOf', f'{ns}g/Uncategorized_Variables', prov), edges)
 
 
 class StatVarGroupGeneratorCustomDcTest(StatVarGroupGeneratorIntegrationTest):

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
@@ -472,7 +472,7 @@ class TestOrchestratorOrdering(unittest.TestCase):
 
     def test_active_stages_includes_stage_0(self, mock_executor):
         """Verifies stage 0 is included in active stages for matching imports."""
-        active_stages = self.orchestrator.get_active_stages(["TestImport"])
+        active_stages = self.orchestrator._get_active_stages_for_import("TestImport")
         self.assertEqual(active_stages, [0, 1])
 
     def test_calculation_priority_sorting(self, mock_executor):

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from google.cloud import bigquery
 from .bq_executor import BigQueryExecutor
-from .common import BASE_PROVENANCE_PREFIX, _escape_sql_literal
+from .common import BASE_PROVENANCE_PREFIX, _escape_sql_literal, get_provenance_name
 
 class StatVarGroupGenerator:
     """Iteratively generates StatVarGroup nodes and hierarchical edges from MCF schemas."""
@@ -30,6 +30,7 @@ class StatVarGroupGenerator:
         self.executor = executor
         self.max_iterations = max_iterations
         self.namespace = namespace if namespace is not None else ('dc/' if is_base_dc else 'c/')
+        self.is_base_dc = is_base_dc
         self.generated_provenance = (
           generated_provenance
           if generated_provenance is not None
@@ -47,17 +48,26 @@ class StatVarGroupGenerator:
         logging.info(f"Running global aggregations for imports: {import_names}")
 
         jobs = [
-            self.run_stat_var_group(),
+            self.run_stat_var_group(import_names),
         ]
         return [job for job in jobs if job]
 
-    def run_stat_var_group(self) -> List[Optional[bigquery.job.QueryJob]]:
+    def run_stat_var_group(self, import_names: List[str]) -> Optional[bigquery.job.QueryJob]:
         """Compiles and executes the StatVarGroup generation script."""
+        if not import_names:
+            logging.info("No imports specified. Skipping StatVarGroup generation.")
+            return None
+
         logging.info("Starting StatVarGroup generation script...")
 
         dest_uri = _escape_sql_literal(self.executor.get_spanner_destination_uri())
         conn_id = _escape_sql_literal(self.executor.connection_id)
         no_cache_config = bigquery.QueryJobConfig(use_query_cache=False)
+
+        # Handle import filtering
+        safe_imports = [_escape_sql_literal(name) for name in import_names]
+        imports_str = ", ".join([f"'{get_provenance_name(name, self.is_base_dc)}'" for name in safe_imports])
+        provenance_filter = f"AND provenance IN ({imports_str})"
 
         # =====================================================================
         # OPTIMIZATION: Two-Stage Fetch for StatVar Triples
@@ -133,7 +143,7 @@ class StatVarGroupGenerator:
         -- Fetch all StatVarGroupSpec nodes.
         CREATE OR REPLACE TEMP TABLE StatVarGroupSpec AS (
           SELECT DISTINCT subject_id
-          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id FROM Edge WHERE predicate = 'typeOf' AND object_id = 'StatVarGroupSpec'")
+          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id FROM Edge WHERE predicate = 'typeOf' AND object_id = 'StatVarGroupSpec' {provenance_filter}")
         );
 
         -- Fetch StatVarGroupSpec edges for relevant properties.
@@ -150,7 +160,7 @@ class StatVarGroupGenerator:
               'constraintProperties', 
               'vertical', 
               'dependentPropertyValue'
-            )''') E
+            ) {provenance_filter}''') E
           JOIN StatVarGroupSpec S ON E.subject_id = S.subject_id
         );
 
@@ -222,7 +232,7 @@ class StatVarGroupGenerator:
         -- Fetch curated memberOf edges to identify which SVs to skip during generation.
         CREATE OR REPLACE TEMP TABLE CuratedMemberOf AS (
           SELECT subject_id AS statvar, object_id AS parent_svg
-          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id, object_id, provenance FROM Edge WHERE predicate = 'memberOf'")
+          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id, object_id, provenance FROM Edge WHERE predicate = 'memberOf' {provenance_filter}")
           WHERE provenance != generated_provenance
         );
         
@@ -248,7 +258,7 @@ class StatVarGroupGenerator:
         -- Fetch all StatisticalVariable nodes.
         CREATE OR REPLACE TEMP TABLE StatVar AS (
           SELECT subject_id
-          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id FROM Edge WHERE predicate = 'typeOf' AND object_id = 'StatisticalVariable'")
+          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id FROM Edge WHERE predicate = 'typeOf' AND object_id = 'StatisticalVariable' {provenance_filter}")
         );
 
         -- Fetch relevant StatisticalVariable triples.
@@ -258,7 +268,7 @@ class StatVarGroupGenerator:
         CREATE OR REPLACE TEMP TABLE StatVarTriple AS (
           SELECT DISTINCT E.subject_id, E.predicate, E.object_id
           FROM EXTERNAL_QUERY("{conn_id}",
-            "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate IN UNNEST([{sv_predicates_sql}]) AND object_id NOT LIKE '[%'"
+            "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate IN UNNEST([{sv_predicates_sql}]) AND object_id NOT LIKE '[%' {provenance_filter}"
           ) E
           JOIN StatVar SV ON SV.subject_id = E.subject_id
         );

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
@@ -75,7 +75,7 @@ class StatVarGroupGenerator:
         logging.info("Fetching distinct constraint properties...")
         prep_query = f"""
             SELECT DISTINCT object_id
-            FROM EXTERNAL_QUERY("{conn_id}", "SELECT object_id FROM Edge WHERE predicate = 'constraintProperties'")
+            FROM EXTERNAL_QUERY("{conn_id}", "SELECT object_id FROM Edge WHERE predicate = 'constraintProperties' {provenance_filter}")
         """
         prep_sv_job = self.executor.execute(prep_query, job_config=no_cache_config)
         constraint_props = [row.object_id for row in prep_sv_job]


### PR DESCRIPTION
The `StatVarGroupGenerator` is currently running for all imports. I'm guessing this is a gap in the implementation and not intentional.

This PR restricts the generation to specified imports.

This is a prerequisite to addressing http://b/534933214 (which will tag each generated row with a specific import).