### PR TITLE
DCP schema - remove legacy Cache table

### DIFF
--- a/pipeline/workflow/ingestion-helper/clients/schema.sql
+++ b/pipeline/workflow/ingestion-helper/clients/schema.sql
@@ -173,13 +173,6 @@ CREATE PROPERTY GRAPH DCGraph
         subject_id)
   );
 
-CREATE TABLE Cache (
-  type STRING(1024) NOT NULL,
-  key STRING(1024) NOT NULL,
-  provenance STRING(1024) NOT NULL,
-  value JSON,
-) PRIMARY KEY(type, key, provenance);
-
 CREATE TABLE KeyValueStore (
   type STRING(1024) NOT NULL,
   key STRING(1024) NOT NULL,

--- a/pipeline/workflow/ingestion-helper/clients/spanner.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner.py
@@ -590,7 +590,7 @@ class SpannerClient:
         required_tables = [
             "Node", "Edge", "TimeSeries", "Observation", "ImportStatus",
             "IngestionHistory", "ImportVersionHistory", "IngestionLock",
-            "Cache", "KeyValueStore", self.embedding_table
+            "KeyValueStore", self.embedding_table
         ]
         required_indexes = [
             "InEdge",

--- a/pipeline/workflow/ingestion-helper/clients/spanner_test.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner_test.py
@@ -45,7 +45,6 @@ class TestSpannerClient(unittest.TestCase):
             ["table", "IngestionHistory"],
             ["table", "ImportVersionHistory"],
             ["table", "IngestionLock"],
-            ["table", "Cache"],
             ["table", "KeyValueStore"],
             ["table", "VariableMetadata"],
             ["index", "NodeEmbeddingIndex"],


### PR DESCRIPTION
## Description
This PR deletes the obsolete Spanner `Cache` table definition and its references from the ingestion helper client, as it has been replaced by the `KeyValueStore` table.

## Changes
- Removed `CREATE TABLE Cache (...)` block from `pipeline/workflow/ingestion-helper/clients/schema.sql`
- Removed `"Cache"` from `required_tables` in `pipeline/workflow/ingestion-helper/clients/spanner.py`
- Removed `["table", "Cache"]` from mock schema checks in `pipeline/workflow/ingestion-helper/clients/spanner_test.py`

## Verification
- Ran `uv run pytest` on ingestion helper tests: 51 passed.