### PR TITLE
fix(ingestion-helper): fix CI unit test runner environment

### DIFF
--- a/pipeline/workflow/ingestion-helper/cloudbuild.yaml
+++ b/pipeline/workflow/ingestion-helper/cloudbuild.yaml
@@ -26,7 +26,8 @@
 
 steps:
   # Run unit tests
-  - name: 'ghcr.io/astral-sh/uv:latest'
+  - name: 'ghcr.io/astral-sh/uv:python3.12-bookworm-slim'
+    entrypoint: 'uv'
     args: ['run', 'pytest', '--ignore=aggregation/e2e_tests/']
 
   # Build the container image

--- a/run_test.sh
+++ b/run_test.sh
@@ -75,12 +75,20 @@ function py_test {
   python3 -m venv .env
   source .env/bin/activate
 
+  ROOT_DIR=$(pwd)
+
   cd simple
   pip3 install -r requirements.txt -q
 
   echo -e "#### Running stats tests"
   python3 -m pytest tests/ -s
 
+  echo -e "#### Running ingestion helper tests"
+  cd "${ROOT_DIR}/pipeline/workflow/ingestion-helper"
+  pip3 install uv -q
+  uv run pytest --ignore=aggregation/e2e_tests/
+
+  cd "${ROOT_DIR}"
   deactivate
 }
 


### PR DESCRIPTION
Fixes the Cloud Build CI workflow step by running unit tests inside the official `ghcr.io/astral-sh/uv:python3.12-bookworm-slim` image, which bundles both the `uv` tool and a Python 3.12 runtime.

Also adds the `ingestion-helper` unit tests (excluding destructive E2E database tests) to the main `run_test.sh` wrapper script, ensuring they run automatically on every PR submission check and can be easily executed by developers locally.
