### PR TITLE
Refactor aggregation generators to use dataclasses for configs

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/__init__.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/__init__.py
@@ -18,16 +18,16 @@ linked relationship edges and provenance summaries in Spanner.
 """
 
 from .bq_executor import BigQueryExecutor
-from .linked_edge_generator import LinkedEdgeGenerator
-from .provenance_summary_generator import ProvenanceSummaryGenerator
-from .stat_var_aggregator import StatVarAggregator
-from .place_aggregation_generator import PlaceAggregationGenerator
-from .stat_var_group_generator import StatVarGroupGenerator
-from .stat_var_calculation_generator import StatVarCalculationGenerator
-from .stat_var_series_aggregator import StatVarSeriesAggregator
-from .super_enum_aggregation_generator import SuperEnumAggregationGenerator
+from .linked_edge_generator import LinkedEdgeGenerator, LinkedEdgeConfig
+from .provenance_summary_generator import ProvenanceSummaryGenerator, ProvenanceSummaryConfig
+from .stat_var_aggregator import StatVarAggregator, StatVarAggregationConfig
+from .place_aggregation_generator import PlaceAggregationGenerator, PlaceAggregationConfig
+from .stat_var_group_generator import StatVarGroupGenerator, StatVarGroupConfig
+from .stat_var_calculation_generator import StatVarCalculationGenerator, StatVarCalculationConfig
+from .stat_var_series_aggregator import StatVarSeriesAggregator, StatVarSeriesAggregationConfig
+from .super_enum_aggregation_generator import SuperEnumAggregationGenerator, SuperEnumAggregationConfig
 from .entity_aggregation_generator import EntityAggregationGenerator, EntityAggregationConfig
-from .embedding_generator import EmbeddingGenerator
+from .embedding_generator import EmbeddingGenerator, EmbeddingGenerationConfig
 from .orchestrator import (
     AggregationOrchestrator,
     AggregationRunResult,
@@ -40,16 +40,25 @@ from .deleter import AggregationDeleter
 __all__ = [
     'BigQueryExecutor',
     'LinkedEdgeGenerator',
+    'LinkedEdgeConfig',
     'ProvenanceSummaryGenerator',
+    'ProvenanceSummaryConfig',
     'StatVarAggregator',
+    'StatVarAggregationConfig',
     'PlaceAggregationGenerator',
+    'PlaceAggregationConfig',
     'StatVarGroupGenerator',
+    'StatVarGroupConfig',
     'StatVarCalculationGenerator',
+    'StatVarCalculationConfig',
     'StatVarSeriesAggregator',
+    'StatVarSeriesAggregationConfig',
     'SuperEnumAggregationGenerator',
+    'SuperEnumAggregationConfig',
     'EntityAggregationGenerator',
     'EntityAggregationConfig',
     'EmbeddingGenerator',
+    'EmbeddingGenerationConfig',
     'AggregationOrchestrator',
     'OrchestratorConfig',
     'AggregationDeleter',
@@ -57,3 +66,4 @@ __all__ = [
     'ImportExecutionResult',
     'validate_config',
 ]
+

--- a/pipeline/workflow/aggregation-helper/aggregation/aggregation_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/aggregation_test.py
@@ -21,10 +21,10 @@ from unittest.mock import patch
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from aggregation import BigQueryExecutor
-from aggregation import LinkedEdgeGenerator
-from aggregation import ProvenanceSummaryGenerator
-from aggregation import PlaceAggregationGenerator
-from aggregation import EmbeddingGenerator
+from aggregation import LinkedEdgeGenerator, LinkedEdgeConfig
+from aggregation import ProvenanceSummaryGenerator, ProvenanceSummaryConfig
+from aggregation import PlaceAggregationGenerator, PlaceAggregationConfig
+from aggregation import EmbeddingGenerator, EmbeddingGenerationConfig
 from aggregation.embedding_generator import EmbeddingSpec
 from aggregation.common import (
     BASE_PROVENANCE_PREFIX,
@@ -201,7 +201,7 @@ class TestLinkedEdgeGenerator(unittest.TestCase):
 
     def test_run_all_empty(self):
         generator = LinkedEdgeGenerator(self.mock_executor)
-        jobs = generator.run_all([])
+        jobs = generator.run_all(LinkedEdgeConfig(import_names=[]))
         self.assertEqual(jobs, [])
         self.mock_executor.execute.assert_not_called()
 
@@ -211,7 +211,7 @@ class TestLinkedEdgeGenerator(unittest.TestCase):
         mock_job = MagicMock()
         self.mock_executor.execute.return_value = mock_job
 
-        jobs = generator.run_all(["import1", "import2"])
+        jobs = generator.run_all(LinkedEdgeConfig(import_names=["import1", "import2"]))
 
         self.assertEqual(len(jobs), 3)  # Should run 3 queries
         self.assertEqual(self.mock_executor.execute.call_count, 3)
@@ -236,7 +236,7 @@ class TestProvenanceSummaryGenerator(unittest.TestCase):
 
     def test_run_all_empty(self):
         generator = ProvenanceSummaryGenerator(self.mock_executor)
-        jobs = generator.run_all([])
+        jobs = generator.run_all(ProvenanceSummaryConfig(import_names=[]))
         self.assertEqual(jobs, [])
         self.mock_executor.execute.assert_not_called()
 
@@ -247,7 +247,7 @@ class TestProvenanceSummaryGenerator(unittest.TestCase):
         mock_job = MagicMock()
         self.mock_executor.execute.return_value = mock_job
 
-        jobs = generator.run_all(["import1"])
+        jobs = generator.run_all(ProvenanceSummaryConfig(import_names=["import1"]))
 
         self.assertEqual(len(jobs), 1)
         self.mock_executor.execute.assert_called_once()
@@ -271,9 +271,11 @@ class TestPlaceAggregationGenerator(unittest.TestCase):
         """Verifies that it returns None immediately if import list is empty."""
         generator = PlaceAggregationGenerator(self.mock_executor)
         job = generator.aggregate_places(
-            import_names=[],
-            source_type="County",
-            destination_type="State"
+            PlaceAggregationConfig(
+                import_names=[],
+                source_type="County",
+                destination_type="State"
+            )
         )
         self.assertIsNone(job)
         self.mock_executor.execute.assert_not_called()
@@ -281,19 +283,21 @@ class TestPlaceAggregationGenerator(unittest.TestCase):
     def test_aggregate_places_calls_executor(self):
         """Verifies that it constructs a query and delegates execution to the executor."""
         generator = PlaceAggregationGenerator(self.mock_executor)
-        
+
         mock_job = MagicMock()
         self.mock_executor.execute.return_value = mock_job
 
         job = generator.aggregate_places(
-            import_names=["import1"],
-            source_type="County",
-            destination_type="State"
+            PlaceAggregationConfig(
+                import_names=["import1"],
+                source_type="County",
+                destination_type="State"
+            )
         )
-        
+
         # Should return the job returned by the executor
         self.assertEqual(job, mock_job)
-        
+
         # Should have called execute once with a non-empty query string
         self.mock_executor.execute.assert_called_once()
         query = self.mock_executor.execute.call_args[0][0]
@@ -325,7 +329,7 @@ class TestEmbeddingGenerator(unittest.TestCase):
                 node_filter_type="NoFilter"
             )
         ]
-        jobs = generator.run_all(specs=specs, embedding_table="CustomEmbeddingTable")
+        jobs = generator.run_all(EmbeddingGenerationConfig(specs=specs, embedding_table="CustomEmbeddingTable"))
 
         self.assertEqual(len(jobs), 1)
         self.mock_executor.execute.assert_called_once()
@@ -353,7 +357,7 @@ class TestEmbeddingGenerator(unittest.TestCase):
                 node_filter_type="NLStatisticalVariable"
             )
         ]
-        jobs = generator.run_all(specs=specs, embedding_table="CustomEmbeddingTable")
+        jobs = generator.run_all(EmbeddingGenerationConfig(specs=specs, embedding_table="CustomEmbeddingTable"))
 
         self.assertEqual(len(jobs), 1)
         self.mock_executor.execute.assert_called_once()

--- a/pipeline/workflow/aggregation-helper/aggregation/embedding_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/embedding_generator.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import csv
+from dataclasses import dataclass
 from functools import lru_cache
 import io
 import json
@@ -25,6 +26,14 @@ from google.cloud import bigquery
 from google.cloud import storage
 from pydantic import BaseModel
 from .bq_executor import BigQueryExecutor
+
+
+@dataclass
+class EmbeddingGenerationConfig:
+    """Configuration for embedding generation."""
+    specs: Optional[List[Any]] = None
+    embedding_table: str = "NodeEmbedding"
+
 
 _NL_STAT_VAR_FILE = "gs://datcom-nl-models/base_uae_mem_2025_11_03_07_10_42/embeddings.csv"
 
@@ -80,7 +89,7 @@ def _extract_nl_stat_var() -> dict[str, str]:
 
 
 class EmbeddingGenerator:
-    """Generates embeddings using Vertex AI remote models and saves them to Spanner."""
+    """Generates Node embeddings asynchronously in BigQuery and ingests them into Spanner."""
 
     def __init__(self,
                  executor: BigQueryExecutor,
@@ -89,8 +98,11 @@ class EmbeddingGenerator:
         self.executor = executor
         self.is_base_dc = is_base_dc
 
-    def run_all(self, specs: Optional[List[Any]] = None, embedding_table: str = "NodeEmbedding") -> List[bigquery.job.QueryJob]:
+    def run_all(self,
+                config: EmbeddingGenerationConfig) -> List[bigquery.job.QueryJob]:
         """Runs all embedding generations asynchronously and returns their jobs."""
+        specs = config.specs
+        embedding_table = config.embedding_table
         if not self.executor.enable_embeddings or not self.is_base_dc:
             logging.info("Embeddings generation is disabled in config/env or not in base DC. Skipping.")
             return []

--- a/pipeline/workflow/aggregation-helper/aggregation/entity_aggregation_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/entity_aggregation_generator.py
@@ -15,30 +15,23 @@
 
 import logging
 import re
-from typing import Dict, List, Tuple
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
 from google.cloud import bigquery
 from .bq_executor import BigQueryExecutor
 from .common import _escape_sql_literal, get_provenance_name
 
 
+@dataclass
 class EntityAggregationConfig:
     """Configuration for entity aggregation."""
-
-    def __init__(self,
-                 entity_types: List[str],
-                 location_props: List[str],
-                 date_prop: str,
-                 agg_date_formats: List[str],
-                 constraints: List[Dict],
-                 output_import: str,
-                 input_imports: List[str]):
-        self.entity_types = entity_types
-        self.location_props = location_props
-        self.date_prop = date_prop
-        self.agg_date_formats = agg_date_formats
-        self.constraints = constraints
-        self.output_import = output_import
-        self.input_imports = input_imports
+    entity_types: List[str]
+    location_props: List[str]
+    date_prop: str
+    agg_date_formats: List[str]
+    constraints: List[Dict[str, Any]]
+    output_import: str
+    input_imports: List[str]
 
 
 class EntityAggregationGenerator:

--- a/pipeline/workflow/aggregation-helper/aggregation/linked_edge_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/linked_edge_generator.py
@@ -13,12 +13,19 @@
 # limitations under the License.
 
 import logging
+from dataclasses import dataclass
 from typing import List, Optional
 
 from google.cloud import bigquery
 
 from .bq_executor import BigQueryExecutor
 from .common import BASE_PROVENANCE_PREFIX, _escape_sql_literal
+
+
+@dataclass
+class LinkedEdgeConfig:
+    """Configuration for linked edge generation."""
+    import_names: Optional[List[str]] = None
 
 
 class LinkedEdgeGenerator:
@@ -32,8 +39,10 @@ class LinkedEdgeGenerator:
         self.is_base_dc = is_base_dc
 
     def run_all(self,
-                import_names: List[str] = None) -> List[bigquery.job.QueryJob]:
+                config: LinkedEdgeConfig) -> List[bigquery.job.QueryJob]:
         """Runs all global aggregations asynchronously and returns their jobs."""
+        import_names = config.import_names
+
         if not import_names:
             logging.info("No imports specified. Skipping global aggregations.")
             return []

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -24,16 +24,16 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from .bq_executor import BigQueryExecutor
-from .embedding_generator import EmbeddingGenerator
-from .linked_edge_generator import LinkedEdgeGenerator
-from .place_aggregation_generator import PlaceAggregationGenerator
-from .provenance_summary_generator import ProvenanceSummaryGenerator
-from .stat_var_aggregator import StatVarAggregator
-from .stat_var_calculation_generator import StatVarCalculationGenerator
-from .stat_var_group_generator import StatVarGroupGenerator
-from .stat_var_series_aggregator import StatVarSeriesAggregator
+from .embedding_generator import EmbeddingGenerator, EmbeddingGenerationConfig
+from .linked_edge_generator import LinkedEdgeGenerator, LinkedEdgeConfig
+from .place_aggregation_generator import PlaceAggregationGenerator, PlaceAggregationConfig
+from .provenance_summary_generator import ProvenanceSummaryGenerator, ProvenanceSummaryConfig
+from .stat_var_aggregator import StatVarAggregator, StatVarAggregationConfig
+from .stat_var_calculation_generator import StatVarCalculationGenerator, StatVarCalculationConfig
+from .stat_var_group_generator import StatVarGroupGenerator, StatVarGroupConfig
+from .stat_var_series_aggregator import StatVarSeriesAggregator, StatVarSeriesAggregationConfig
 from .entity_aggregation_generator import EntityAggregationGenerator, EntityAggregationConfig
-from .super_enum_aggregation_generator import SuperEnumAggregationGenerator
+from .super_enum_aggregation_generator import SuperEnumAggregationGenerator, SuperEnumAggregationConfig
 from .common import CALCULATION_TYPE_PRIORITY
 from .validator import validate_config
 from .deleter import AggregationDeleter
@@ -462,12 +462,13 @@ class AggregationOrchestrator:
 
         logging.info(f"  -> Place Rollup: {from_type} -> {to_type} for imports {applicable_imports}")
         generator = PlaceAggregationGenerator(self.executor, self.is_base_dc)
-        job = generator.aggregate_places(
+        place_config = PlaceAggregationConfig(
             import_names=applicable_imports,
             source_type=from_type,
             destination_type=to_type,
             allow_multiple_to_places=place_cfg.get("allow_multiple_to_places", False)
         )
+        job = generator.aggregate_places(config=place_config)
         return [job] if job else []
 
     def _trigger_stat_var(self, config: Dict[str, Any], applicable_imports: List[str]) -> List[Any]:
@@ -485,13 +486,14 @@ class AggregationOrchestrator:
             logging.info(
                 f"  -> Stat Var Aggregation: ancestor '{ancestor_sv}' (sources: {source_svs}) for imports {applicable_imports}"
             )
-            item_jobs = generator.aggregate_stat_vars(
+            sv_config = StatVarAggregationConfig(
                 ancestor_sv=ancestor_sv,
                 source_svs=source_svs,
                 import_names=applicable_imports,
                 output_import_name=output_import_name,
                 skip_all_sources_present_check=item.get("skip_all_sources_present_check", False)
             )
+            item_jobs = generator.aggregate_stat_vars(config=sv_config)
             jobs.extend(item_jobs)
 
         return jobs
@@ -504,23 +506,26 @@ class AggregationOrchestrator:
 
         logging.info(f"  -> Stat Var Calculation for imports {applicable_imports}")
         generator = StatVarCalculationGenerator(self.executor, self.is_base_dc)
-        return generator.calculate_stat_vars(
+        calc_config = StatVarCalculationConfig(
             calculations=calculations,
             import_names=applicable_imports,
             output_import_name=output_import_name
         )
+        return generator.calculate_stat_vars(config=calc_config)
 
     def _trigger_linked_edges(self, config: Dict[str, Any], applicable_imports: List[str]) -> List[Any]:
         """Triggers linked edge aggregations."""
         logging.info(f"  -> Linked Edges Aggregation for imports {applicable_imports}")
         generator = LinkedEdgeGenerator(self.executor, self.is_base_dc)
-        return generator.run_all(applicable_imports)
+        edge_config = LinkedEdgeConfig(import_names=applicable_imports)
+        return generator.run_all(config=edge_config)
 
     def _trigger_provenance_summary(self, config: Dict[str, Any], applicable_imports: List[str]) -> List[Any]:
         """Triggers provenance summary aggregations."""
         logging.info(f"  -> Provenance Summary Aggregation for imports {applicable_imports}")
         generator = ProvenanceSummaryGenerator(self.executor, self.is_base_dc)
-        return generator.run_all(applicable_imports)
+        prov_config = ProvenanceSummaryConfig(import_names=applicable_imports)
+        return generator.run_all(config=prov_config)
 
     def _trigger_stat_var_groups(self, config: Dict[str, Any], applicable_imports: List[str]) -> List[Any]:
         """Triggers statistical variable group aggregations."""
@@ -537,7 +542,8 @@ class AggregationOrchestrator:
             self.executor, self.is_base_dc,
             should_prune_single_child_svgs=should_prune
         )
-        return generator.run_all(applicable_imports)
+        svg_config = StatVarGroupConfig(import_names=applicable_imports)
+        return generator.run_all(config=svg_config)
 
     def _trigger_stat_var_series_aggregation(self, config: Dict[str, Any], applicable_imports: List[str]) -> List[Any]:
         """Triggers statistical variable series aggregations."""
@@ -545,7 +551,8 @@ class AggregationOrchestrator:
         calc = config.copy()
         calc["input_imports"] = applicable_imports
         generator = StatVarSeriesAggregator(self.executor, self.is_base_dc)
-        return generator.aggregate_series([calc])
+        series_config = StatVarSeriesAggregationConfig(calculations=[calc])
+        return generator.aggregate_series(config=series_config)
 
     def _trigger_entity(self, config: Dict[str, Any], applicable_imports: List[str]) -> List[Any]:
         """Triggers entity aggregations."""
@@ -570,7 +577,8 @@ class AggregationOrchestrator:
         """Triggers super enum aggregations."""
         logging.info(f"  -> Super Enum Aggregation for imports {applicable_imports}")
         generator = SuperEnumAggregationGenerator(self.executor, self.is_base_dc)
-        return generator.run(applicable_imports)
+        super_config = SuperEnumAggregationConfig(import_names=applicable_imports)
+        return generator.run(config=super_config)
 
     def _trigger_embeddings(self, config: Dict[str, Any]) -> List[Any]:
         """Triggers node embedding generation."""
@@ -579,7 +587,11 @@ class AggregationOrchestrator:
         embedding_table = config.get("embedding_table", "NodeEmbedding")
         logging.info(f"  -> Node Embeddings Generation (specs: {len(specs)}, table: {embedding_table})")
         generator = EmbeddingGenerator(self.executor, self.is_base_dc)
-        return generator.run_all(specs=specs, embedding_table=embedding_table)
+        embed_config = EmbeddingGenerationConfig(
+            specs=specs,
+            embedding_table=embedding_table
+        )
+        return generator.run_all(config=embed_config)
 
     def _calc_applies_to_import(self, calc: Dict[str, Any], single_import: str) -> bool:
         """Determines if a calculation step applies to a single import."""

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
@@ -22,7 +22,13 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from aggregation.common import CALCULATION_TYPE_PRIORITY
-from aggregation.orchestrator import AggregationOrchestrator, CalculationType, OrchestratorConfig
+from aggregation.orchestrator import (
+    AggregationOrchestrator,
+    CalculationType,
+    OrchestratorConfig,
+    PlaceAggregationConfig,
+    StatVarAggregationConfig,
+)
 
 
 VALID_CONFIG_YAML = textwrap.dedent("""\
@@ -182,18 +188,22 @@ class TestOrchestratorExecution(unittest.TestCase):
         self.assertTrue(result.import_results["USFed_Census"].success)
 
         mock_place_gen.return_value.aggregate_places.assert_called_once_with(
-            import_names=["USFed_Census"],
-            source_type="County",
-            destination_type="State",
-            allow_multiple_to_places=False
+            config=PlaceAggregationConfig(
+                import_names=["USFed_Census"],
+                source_type="County",
+                destination_type="State",
+                allow_multiple_to_places=False
+            )
         )
 
         mock_sv_agg.return_value.aggregate_stat_vars.assert_called_once_with(
-            ancestor_sv="Count_Person",
-            source_svs=["Count_Person_Male", "Count_Person_Female"],
-            import_names=["USFed_Census"],
-            output_import_name="USFed_Census_StatVarAgg",
-            skip_all_sources_present_check=True
+            config=StatVarAggregationConfig(
+                ancestor_sv="Count_Person",
+                source_svs=["Count_Person_Male", "Count_Person_Female"],
+                import_names=["USFed_Census"],
+                output_import_name="USFed_Census_StatVarAgg",
+                skip_all_sources_present_check=True
+            )
         )
 
         # Verify deleter was called with expected outputs
@@ -309,10 +319,11 @@ class TestOrchestratorChainedExecution(unittest.TestCase):
         mock_job2 = MagicMock()
         mock_job2.job_id = "job-place-2"
         
-        def aggregate_places_side_effect(import_names, source_type, destination_type, allow_multiple_to_places=False):
-            if import_names == ["USFed_Census"]:
+        def aggregate_places_side_effect(config: PlaceAggregationConfig):
+            names = config.import_names
+            if names == ["USFed_Census"]:
                 return mock_job1
-            elif import_names == ["USFed_Census_AggState"]:
+            elif names == ["USFed_Census_AggState"]:
                 return mock_job2
             return None
             

--- a/pipeline/workflow/aggregation-helper/aggregation/place_aggregation_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/place_aggregation_generator.py
@@ -14,12 +14,22 @@
 """Place-based aggregation generator using BQ Federation."""
 
 import logging
+from dataclasses import dataclass
 from typing import List, Optional
 
 from google.cloud import bigquery
 
 from .bq_executor import BigQueryExecutor
 from .common import _escape_sql_literal, get_provenance_name
+
+
+@dataclass
+class PlaceAggregationConfig:
+    """Configuration for place aggregation."""
+    import_names: List[str]
+    source_type: str
+    destination_type: str
+    allow_multiple_to_places: bool = False
 
 
 class PlaceAggregationGenerator:
@@ -40,10 +50,7 @@ class PlaceAggregationGenerator:
 
     def aggregate_places(
             self,
-            import_names: List[str],
-            source_type: str,
-            destination_type: str,
-            allow_multiple_to_places: bool = False) -> Optional[bigquery.job.QueryJob]:
+            config: PlaceAggregationConfig) -> Optional[bigquery.job.QueryJob]:
         """Generates and runs place-based aggregations using BigQuery Federation.
 
         This is a multi-statement SQL script that:
@@ -53,13 +60,13 @@ class PlaceAggregationGenerator:
            the facet_id via Farm Fingerprint, and exports the Observations.
 
         Args:
-            import_names: List of import names to filter by.
-            source_type: The source place type (e.g., 'County').
-            destination_type: The destination place type (e.g., 'State').
-            allow_multiple_to_places: If False, each child place is aggregated into
-              at most one parent place (lexicographically first) to prevent double-counting.
-              If True, a child place can roll up to multiple parents (useful for grids/ZIPs).
+            config: Structured PlaceAggregationConfig dataclass instance.
         """
+        import_names = config.import_names
+        source_type = config.source_type
+        destination_type = config.destination_type
+        allow_multiple_to_places = config.allow_multiple_to_places
+
         if not import_names:
             return None
 

--- a/pipeline/workflow/aggregation-helper/aggregation/provenance_summary_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/provenance_summary_generator.py
@@ -13,12 +13,19 @@
 # limitations under the License.
 
 import logging
+from dataclasses import dataclass
 from typing import List, Optional
 
 from google.cloud import bigquery
 
 from .bq_executor import BigQueryExecutor
 from .common import _escape_sql_literal, get_provenance_name
+
+
+@dataclass
+class ProvenanceSummaryConfig:
+    """Configuration for provenance summary generation."""
+    import_names: List[str]
 
 
 class ProvenanceSummaryGenerator:
@@ -31,8 +38,11 @@ class ProvenanceSummaryGenerator:
         self.executor = executor
         self.is_base_dc = is_base_dc
 
-    def run_all(self, import_names: List[str]) -> List[bigquery.job.QueryJob]:
+    def run_all(self,
+                config: ProvenanceSummaryConfig) -> List[bigquery.job.QueryJob]:
         """Runs all provenance summary generation asynchronously and returns their jobs."""
+        import_names = config.import_names
+
         if not import_names:
             logging.info("No imports specified. Skipping cache aggregations.")
             return []

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_aggregator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_aggregator.py
@@ -14,6 +14,7 @@
 """Generates aggregated Observations and TimeSeries directly for Statvars."""
 
 import logging
+from dataclasses import dataclass
 from typing import List, Optional
 
 from google.cloud import bigquery
@@ -22,6 +23,16 @@ from .bq_executor import BigQueryExecutor
 from .common import _escape_sql_literal, get_provenance_name
 
 logging.getLogger().setLevel(logging.INFO)
+
+
+@dataclass
+class StatVarAggregationConfig:
+    """Configuration for statistical variable aggregation."""
+    ancestor_sv: str
+    source_svs: List[str]
+    import_names: List[str]
+    output_import_name: Optional[str] = None
+    skip_all_sources_present_check: bool = False
 
 
 class StatVarAggregator:
@@ -45,11 +56,7 @@ class StatVarAggregator:
 
     def aggregate_stat_vars(
         self,
-        ancestor_sv: str,
-        source_svs: List[str],
-        import_names: List[str],
-        output_import_name: Optional[str] = None,
-        skip_all_sources_present_check: bool = False
+        config: StatVarAggregationConfig
     ) -> List[bigquery.job.QueryJob]:
         """Aggregates multiple source StatVars into an ancestor StatVar.
 
@@ -57,17 +64,16 @@ class StatVarAggregator:
         TimeSeries and Observation rows in Spanner.
 
         Args:
-            ancestor_sv: The target parent StatVar ID (e.g., 'Count_Person').
-            source_svs: List of source StatVar IDs to aggregate.
-            import_names: List of input import names (provenances) to process.
-            output_import_name: Optional name for the output import (provenance).
-                If not specified, defaults to '{import_names[0]}_StatVarAgg'.
-            skip_all_sources_present_check: If True, aggregates even if some source
-                variables are missing. If False, only aggregates if all sources are present.
+            config: Structured StatVarAggregationConfig dataclass instance.
 
         Returns:
             A list of BigQuery QueryJob objects representing the async execution.
         """
+        ancestor_sv = config.ancestor_sv
+        source_svs = config.source_svs
+        import_names = config.import_names
+        output_import_name = config.output_import_name
+        skip_all_sources_present_check = config.skip_all_sources_present_check
         if not import_names or not source_svs:
             logging.info("Empty imports or sources. Skipping aggregation.")
             return []

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_calculation_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_calculation_generator.py
@@ -28,7 +28,7 @@ class StatVarCalculationConfig:
     """Configuration for statistical variable calculation."""
     calculations: List[Dict[str, Any]]
     import_names: List[str]
-    output_import_name: str
+    output_import_name: Optional[str] = None
 
 
 class StatVarCalculationGenerator:
@@ -67,8 +67,8 @@ class StatVarCalculationGenerator:
         calculations = config.calculations
         import_names = config.import_names
         output_import_name = config.output_import_name
-        if not calculations or not import_names:
-            logging.info("Empty calculations or import names. Skipping.")
+        if not calculations or not import_names or not output_import_name:
+            logging.info("Empty calculations, import names, or output import name. Skipping.")
             return []
 
         connection_id = self.executor.connection_id

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_calculation_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_calculation_generator.py
@@ -14,12 +14,21 @@
 """Statistical Variable Calculation Generator using BQ Federation."""
 
 import logging
-from typing import List, Dict
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
 
 from google.cloud import bigquery
 
 from .bq_executor import BigQueryExecutor
 from .common import _escape_sql_literal, get_provenance_name
+
+
+@dataclass
+class StatVarCalculationConfig:
+    """Configuration for statistical variable calculation."""
+    calculations: List[Dict[str, Any]]
+    import_names: List[str]
+    output_import_name: str
 
 
 class StatVarCalculationGenerator:
@@ -45,20 +54,19 @@ class StatVarCalculationGenerator:
 
     def calculate_stat_vars(
         self,
-        calculations: List[Dict],
-        import_names: List[str],
-        output_import_name: str
+        config: StatVarCalculationConfig
     ) -> List[bigquery.job.QueryJob]:
         """Runs the statistical variable calculations.
 
         Args:
-            calculations: List of calculation specs (parsed from manifest).
-            import_names: List of input import names (provenances) to filter by.
-            output_import_name: Name of the output import (provenance) to write.
+            config: Structured StatVarCalculationConfig dataclass instance.
 
         Returns:
             A list containing the BigQuery QueryJob representing the async execution.
         """
+        calculations = config.calculations
+        import_names = config.import_names
+        output_import_name = config.output_import_name
         if not calculations or not import_names:
             logging.info("Empty calculations or import names. Skipping.")
             return []

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
@@ -1,9 +1,17 @@
 import logging
+from dataclasses import dataclass
 from typing import List, Optional
 
 from google.cloud import bigquery
 from .bq_executor import BigQueryExecutor
 from .common import BASE_PROVENANCE_PREFIX, _escape_sql_literal, get_provenance_name
+
+
+@dataclass
+class StatVarGroupConfig:
+    """Configuration for statistical variable group generation."""
+    import_names: Optional[List[str]] = None
+
 
 class StatVarGroupGenerator:
     """Iteratively generates StatVarGroup nodes and hierarchical edges from MCF schemas."""
@@ -42,8 +50,10 @@ class StatVarGroupGenerator:
         self.should_prune_single_child_svgs = should_prune_single_child_svgs
 
     def run_all(self,
-                import_names: List[str] = None) -> List[bigquery.job.QueryJob]:
+                config: StatVarGroupConfig) -> List[bigquery.job.QueryJob]:
         """Runs all global aggregations asynchronously and returns their jobs."""
+        import_names = config.import_names
+
         if not import_names:
             logging.info("No imports specified. Skipping global aggregations.")
             return []

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_series_aggregator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_series_aggregator.py
@@ -14,7 +14,8 @@
 """Orchestrates StatVar Series Aggregations using BigQuery Federation."""
 
 import logging
-from typing import Any, Dict, List
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
 
 from google.cloud import bigquery
 
@@ -22,6 +23,12 @@ from .bq_executor import BigQueryExecutor
 from .common import _escape_sql_literal, get_provenance_name
 
 logging.getLogger().setLevel(logging.INFO)
+
+
+@dataclass
+class StatVarSeriesAggregationConfig:
+    """Configuration for statistical variable series aggregation."""
+    calculations: List[Dict[str, Any]]
 
 
 class StatVarSeriesAggregator:
@@ -42,15 +49,20 @@ class StatVarSeriesAggregator:
         self.executor = executor
         self.is_base_dc = is_base_dc
 
-    def aggregate_series(self, calculations: List[Dict[str, Any]]) -> List[Any]:
+    def aggregate_series(
+        self,
+        config: StatVarSeriesAggregationConfig
+    ) -> List[Any]:
         """Orchestrates multi-round StatVar Series Aggregations.
 
         Args:
-            calculations: A list of dicts representing the calculations to run.
+            config: Structured StatVarSeriesAggregationConfig dataclass instance.
 
         Returns:
             A list of completed BigQuery job objects.
         """
+        calculations = config.calculations
+
         if not calculations:
             logging.info("No calculations specified. Skipping.")
             return []

--- a/pipeline/workflow/aggregation-helper/aggregation/super_enum_aggregation_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/super_enum_aggregation_generator.py
@@ -14,11 +14,19 @@
 """Super Enum Aggregation Generator."""
 
 import logging
+from dataclasses import dataclass
 from typing import Any, List, Optional
 from google.cloud import spanner
 from google.cloud import bigquery
 from .bq_executor import BigQueryExecutor
 from .common import BASE_PROVENANCE_PREFIX, _escape_sql_literal
+
+
+@dataclass
+class SuperEnumAggregationConfig:
+    """Configuration for super enum aggregation."""
+    import_names: List[str]
+
 
 def get_dc_base32_encode_sql() -> str:
     """Returns the SQL definition for the DC_BASE32_ENCODE UDF.
@@ -135,12 +143,15 @@ class SuperEnumAggregationGenerator:
         self.spanner_client = spanner_client
         self.spanner_database = spanner_database
 
-    def run(self, import_names: List[str]) -> List[bigquery.job.QueryJob]:
+    def run(self,
+            config: SuperEnumAggregationConfig) -> List[bigquery.job.QueryJob]:
         """Runs the Super Enum aggregation.
 
         Args:
-            import_names: List of import names to process.
+            config: Structured SuperEnumAggregationConfig dataclass instance.
         """
+        import_names = config.import_names
+
         if not import_names:
             logging.info("Empty import names. Skipping Super Enum aggregation.")
             return []


### PR DESCRIPTION
This PR adds dataclasses for each of the aggregations' config. This makes the config interfaces clearer, and reduces the long list of params to be passed into a single wrapped object.

(I discovered a few bugs while doing this. For example, the place aggregation generator was hardcoding the output import names, instead of consuming from the yaml config. I'll send the fixes in follow-up PRs).