### PR TITLE
feat: Add update timestamps to graph edges

### DIFF
--- a/pipeline/spanner/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
+++ b/pipeline/spanner/src/main/java/org/datacommons/ingestion/spanner/SpannerClient.java
@@ -192,6 +192,8 @@ public class SpannerClient implements Serializable {
         .to(edge.getObjectId())
         .set("provenance")
         .to(edge.getProvenance())
+        .set("last_update_timestamp")
+        .to(Value.COMMIT_TIMESTAMP)
         .build();
   }
 

--- a/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
+++ b/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
@@ -76,8 +76,12 @@ public class SpannerClientTest {
     Mutation mutation = spannerClient.toEdgeMutation(edge);
 
     assertEquals(mutation.getTable(), "Edge");
-    assertEquals(
-        mutation.asMap().get("last_update_timestamp").toString(), "spanner.commit_timestamp()");
+    var mutationMap = mutation.asMap();
+    assertEquals(mutationMap.get("subject_id").getString(), "dcid:subject");
+    assertEquals(mutationMap.get("predicate").getString(), "dcid:predicate");
+    assertEquals(mutationMap.get("object_id").getString(), "dcid:object");
+    assertEquals(mutationMap.get("provenance").getString(), "dcid:provenance");
+    assertEquals(mutationMap.get("last_update_timestamp").toString(), "spanner.commit_timestamp()");
   }
 
   @Test

--- a/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
+++ b/pipeline/spanner/src/test/java/org/datacommons/ingestion/spanner/SpannerClientTest.java
@@ -7,6 +7,7 @@ import com.google.cloud.spanner.Mutation;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.util.List;
+import org.datacommons.ingestion.data.Edge;
 import org.datacommons.ingestion.data.Node;
 import org.datacommons.ingestion.data.TimeSeries;
 import org.junit.Before;
@@ -60,6 +61,23 @@ public class SpannerClientTest {
     assertEquals(mutationMap.get("subject_id").getString(), "dcid:456");
     assertFalse(mutationMap.containsKey("value"));
     assertEquals(mutationMap.get("last_update_timestamp").toString(), "spanner.commit_timestamp()");
+  }
+
+  @Test
+  public void testToEdgeMutation() {
+    Edge edge =
+        Edge.builder()
+            .subjectId("dcid:subject")
+            .predicate("dcid:predicate")
+            .objectId("dcid:object")
+            .provenance("dcid:provenance")
+            .build();
+
+    Mutation mutation = spannerClient.toEdgeMutation(edge);
+
+    assertEquals(mutation.getTable(), "Edge");
+    assertEquals(
+        mutation.asMap().get("last_update_timestamp").toString(), "spanner.commit_timestamp()");
   }
 
   @Test

--- a/pipeline/workflow/ingestion-helper/clients/schema.sql
+++ b/pipeline/workflow/ingestion-helper/clients/schema.sql
@@ -28,6 +28,7 @@ CREATE TABLE Edge (
   predicate STRING(1024) NOT NULL,
   object_id STRING(1024) NOT NULL,
   provenance STRING(1024) NOT NULL,
+  last_update_timestamp TIMESTAMP OPTIONS (allow_commit_timestamp=true),
 ) PRIMARY KEY(subject_id, predicate, object_id, provenance),
 INTERLEAVE IN Node, OPTIONS (
   columnar_policy = 'enabled'


### PR DESCRIPTION
  ## Summary

  - Adds last_update_timestamp to the Spanner Edge table.
  - Records the Spanner commit timestamp whenever an edge is inserted or updated.
  - Adds unit test coverage for edge timestamp mutations.

  ## Testing

  - mvn -pl pipeline/spanner -am test -Dtest=SpannerClientTest -Dsurefire.failIfNoSpecifiedTests=false