### PR TITLE
[SVG Hierarchy] 

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -250,9 +250,6 @@ class AggregationOrchestrator:
 
         logging.info(f"=== Starting Global Import-Independent Calculations ({len(global_calcs)} step(s)) ===")
         for calc in global_calcs:
-            if not self.config.generate_stat_var_groups and calc.get("type") == CalculationType.STAT_VAR_GROUPS:
-                logging.info("Skipping global step 'STAT_VAR_GROUPS' because generate_stat_var_groups is False.")
-                continue
             step_type = calc.get("type")
             if dry_run:
                 logging.info(f"[DRY RUN] Would execute global step: {calc.get('name', step_type)}")
@@ -603,7 +600,6 @@ class AggregationOrchestrator:
             return False
 
         if not self.config.generate_stat_var_groups and calc.get("type") == CalculationType.STAT_VAR_GROUPS:
-            logging.info("Skipping step 'STAT_VAR_GROUPS' because generate_stat_var_groups is False.")
             return False
 
         if calc.get("type") in GLOBAL_CALCULATION_TYPES:

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -100,6 +100,7 @@ class OrchestratorConfig:
     poll_interval: int = 15
     enable_embeddings: bool = False
     bq_dataset_id: str = "datacommons"
+    generate_stat_var_groups: bool = True
 
 
 class AggregationOrchestrator:
@@ -249,7 +250,10 @@ class AggregationOrchestrator:
 
         logging.info(f"=== Starting Global Import-Independent Calculations ({len(global_calcs)} step(s)) ===")
         for calc in global_calcs:
-            step_type = calc.get("type")
+            step_type = str(calc.get("type"))
+            if step_type in self.config.skip_types or calc.get("type") in self.config.skip_types:
+                logging.info(f"Skipping global step '{calc.get('name', step_type)}' because calculation type '{step_type}' is in skip_types.")
+                continue
             if dry_run:
                 logging.info(f"[DRY RUN] Would execute global step: {calc.get('name', step_type)}")
             else:
@@ -596,6 +600,10 @@ class AggregationOrchestrator:
     def _calc_applies_to_import(self, calc: Dict[str, Any], single_import: str) -> bool:
         """Determines if a calculation step applies to a single import."""
         if calc.get("disabled", False):
+            return False
+
+        if not self.config.generate_stat_var_groups and calc.get("type") == CalculationType.STAT_VAR_GROUPS:
+            logging.info("Skipping step 'STAT_VAR_GROUPS' because generate_stat_var_groups is False.")
             return False
 
         if calc.get("type") in GLOBAL_CALCULATION_TYPES:

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -250,10 +250,10 @@ class AggregationOrchestrator:
 
         logging.info(f"=== Starting Global Import-Independent Calculations ({len(global_calcs)} step(s)) ===")
         for calc in global_calcs:
-            step_type = str(calc.get("type"))
-            if step_type in self.config.skip_types or calc.get("type") in self.config.skip_types:
-                logging.info(f"Skipping global step '{calc.get('name', step_type)}' because calculation type '{step_type}' is in skip_types.")
+            if not self.config.generate_stat_var_groups and calc.get("type") == CalculationType.STAT_VAR_GROUPS:
+                logging.info("Skipping global step 'STAT_VAR_GROUPS' because generate_stat_var_groups is False.")
                 continue
+            step_type = calc.get("type")
             if dry_run:
                 logging.info(f"[DRY RUN] Would execute global step: {calc.get('name', step_type)}")
             else:

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
@@ -493,6 +493,31 @@ class TestOrchestratorOrdering(unittest.TestCase):
         ]
         self.assertEqual(types_in_order, expected_order)
 
+    def test_generate_stat_var_groups_disabled(self, mock_executor):
+        """Verifies STAT_VAR_GROUPS calculation step is skipped when generate_stat_var_groups is set to False."""
+        orchestrator = AggregationOrchestrator(OrchestratorConfig(
+            connection_id="conn",
+            project_id="proj",
+            instance_id="inst",
+            database_id="db",
+            config_file_path=self.config_path,
+            generate_stat_var_groups=False
+        ))
+
+        svg_calc = next(c for c in orchestrator.calculations if c.get("type") == CalculationType.STAT_VAR_GROUPS)
+        self.assertFalse(orchestrator._calc_applies_to_import(svg_calc, "TestImport"))
+
+        # Verify STAT_VAR_GROUPS is active when generate_stat_var_groups is True
+        orchestrator_enabled = AggregationOrchestrator(OrchestratorConfig(
+            connection_id="conn",
+            project_id="proj",
+            instance_id="inst",
+            database_id="db",
+            config_file_path=self.config_path,
+            generate_stat_var_groups=True
+        ))
+        self.assertTrue(orchestrator_enabled._calc_applies_to_import(svg_calc, "TestImport"))
+
 
 class TestConfigSanity(unittest.TestCase):
     """Sanity checks for calculation configurations and metadata."""

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
@@ -22,7 +22,7 @@ class StatVarGroupGenerator:
                  max_iterations: int = 50,
                  namespace: Optional[str] = None,
                  generated_provenance: Optional[str] = None,
-                 should_filter_basic_population_type: bool = True,
+                 should_filter_basic_population_type: Optional[bool] = None,
                  should_prune_single_child_svgs: bool = False) -> None:
         """Initializes the StatVarGroupGenerator with executor and configuration parameters.
 
@@ -46,7 +46,11 @@ class StatVarGroupGenerator:
           if generated_provenance is not None
           else (f'{BASE_PROVENANCE_PREFIX}GeneratedGraphs' if is_base_dc else 'GeneratedGraphs')
         )
-        self.should_filter_basic_population_type = should_filter_basic_population_type
+        self.should_filter_basic_population_type = (
+            should_filter_basic_population_type
+            if should_filter_basic_population_type is not None
+            else is_base_dc
+        )
         self.should_prune_single_child_svgs = should_prune_single_child_svgs
 
     def run_all(self,

--- a/pipeline/workflow/aggregation-helper/main.py
+++ b/pipeline/workflow/aggregation-helper/main.py
@@ -89,7 +89,7 @@ def main():
         "--generate_stat_var_groups",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="Whether to auto-generate StatVarGroup hierarchy tree (default: True, use --no-generate_stat_var_groups or --generate_stat_var_groups=false to disable)."
+        help="Whether to auto-generate StatVarGroup hierarchy tree (default: True, use --no-generate_stat_var_groups to disable)."
     )
     parser.add_argument(
         "--dry_run",

--- a/pipeline/workflow/aggregation-helper/main.py
+++ b/pipeline/workflow/aggregation-helper/main.py
@@ -68,6 +68,7 @@ def create_orchestrator_config(
         config_file_path=config_path,
         enable_embeddings=enable_embeddings,
         bq_dataset_id=bq_dataset_id,
+        generate_stat_var_groups=args.generate_stat_var_groups,
     )
 
 
@@ -83,6 +84,12 @@ def main():
     parser.add_argument(
         "--config_path",
         help="Optional path to a specific YAML config file or directory (e.g., aggregation/configs/embedding.yaml)."
+    )
+    parser.add_argument(
+        "--generate_stat_var_groups",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Whether to auto-generate StatVarGroup hierarchy tree (default: True, use --no-generate_stat_var_groups or --generate_stat_var_groups=false to disable)."
     )
     parser.add_argument(
         "--dry_run",

--- a/simple/stats/runner.py
+++ b/simple/stats/runner.py
@@ -299,7 +299,10 @@ class Runner:
       ]
       handshake_payload = {"status": "FAILURE", "errors": errors_dict}
     else:
-      handshake_payload = {"importList": json.dumps(self.trigger_workflow_info)}
+      handshake_payload = {
+          "importList": json.dumps(self.trigger_workflow_info),
+          "generateStatVarGroups": self.config.generate_hierarchy(),
+      }
 
     output_json_path = f"{temp_location.rstrip('/')}/datacommons/ingestion_records/{workflow_id}.json"
     logging.info(

--- a/simple/tests/stats/runner_test.py
+++ b/simple/tests/stats/runner_test.py
@@ -579,6 +579,7 @@ class TestRunner(unittest.TestCase):
       written_str = entered_mock.as_file.return_value.write.call_args[0][0]
       written_payload = json.loads(written_str)
       self.assertIn("importList", written_payload)
+      self.assertIn("generateStatVarGroups", written_payload)
 
       decoded_import_list = json.loads(written_payload["importList"])
       self.assertEqual(len(decoded_import_list), 2)


### PR DESCRIPTION
Make preprocessor propagate wether we should generate the SVG hierarchy for the current import into the handshake file.

https://github.com/datacommonsorg/datacommons/pull/184 parses that value from the handshake file, andpasses the flag in postprocessor.

This PR also adds the postprocessor code to skip SVG hierarchy generation if explicitly disabled.  