### PR TITLE
Support custom namespaces in MCF and observations importers

### DIFF
--- a/simple/kg_util/mcf_parser.py
+++ b/simple/kg_util/mcf_parser.py
@@ -56,11 +56,11 @@ def _is_schema_ref_property(prop):
 
 
 def _is_common_ref_property(prop):
-  return (_is_schema_ref_property(prop) or
-          prop in ('location', 'observedNode', 'containedInPlace',
-                   'containedIn', 'populationType', 'measuredProperty',
-                   'measurementDenominator', 'populationGroup',
-                   'constraintProperties', 'measurementMethod', 'comparedNode'))
+  return (_is_schema_ref_property(prop) or prop
+          in ('location', 'observedNode', 'containedInPlace', 'containedIn',
+              'populationType', 'measuredProperty', 'measurementDenominator',
+              'populationGroup', 'constraintProperties', 'measurementMethod',
+              'comparedNode', 'source', 'sourceLink'))
 
 
 def _is_global_ref(value):

--- a/simple/stats/events_importer.py
+++ b/simple/stats/events_importer.py
@@ -27,6 +27,7 @@ from stats.db import Db
 from stats.importer import Importer
 from stats.nodes import Nodes
 from stats.reporter import FileImportReporter
+from stats.util import is_uri_or_namespace
 from util.filesystem import File
 
 from util import dc_client as dc
@@ -223,9 +224,12 @@ class EventsImporter(Importer):
     pre_resolved_entities = {}
 
     def remove_pre_resolved(entity: str) -> bool:
-      if entity.startswith(constants.DCID_OVERRIDE_PREFIX):
-        pre_resolved_entities[entity] = entity[
-            len(constants.DCID_OVERRIDE_PREFIX):].strip()
+      if is_uri_or_namespace(entity):
+        if entity.startswith(constants.DCID_OVERRIDE_PREFIX):
+          pre_resolved_entities[entity] = entity[
+              len(constants.DCID_OVERRIDE_PREFIX):].strip()
+        else:
+          pre_resolved_entities[entity] = entity
         return False
       return True
 

--- a/simple/stats/observations_importer.py
+++ b/simple/stats/observations_importer.py
@@ -24,6 +24,7 @@ from stats.db import Db
 from stats.importer import Importer
 from stats.nodes import Nodes
 from stats.reporter import FileImportReporter
+from stats.util import is_uri_or_namespace
 from util.filesystem import File
 
 from util import dc_client as dc
@@ -172,9 +173,12 @@ class ObservationsImporter(Importer):
     pre_resolved_entities = {}
 
     def remove_pre_resolved(entity: str) -> bool:
-      if entity.startswith(constants.DCID_OVERRIDE_PREFIX):
-        pre_resolved_entities[entity] = entity[
-            len(constants.DCID_OVERRIDE_PREFIX):].strip()
+      if is_uri_or_namespace(entity):
+        if entity.startswith(constants.DCID_OVERRIDE_PREFIX):
+          pre_resolved_entities[entity] = entity[
+              len(constants.DCID_OVERRIDE_PREFIX):].strip()
+        else:
+          pre_resolved_entities[entity] = entity
         return False
       return True
 

--- a/simple/tests/stats/mcf_importer_test.py
+++ b/simple/tests/stats/mcf_importer_test.py
@@ -107,3 +107,4 @@ class TestMcfImporter(unittest.TestCase):
     _test_import(self, "basic_mcf_main_dc", is_main_dc=True)
     _test_import(self, "invalid_mcf", is_main_dc=False, raises_error=True)
     _test_import(self, "provenance_source", is_main_dc=False)
+    _test_import(self, "custom_namespace_provenance", is_main_dc=False)

--- a/simple/tests/stats/observations_importer_test.py
+++ b/simple/tests/stats/observations_importer_test.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -77,13 +78,12 @@ def _test_import(test: unittest.TestCase, test_name: str):
     reporter = FileImportReporter(input_path, ImportReporter(report_file))
     nodes = Nodes(config)
 
-    dc_client.get_property_of_entities = MagicMock(return_value={})
-
-    ObservationsImporter(input_file=input_file,
-                         db=db,
-                         debug_resolve_file=debug_resolve_file,
-                         reporter=reporter,
-                         nodes=nodes).do_import()
+    with mock.patch.object(dc_client, "get_property_of_entities", return_value={}):
+      ObservationsImporter(input_file=input_file,
+                           db=db,
+                           debug_resolve_file=debug_resolve_file,
+                           reporter=reporter,
+                           nodes=nodes).do_import()
     db.commit_and_close()
 
     write_observations(db_path, output_path)
@@ -105,3 +105,6 @@ class TestObservationsImporter(unittest.TestCase):
 
   def test_obs_props(self):
     _test_import(self, "obs_props")
+
+  def test_custom_namespace_observations(self):
+    _test_import(self, "custom_namespace_observations")

--- a/simple/tests/stats/test_data/mcf_importer/expected/custom_namespace_provenance.triples.db.csv
+++ b/simple/tests/stats/test_data/mcf_importer/expected/custom_namespace_provenance.triples.db.csv
@@ -1,0 +1,8 @@
+subject_id,predicate,object_id,object_value
+source/UnitedNationsStatisticsDivision,typeOf,Source,
+source/UnitedNationsStatisticsDivision,name,,United Nations Statistics Division
+source/UnitedNationsStatisticsDivision,url,,https://unstats.un.org
+provenance/GlobalSustainableDevelopmentGoalsDatabase,typeOf,Provenance,
+provenance/GlobalSustainableDevelopmentGoalsDatabase,name,,Global Sustainable Development Goals Database
+provenance/GlobalSustainableDevelopmentGoalsDatabase,source,source/UnitedNationsStatisticsDivision,
+provenance/GlobalSustainableDevelopmentGoalsDatabase,url,,https://unstats.un.org/sdgs/dataportal

--- a/simple/tests/stats/test_data/mcf_importer/input/custom_namespace_provenance.mcf
+++ b/simple/tests/stats/test_data/mcf_importer/input/custom_namespace_provenance.mcf
@@ -1,0 +1,10 @@
+Node: undata:source/UnitedNationsStatisticsDivision
+typeOf: dcs:Source
+name: "United Nations Statistics Division"
+url: "https://unstats.un.org"
+
+Node: undata:provenance/GlobalSustainableDevelopmentGoalsDatabase
+typeOf: dcs:Provenance
+name: "Global Sustainable Development Goals Database"
+source: undata:source/UnitedNationsStatisticsDivision
+url: "https://unstats.un.org/sdgs/dataportal"

--- a/simple/tests/stats/test_data/observations_importer/expected/custom_namespace_observations/observations.db.csv
+++ b/simple/tests/stats/test_data/observations_importer/expected/custom_namespace_observations/observations.db.csv
@@ -1,0 +1,3 @@
+entity,variable,date,value,provenance,unit,scaling_factor,measurement_method,observation_period,properties
+country/BRA,var1,2023,0.19,custom_namespace_observations/input.csv,,,,,{}
+country/JPN,var1,2023,0.21,custom_namespace_observations/input.csv,,,,,{}

--- a/simple/tests/stats/test_data/observations_importer/input/custom_namespace_observations/config.json
+++ b/simple/tests/stats/test_data/observations_importer/input/custom_namespace_observations/config.json
@@ -1,0 +1,7 @@
+{
+  "inputFiles": {
+    "input.csv": {
+      "entityType": "Dummy"
+    }
+  }
+}

--- a/simple/tests/stats/test_data/observations_importer/input/custom_namespace_observations/input.csv
+++ b/simple/tests/stats/test_data/observations_importer/input/custom_namespace_observations/input.csv
@@ -1,0 +1,3 @@
+country,year,var1
+undata:country/BRA,2023,0.19
+undata:country/JPN,2023,0.21

--- a/simple/tests/stats/validation_test.py
+++ b/simple/tests/stats/validation_test.py
@@ -50,6 +50,43 @@ class TestMetadataValidator(unittest.TestCase):
     # Should complete without raising an error
     validator.validate()
 
+  def test_validation_custom_namespace_success(self):
+    # Setup mock config with referenced provenance using custom namespace
+    mock_config = mock.MagicMock(spec=Config)
+    mock_config.data = {
+        "inputFiles": [{
+            "pattern":
+                "data.csv",
+            "provenance":
+                "undata:provenance/GlobalSustainableDevelopmentGoalsDatabase"
+        }]
+    }
+
+    # Setup mock database with matching MCF definitions using custom namespace
+    mock_db = mock.MagicMock(spec=Db)
+    mock_db._triples = {
+        "_global": [
+            # Define Source
+            Triple("undata:source/UnitedNationsStatisticsDivision",
+                   "typeOf",
+                   object_id="Source"),
+            # Define Provenance
+            Triple(
+                "undata:provenance/GlobalSustainableDevelopmentGoalsDatabase",
+                "typeOf",
+                object_id="Provenance"),
+            # Link Provenance to Source
+            Triple(
+                "undata:provenance/GlobalSustainableDevelopmentGoalsDatabase",
+                "source",
+                object_id="undata:source/UnitedNationsStatisticsDivision"),
+        ]
+    }
+
+    validator = MetadataValidator(mock_config, mock_db)
+    # Should complete without raising an error
+    validator.validate()
+
   def test_validation_missing_provenance(self):
     # Setup mock config with referenced provenance
     mock_config = mock.MagicMock(spec=Config)


### PR DESCRIPTION
Add support for custom namespace subjects and objects in MCF and Observations importers, allowing custom namespace data sources to be successfully processed.

### Highlights:
1. **MCF Importer Namespace Resolution:** Updated `simple/kg_util/mcf_parser.py` and `mcf_importer.py` to parse and maintain custom namespaces in the node properties.
2. **Observations Importer Namespace support:** Ensured `simple/stats/observations_importer.py` handles namespaced identifiers during pre-resolution and resolving phases.
3. **Validation & Test Cases:** Added test inputs and expected output files for custom namespace testing (`custom_namespace_provenance` and `custom_namespace_observations`).