### PR TITLE
Scope derived graph provenances in LinkedEdgeGenerator by source import

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/aggregation_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/aggregation_test.py
@@ -30,7 +30,9 @@ from aggregation.common import (
     BASE_PROVENANCE_PREFIX,
     _escape_sql_literal,
     get_provenance_prefix,
-    get_provenance_name
+    get_provenance_name,
+    get_generated_provenance_name,
+    get_sql_generated_provenance_expr,
 )
 
 
@@ -52,6 +54,14 @@ class TestCommonUtils(unittest.TestCase):
     def test_get_provenance_name(self):
         self.assertEqual(get_provenance_name("USFed_Census", is_base_dc=True), "dc/base/USFed_Census")
         self.assertEqual(get_provenance_name("USFed_Census", is_base_dc=False), "USFed_Census")
+
+    def test_get_generated_provenance_name(self):
+        self.assertEqual(get_generated_provenance_name("USFed_Census", is_base_dc=True), "dc/base/generated/USFed_Census")
+        self.assertEqual(get_generated_provenance_name("USFed_Census", is_base_dc=False), "generated/USFed_Census")
+
+    def test_get_sql_generated_provenance_expr(self):
+        self.assertIn("CONCAT('dc/base/generated/'", get_sql_generated_provenance_expr(True, "prov"))
+        self.assertIn("CONCAT('generated/'", get_sql_generated_provenance_expr(False, "prov"))
 
 
 @patch('aggregation.bq_executor.bigquery.Client')

--- a/pipeline/workflow/aggregation-helper/aggregation/common.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/common.py
@@ -25,6 +25,19 @@ def get_provenance_name(import_name: str, is_base_dc: bool) -> str:
     return f"{get_provenance_prefix(is_base_dc)}{import_name}"
 
 
+def get_generated_provenance_name(import_name: str, is_base_dc: bool) -> str:
+    """Returns the generated provenance name for an import (e.g. 'dc/base/generated/USFed_Census' or 'generated/USFed_Census')."""
+    return f"{get_provenance_prefix(is_base_dc)}generated/{import_name}"
+
+
+def get_sql_generated_provenance_expr(is_base_dc: bool, source_col: str = "provenance") -> str:
+    """Returns a SQL expression that transforms a source provenance into a scoped generated provenance."""
+    if is_base_dc:
+        return f"CONCAT('dc/base/generated/', REGEXP_REPLACE({source_col}, r'^dc/base/(generated/)?', ''))"
+    else:
+        return f"CONCAT('generated/', REGEXP_REPLACE({source_col}, r'^(generated/)?', ''))"
+
+
 def _escape_sql_literal(val: str) -> str:
     r"""
     Escapes a string literal for use in nested BigQuery/Spanner queries.

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/deletions_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/deletions_test.py
@@ -280,5 +280,25 @@ class AggregationDeletionsIntegrationTest(AggregationIntegrationTestBase):
             ))
             self.assertEqual(len(new_obs_b), 0)
 
+    def test_scoped_linked_edges_deletion(self):
+        """Verifies that deleting aggregations for ImportA deletes generated/ImportA but preserves generated/ImportB."""
+        import_a = 'ImportA_LinkedDelTest'
+        import_b = 'ImportB_LinkedDelTest'
+        prov_gen_a = 'dc/base/generated/ImportA_LinkedDelTest' if self.is_base_dc else 'generated/ImportA_LinkedDelTest'
+        prov_gen_b = 'dc/base/generated/ImportB_LinkedDelTest' if self.is_base_dc else 'generated/ImportB_LinkedDelTest'
+        
+        self.add_edge('geoId/06075', 'linkedContainedInPlace', 'geoId/06', f'generated/{import_a}')
+        self.add_edge('geoId/36061', 'linkedContainedInPlace', 'geoId/36', f'generated/{import_b}')
+        self.flush_to_spanner()
+        
+        calculations = [{"name": "Linked Edges", "type": "LINKED_EDGES", "stage": 1, "input_imports": ["*"]}]
+        self.run_orchestrator(calculations=calculations, active_imports=[import_a])
+        
+        with self.database.snapshot(multi_use=True) as snapshot:
+            edges_a = list(snapshot.execute_sql(f"SELECT subject_id FROM Edge WHERE provenance = '{prov_gen_a}'"))
+            edges_b = list(snapshot.execute_sql(f"SELECT subject_id FROM Edge WHERE provenance = '{prov_gen_b}'"))
+            self.assertEqual(len(edges_a), 0, "ImportA generated linked edges should be deleted.")
+            self.assertEqual(len(edges_b), 1, "ImportB generated linked edges should be preserved.")
+
 if __name__ == '__main__':
     unittest.main()

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/linked_edge_generator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/linked_edge_generator_test.py
@@ -89,7 +89,7 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
             """
             results = list(snapshot.execute_sql(query))
             
-            expected_provenance = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+            expected_provenance = f'dc/base/generated/{import_name}' if self.is_base_dc else f'generated/{import_name}'
             self.assertEqual(len(results), 3)
             self.assertEqual(tuple(results[0]), ('geoId/06', 'country/USA', expected_provenance))
             self.assertEqual(tuple(results[1]), ('geoId/06075', 'country/USA', expected_provenance))
@@ -134,7 +134,7 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
             """
             results = list(snapshot.execute_sql(query))
             
-            expected_provenance = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+            expected_provenance = f'dc/base/generated/{import_name}' if self.is_base_dc else f'generated/{import_name}'
             self.assertEqual(len(results), 2)
             self.assertEqual(tuple(results[0]), ('Instance_A', 'Class_B', expected_provenance))
             self.assertEqual(tuple(results[1]), ('Instance_A', 'Class_C', expected_provenance))
@@ -178,7 +178,7 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
             """
             results = list(snapshot.execute_sql(query))
             
-            expected_provenance = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+            expected_provenance = f'dc/base/generated/{import_name}' if self.is_base_dc else f'generated/{import_name}'
             self.assertEqual(len(results), 1)
             self.assertEqual(tuple(results[0]), ('TestVariable', 'dc/topic/TestTopic', expected_provenance))
 
@@ -219,7 +219,7 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
             """
             results = list(snapshot.execute_sql(query))
             
-            expected_provenance = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+            expected_provenance = f'dc/base/generated/{import_name}' if self.is_base_dc else f'generated/{import_name}'
             # Should resolve to 4 distinct edges: 06->06, 06->36, 36->06, 36->36
             self.assertEqual(len(results), 4)
             self.assertEqual(tuple(results[0]), ('geoId/06', 'geoId/06', expected_provenance))
@@ -237,7 +237,7 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
         self.add_edge('geoId/06075', 'containedInPlace', 'geoId/06', import_name)
         
         # 2. Pre-insert the expected generated edge (simulating a previous run)
-        self.add_edge('geoId/06075', 'linkedContainedInPlace', 'geoId/06', 'GeneratedGraphs')
+        self.add_edge('geoId/06075', 'linkedContainedInPlace', 'geoId/06', f'generated/{import_name}')
         
         self.flush_to_spanner()
         
@@ -262,9 +262,44 @@ class LinkedEdgeGeneratorIntegrationTest(AggregationIntegrationTestBase):
             """
             results = list(snapshot.execute_sql(query))
             
-            expected_provenance = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+            expected_provenance = f'dc/base/generated/{import_name}' if self.is_base_dc else f'generated/{import_name}'
             self.assertEqual(len(results), 1)
             self.assertEqual(tuple(results[0]), ('geoId/06075', 'geoId/06', expected_provenance))
+
+    def test_linked_edges_multiple_imports(self):
+        """Tests that passing multiple imports simultaneously assigns distinct scoped provenances per row."""
+        import_a = 'ImportA_MultiTest'
+        import_b = 'ImportB_MultiTest'
+        self.add_node('geoId/06075', 'San Francisco County', types=['County'])
+        self.add_node('geoId/06', 'California', types=['State'])
+        self.add_node('country/USA', 'United States', types=['Country'])
+        self.add_node('geoId/36061', 'New York County', types=['County'])
+        self.add_node('geoId/36', 'New York', types=['State'])
+        
+        self.add_edge('geoId/06075', 'containedInPlace', 'geoId/06', import_a)
+        self.add_edge('geoId/06', 'containedInPlace', 'country/USA', import_a)
+        self.add_edge('geoId/36061', 'containedInPlace', 'geoId/36', import_b)
+        self.add_edge('geoId/36', 'containedInPlace', 'country/USA', import_b)
+        self.flush_to_spanner()
+        
+        calculations = [
+            {
+                "name": "Linked Edges Multiple Imports",
+                "type": "LINKED_EDGES",
+                "stage": 1,
+                "input_imports": [import_a, import_b]
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_a, import_b])
+        self.assertTrue(res.success)
+        
+        with self.database.snapshot(multi_use=True) as snapshot:
+            prov_a = 'dc/base/generated/ImportA_MultiTest' if self.is_base_dc else 'generated/ImportA_MultiTest'
+            prov_b = 'dc/base/generated/ImportB_MultiTest' if self.is_base_dc else 'generated/ImportB_MultiTest'
+            res_a = list(snapshot.execute_sql(f"SELECT subject_id FROM Edge WHERE provenance = '{prov_a}' AND predicate = 'linkedContainedInPlace'"))
+            res_b = list(snapshot.execute_sql(f"SELECT subject_id FROM Edge WHERE provenance = '{prov_b}' AND predicate = 'linkedContainedInPlace'"))
+            self.assertEqual(len(res_a), 3, "ImportA should have 3 scoped linked edges.")
+            self.assertEqual(len(res_b), 3, "ImportB should have 3 scoped linked edges.")
 
 
 class LinkedEdgeGeneratorCustomDcTest(LinkedEdgeGeneratorIntegrationTest):

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/provenance_scoping_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/provenance_scoping_test.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration E2E test suite for SQL provenance scoping expressions in live Spanner SQL."""
+
+import unittest
+from aggregation.e2e_tests.base import AggregationIntegrationTestBase
+from aggregation.common import get_sql_generated_provenance_expr
+
+
+class ProvenanceScopingSqlIntegrationTest(AggregationIntegrationTestBase):
+    """Verifies that SQL generated provenance expressions execute idempotently in live Spanner SQL."""
+
+    is_base_dc = True
+
+    def test_sql_expr_idempotency_live_spanner(self):
+        """Tests get_sql_generated_provenance_expr against live Spanner SQL with normal and pre-prefixed data."""
+        import_name = 'LiveSql_Test_Import'
+        normal_prov = f'dc/base/{import_name}' if self.is_base_dc else import_name
+        prefixed_prov = f'dc/base/generated/{import_name}' if self.is_base_dc else f'generated/{import_name}'
+
+        # Insert edges with both normal and already-generated provenances
+        self.add_node('geoId/01', 'Alabama', types=['State'])
+        self.add_node('geoId/02', 'Alaska', types=['State'])
+        self.add_edge('geoId/01', 'testPred', 'geoId/02', import_name)
+        # Manually append already-prefixed edge to mock_edges (bypassing add_edge's auto-prefixing)
+        self.mock_edges.append(('geoId/02', 'testPred', 'geoId/01', prefixed_prov))
+        self.flush_to_spanner()
+
+        prov_expr = get_sql_generated_provenance_expr(self.is_base_dc, "provenance")
+        query = f"""
+            SELECT subject_id, provenance, {prov_expr} AS transformed_prov
+            FROM Edge
+            WHERE predicate = 'testPred'
+            ORDER BY subject_id
+        """
+
+        with self.database.snapshot() as snapshot:
+            results = list(snapshot.execute_sql(query))
+            self.assertEqual(len(results), 2)
+
+            # Both the normal provenance and the already-generated provenance must transform identically
+            expected_transformed = f'dc/base/generated/{import_name}' if self.is_base_dc else f'generated/{import_name}'
+            self.assertEqual(results[0][0], 'geoId/01')
+            self.assertEqual(results[0][1], normal_prov)
+            self.assertEqual(results[0][2], expected_transformed)
+
+            self.assertEqual(results[1][0], 'geoId/02')
+            self.assertEqual(results[1][1], prefixed_prov)
+            self.assertEqual(results[1][2], expected_transformed)
+
+
+class ProvenanceScopingSqlCustomDcTest(ProvenanceScopingSqlIntegrationTest):
+    """Runs the live Spanner SQL idempotency tests in Custom DC (non-base DC) mode."""
+    is_base_dc = False
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pipeline/workflow/aggregation-helper/aggregation/linked_edge_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/linked_edge_generator.py
@@ -19,7 +19,7 @@ from typing import List, Optional
 from google.cloud import bigquery
 
 from .bq_executor import BigQueryExecutor
-from .common import BASE_PROVENANCE_PREFIX, _escape_sql_literal
+from .common import BASE_PROVENANCE_PREFIX, _escape_sql_literal, get_sql_generated_provenance_expr
 
 
 @dataclass
@@ -68,13 +68,13 @@ class LinkedEdgeGenerator:
         prefix = BASE_PROVENANCE_PREFIX if self.is_base_dc else ""
         provenances = [f"'{prefix}{name}'" for name in safe_names]
         provenance_filter = f" AND provenance IN ({', '.join(provenances)})"
-        gen_graphs_prov = f'{BASE_PROVENANCE_PREFIX}GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+        prov_expr = get_sql_generated_provenance_expr(self.is_base_dc, "provenance")
 
         query = f"""  # nosec
         -- Pull base edges needed for memberOf aggregation
         CREATE OR REPLACE TEMPORARY TABLE `temp_base_member_of` AS
         SELECT * FROM EXTERNAL_QUERY("{self.executor.connection_id}", 
-          "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate IN ('memberOf', 'specializationOf'){provenance_filter}");
+          "SELECT subject_id, predicate, object_id, provenance FROM Edge WHERE predicate IN ('memberOf', 'specializationOf'){provenance_filter}");
 
         -- Pull existing generated edges to filter them out later
         CREATE OR REPLACE TEMPORARY TABLE `temp_existing_linked_member_of` AS
@@ -82,7 +82,7 @@ class LinkedEdgeGenerator:
           "SELECT subject_id, predicate, object_id, provenance FROM Edge WHERE predicate = 'linkedMemberOf'");
 
         CREATE OR REPLACE TEMPORARY TABLE `temp_hierarchy` AS
-        SELECT DISTINCT subject_id, predicate, object_id
+        SELECT DISTINCT subject_id, predicate, object_id, provenance
         FROM `temp_base_member_of`;
 
         EXPORT DATA
@@ -93,7 +93,8 @@ class LinkedEdgeGenerator:
           SELECT
             subject_id,
             object_id AS ancestor,
-            1 AS level
+            1 AS level,
+            provenance
           FROM
             temp_hierarchy
           WHERE
@@ -103,7 +104,8 @@ class LinkedEdgeGenerator:
           SELECT
             a.subject_id,
             t.object_id AS ancestor,
-            a.level + 1
+            a.level + 1,
+            a.provenance
           FROM
             Ancestors AS a
           JOIN
@@ -118,7 +120,7 @@ class LinkedEdgeGenerator:
             subject_id,
             'linkedMemberOf' as predicate,
             ancestor as object_id,
-            '{gen_graphs_prov}' as provenance
+            {prov_expr} as provenance
           FROM
             Ancestors
         ),
@@ -161,13 +163,13 @@ class LinkedEdgeGenerator:
         prefix = "dc/base/" if self.is_base_dc else ""
         provenances = [f"'{prefix}{name}'" for name in safe_names]
         provenance_filter = f" AND provenance IN ({', '.join(provenances)})"
-        gen_graphs_prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+        prov_expr = get_sql_generated_provenance_expr(self.is_base_dc, "provenance")
 
         query = f"""  # nosec
         -- Pull base edges needed for containedInPlace aggregation
         CREATE OR REPLACE TEMPORARY TABLE `temp_base_contained_in_place` AS
         SELECT * FROM EXTERNAL_QUERY("{self.executor.connection_id}",
-          "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate = 'containedInPlace'{provenance_filter}");
+          "SELECT subject_id, predicate, object_id, provenance FROM Edge WHERE predicate = 'containedInPlace'{provenance_filter}");
 
         -- Pull existing generated edges to filter them out later
         CREATE OR REPLACE TEMPORARY TABLE `temp_existing_linked_contained_in_place` AS
@@ -175,7 +177,7 @@ class LinkedEdgeGenerator:
           "SELECT subject_id, predicate, object_id, provenance FROM Edge WHERE predicate = 'linkedContainedInPlace'");
 
         CREATE OR REPLACE TEMPORARY TABLE `temp_contained_in_place` AS
-        SELECT subject_id, object_id
+        SELECT subject_id, object_id, provenance
         FROM `temp_base_contained_in_place`;
 
         EXPORT DATA
@@ -186,7 +188,8 @@ class LinkedEdgeGenerator:
           SELECT
             subject_id,
             object_id AS ancestor_place,
-            1 AS level
+            1 AS level,
+            provenance
           FROM
             temp_contained_in_place
           UNION ALL
@@ -194,7 +197,8 @@ class LinkedEdgeGenerator:
           SELECT
             a.subject_id,
             t.object_id AS ancestor_place,
-            a.level + 1
+            a.level + 1,
+            a.provenance
           FROM
             Ancestors AS a
           JOIN
@@ -208,7 +212,7 @@ class LinkedEdgeGenerator:
             subject_id,
             'linkedContainedInPlace' as predicate,
             ancestor_place as object_id,
-            '{gen_graphs_prov}' as provenance
+            {prov_expr} as provenance
           FROM
             Ancestors
         ),
@@ -251,13 +255,13 @@ class LinkedEdgeGenerator:
         prefix = "dc/base/" if self.is_base_dc else ""
         provenances = [f"'{prefix}{name}'" for name in safe_names]
         provenance_filter = f" AND provenance IN ({', '.join(provenances)})"
-        gen_graphs_prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+        prov_expr = get_sql_generated_provenance_expr(self.is_base_dc, "provenance")
 
         query = f"""  # nosec
         -- Pull base edges needed for member aggregation
         CREATE OR REPLACE TEMPORARY TABLE `temp_base_member` AS
         SELECT * FROM EXTERNAL_QUERY("{self.executor.connection_id}", 
-          "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate IN ('relevantVariable', 'member'){provenance_filter}");
+          "SELECT subject_id, predicate, object_id, provenance FROM Edge WHERE predicate IN ('relevantVariable', 'member'){provenance_filter}");
 
         -- Pull existing generated edges to filter them out later
         CREATE OR REPLACE TEMPORARY TABLE `temp_existing_linked_member` AS
@@ -265,7 +269,7 @@ class LinkedEdgeGenerator:
           "SELECT subject_id, predicate, object_id, provenance FROM Edge WHERE predicate = 'linkedMember'");
 
         CREATE OR REPLACE TEMPORARY TABLE `temp_topic_hierarchy` AS
-        SELECT DISTINCT subject_id, object_id
+        SELECT DISTINCT subject_id, object_id, provenance
         FROM `temp_base_member`
         WHERE (subject_id LIKE 'dc/topic%' OR subject_id LIKE 'dc/svpg%');
 
@@ -277,7 +281,8 @@ class LinkedEdgeGenerator:
           SELECT
             subject_id,
             object_id AS descendant,
-            1 AS level
+            1 AS level,
+            provenance
           FROM
             temp_topic_hierarchy
           UNION ALL
@@ -285,7 +290,8 @@ class LinkedEdgeGenerator:
           SELECT
             d.subject_id,
             t.object_id AS descendant,
-            d.level + 1
+            d.level + 1,
+            d.provenance
           FROM
             Descendants AS d
           JOIN
@@ -299,7 +305,7 @@ class LinkedEdgeGenerator:
             descendant as subject_id,
             'linkedMember' as predicate,
             subject_id as object_id,
-            '{gen_graphs_prov}' as provenance
+            {prov_expr} as provenance
           FROM
             Descendants
           WHERE subject_id LIKE 'dc/topic%'

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -84,6 +84,10 @@ GLOBAL_CALCULATION_TYPES = {
     CalculationType.EMBEDDING_GENERATION,
 }
 
+SCOPED_GRAPH_CALCULATION_TYPES = {
+    CalculationType.LINKED_EDGES,
+}
+
 
 @dataclass
 class OrchestratorConfig:
@@ -300,6 +304,8 @@ class AggregationOrchestrator:
                     output = calc.get(_OUTPUT_IMPORT_KEY)
                     if output:
                         to_delete.add(output)
+                    if calc.get("type") in SCOPED_GRAPH_CALCULATION_TYPES:
+                        to_delete.add(f"generated/{single_import}")
 
         if not to_delete:
             logging.info("No existing aggregated data resolved for deletion.")


### PR DESCRIPTION
This PR changes the generated linked edges to record the provenance as `dc/base/generated/<import_name>` instead of `dc/base/GeneratedGraphs`.

I'll do a different PR for svg hierarchy query as that is more complex.