### PR TITLE
Set minimum google-cloud-spanner version to 3.60.0 in ingestion-helper

### DIFF
--- a/pipeline/workflow/ingestion-helper/pyproject.toml
+++ b/pipeline/workflow/ingestion-helper/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "fastapi>=0.110.0",
     "uvicorn[standard]>=0.28.0",
     "pydantic>=2.0.0",
-    "google-cloud-spanner",
+    "google-cloud-spanner>=3.60.0",
     "google-api-python-client",
     "google-cloud-storage",
     "google-auth",

--- a/pipeline/workflow/ingestion-helper/uv.lock
+++ b/pipeline/workflow/ingestion-helper/uv.lock
@@ -406,7 +406,6 @@ dependencies = [
     { name = "gcsfs" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
-    { name = "google-cloud-bigquery" },
     { name = "google-cloud-spanner" },
     { name = "google-cloud-storage" },
     { name = "jinja2" },
@@ -430,8 +429,7 @@ requires-dist = [
     { name = "gcsfs" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
-    { name = "google-cloud-bigquery" },
-    { name = "google-cloud-spanner" },
+    { name = "google-cloud-spanner", specifier = ">=3.60.0" },
     { name = "google-cloud-storage" },
     { name = "jinja2" },
     { name = "pandas", specifier = "~=3.0.3" },
@@ -667,24 +665,6 @@ wheels = [
 ]
 
 [[package]]
-name = "google-cloud-bigquery"
-version = "3.41.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core", extra = ["grpc"] },
-    { name = "google-auth" },
-    { name = "google-cloud-core" },
-    { name = "google-resumable-media" },
-    { name = "packaging" },
-    { name = "python-dateutil" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/13/6515c7aab55a4a0cf708ffd309fb9af5bab54c13e32dc22c5acd6497193c/google_cloud_bigquery-3.41.0.tar.gz", hash = "sha256:2217e488b47ed576360c9b2cc07d59d883a54b83167c0ef37f915c26b01a06fe", size = 513434, upload-time = "2026-03-30T22:50:55.347Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/33/1d3902efadef9194566d499d61507e1f038454e0b55499d2d7f8ab2a4fee/google_cloud_bigquery-3.41.0-py3-none-any.whl", hash = "sha256:2a5b5a737b401cbd824a6e5eac7554100b878668d908e6548836b5d8aaa4dcaa", size = 262343, upload-time = "2026-03-30T22:48:45.444Z" },
-]
-
-[[package]]
 name = "google-cloud-core"
 version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -715,7 +695,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-spanner"
-version = "3.67.0"
+version = "3.69.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -734,9 +714,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "sqlparse" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/ec/f54cb1b6f8654f36705cc0f7485d5889de6892dcb9acd85a5feda7ce9d21/google_cloud_spanner-3.67.0.tar.gz", hash = "sha256:0a01173c2e29aa371173809a15ecb10794b168f1f2edad7c5789a44e47c25d15", size = 902145, upload-time = "2026-06-03T16:13:57.582Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/78/0e3f0c59b38c31287c48c5b0f91976ec0fb0f0f244f8f8c4d1856db7a64f/google_cloud_spanner-3.69.0.tar.gz", hash = "sha256:e274dd63957db3c453bda20d25d9dc42662f2e58f53957bc3706811b3d539484", size = 904828, upload-time = "2026-06-25T23:39:49.976Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/17/4e6ff13fd829dd0b15a8384273adeed6bf305afc334a5d95b430c113af26/google_cloud_spanner-3.67.0-py3-none-any.whl", hash = "sha256:d83b9267db6486972affa69711bc0a182541d58c5931cf4956ca71956f427251", size = 619106, upload-time = "2026-06-03T16:12:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/60/433929de67b12165c212bed01c976d9b79707500c521d343c1fb73e6ebc7/google_cloud_spanner-3.69.0-py3-none-any.whl", hash = "sha256:5efc8bc346fa4958135f43cd68c78cfcfa2c13aaa6bf162fa8b56943ca288ae8", size = 620018, upload-time = "2026-06-25T23:39:19.192Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update minimum `google-cloud-spanner` version requirement to `>=3.60.0` to align with upstream Data Commons Spanner dependency updates.

- Updated `google-cloud-spanner` dependency specifier to `>=3.60.0` in `ingestion-helper/pyproject.toml`.
- Updated `uv.lock` in `ingestion-helper/` to lock `google-cloud-spanner` version 3.69.0.