### PR TITLE
Support pagination for batched node property requests in dc import tool

### DIFF
--- a/util/src/main/java/org/datacommons/util/ApiHelper.java
+++ b/util/src/main/java/org/datacommons/util/ApiHelper.java
@@ -34,7 +34,23 @@ public class ApiHelper {
   public static JsonObject fetchPropertyValues(
       HttpClient httpClient, List<String> nodes, String property)
       throws IOException, InterruptedException {
-    var request = buildPropertyValuesRequest(nodes, property, DcApiConfigs.getConfig());
+    Map<String, List<V2NodeResponse.NodeInfo>> propertyValuesByNode = new HashMap<>();
+    String nextToken = "";
+    do {
+      V2NodeResponse page = fetchPropertyValuesPage(httpClient, nodes, property, nextToken);
+      if (page == null) return null;
+
+      mergePropertyValues(propertyValuesByNode, page, property);
+      nextToken = page.nextToken;
+    } while (nextToken != null && !nextToken.isEmpty());
+
+    return convertToLegacyFormat(propertyValuesByNode, nodes);
+  }
+
+  private static V2NodeResponse fetchPropertyValuesPage(
+      HttpClient httpClient, List<String> nodes, String property, String nextToken)
+      throws IOException, InterruptedException {
+    var request = buildPropertyValuesRequest(nodes, property, nextToken, DcApiConfigs.getConfig());
 
     // maxRetries = 0 means no retries (only initial attempt)
     // maxRetries = 3 means 4 total attempts (1 initial + 3 retries)
@@ -42,6 +58,7 @@ public class ApiHelper {
 
     RetryPolicy<HttpResponse<String>> retryPolicy =
         RetryPolicy.<HttpResponse<String>>builder()
+            // TODO: Retry transient HTTP responses such as 429 and 5xx.
             .handle(IOException.class)
             .withMaxRetries(maxRetries)
             // Exponential backoff: 1s, 2s, 4s, 8s, 8s... (doubles each retry, capped at
@@ -70,12 +87,11 @@ public class ApiHelper {
 
     V2NodeResponse v2Response = new Gson().fromJson(response.body().trim(), V2NodeResponse.class);
     if (v2Response == null || v2Response.data == null) return null;
-
-    return convertToLegacyFormat(v2Response, nodes, property);
+    return v2Response;
   }
 
   static HttpRequest buildPropertyValuesRequest(
-      List<String> nodes, String property, DcApiConfig config) {
+      List<String> nodes, String property, String nextToken, DcApiConfig config) {
     JsonArray dcids = new JsonArray();
     for (var node : nodes) {
       dcids.add(node);
@@ -85,6 +101,9 @@ public class ApiHelper {
     arg.add("nodes", dcids);
     // V2 uses -> for out-edges, which is equivalent to direction: "out" in V1
     arg.addProperty("property", "->" + property);
+    if (nextToken != null && !nextToken.isEmpty()) {
+      arg.addProperty("nextToken", nextToken);
+    }
 
     var requestBuilder =
         HttpRequest.newBuilder(URI.create(config.apiRoot() + NODE_API_PATH))
@@ -98,8 +117,25 @@ public class ApiHelper {
     return requestBuilder.build();
   }
 
+  private static void mergePropertyValues(
+      Map<String, List<V2NodeResponse.NodeInfo>> propertyValuesByNode,
+      V2NodeResponse page,
+      String property) {
+    for (Map.Entry<String, V2NodeResponse.NodeData> entry : page.data.entrySet()) {
+      V2NodeResponse.NodeData nodeData = entry.getValue();
+      if (nodeData == null || nodeData.arcs == null) continue;
+
+      V2NodeResponse.ArcData arcData = nodeData.arcs.get(property);
+      if (arcData == null || arcData.nodes == null) continue;
+
+      propertyValuesByNode
+          .computeIfAbsent(entry.getKey(), unused -> new ArrayList<>())
+          .addAll(arcData.nodes);
+    }
+  }
+
   static JsonObject convertToLegacyFormat(
-      V2NodeResponse v2Response, List<String> nodes, String property) {
+      Map<String, List<V2NodeResponse.NodeInfo>> propertyValuesByNode, List<String> nodes) {
     JsonObject legacyFormat = new JsonObject();
     // Iterate over requested nodes to ensure each has an entry in the response,
     // even if empty. This is required by callers like ExistenceChecker.
@@ -109,16 +145,10 @@ public class ApiHelper {
       outWrapper.add("out", outArray);
       legacyFormat.add(dcid, outWrapper);
 
-      V2NodeResponse.NodeData nodeData = v2Response.data.get(dcid);
-      if (nodeData == null) continue;
+      List<V2NodeResponse.NodeInfo> propertyValues = propertyValuesByNode.get(dcid);
+      if (propertyValues == null) continue;
 
-      Map<String, V2NodeResponse.ArcData> arcs = nodeData.arcs;
-      if (arcs == null) continue;
-
-      V2NodeResponse.ArcData arcData = arcs.get(property);
-      if (arcData == null || arcData.nodes == null) continue;
-
-      for (V2NodeResponse.NodeInfo node : arcData.nodes) {
+      for (V2NodeResponse.NodeInfo node : propertyValues) {
         outArray.add(createOutObject(node));
       }
     }

--- a/util/src/main/java/org/datacommons/util/V2NodeResponse.java
+++ b/util/src/main/java/org/datacommons/util/V2NodeResponse.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 public class V2NodeResponse {
   public Map<String, NodeData> data;
+  public String nextToken;
 
   public static class NodeData {
     public Map<String, ArcData> arcs;

--- a/util/src/test/java/org/datacommons/util/ApiHelperTest.java
+++ b/util/src/test/java/org/datacommons/util/ApiHelperTest.java
@@ -1,14 +1,30 @@
 package org.datacommons.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import java.io.ByteArrayOutputStream;
+import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 public class ApiHelperTest {
 
@@ -18,6 +34,7 @@ public class ApiHelperTest {
         ApiHelper.buildPropertyValuesRequest(
             List.of("geoId/06"),
             "name",
+            "",
             new DcApiConfig("https://api.datacommons.org", "prod-key"));
 
     assertEquals("https://api.datacommons.org/v2/node", request.uri().toString());
@@ -30,6 +47,7 @@ public class ApiHelperTest {
         ApiHelper.buildPropertyValuesRequest(
             List.of("geoId/06"),
             "name",
+            "",
             new DcApiConfig("https://custom.api.datacommons.org/", "key"));
 
     assertEquals("https://custom.api.datacommons.org/v2/node", request.uri().toString());
@@ -40,18 +58,75 @@ public class ApiHelperTest {
   public void buildPropertyValuesRequestOmitsMissingKey() {
     HttpRequest request =
         ApiHelper.buildPropertyValuesRequest(
-            List.of("geoId/06"), "name", new DcApiConfig("https://api.datacommons.org", ""));
+            List.of("geoId/06"), "name", "", new DcApiConfig("https://api.datacommons.org", ""));
 
     assertEquals("https://api.datacommons.org/v2/node", request.uri().toString());
     assertTrue(request.headers().firstValue("x-api-key").isEmpty());
   }
 
   @Test
-  public void convertsNodesWithDcid() throws Exception {
-    V2NodeResponse response = new V2NodeResponse();
-    response.data = Map.of("geoId/06", nodeWith("typeOf", List.of(nodeWithDcid("Class"))));
+  public void fetchPropertyValuesMergesAllPages() throws Exception {
+    HttpClient mockHttp = mock(HttpClient.class);
+    HttpResponse<String> firstResponse = mock(HttpResponse.class);
+    HttpResponse<String> secondResponse = mock(HttpResponse.class);
+    when(firstResponse.body())
+        .thenReturn(
+            "{\"data\":{"
+                + "\"nodeA\":{\"arcs\":{\"typeOf\":{\"nodes\":[{\"dcid\":\"Place\"}]}}},"
+                + "\"nodeB\":{}},"
+                + "\"nextToken\":\"next-page-token\"}");
+    when(secondResponse.body())
+        .thenReturn(
+            "{\"data\":{"
+                + "\"nodeA\":{\"arcs\":{\"typeOf\":{\"nodes\":[{\"dcid\":\"City\"}]}}},"
+                + "\"nodeB\":{\"arcs\":{\"typeOf\":{\"nodes\":[{\"dcid\":\"Place\"}]}}}}}");
+    doReturn(firstResponse, secondResponse).when(mockHttp).send(any(), any());
 
-    JsonObject legacy = ApiHelper.convertToLegacyFormat(response, List.of("geoId/06"), "typeOf");
+    JsonObject result =
+        ApiHelper.fetchPropertyValues(mockHttp, List.of("nodeA", "nodeB"), "typeOf");
+
+    ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+    verify(mockHttp, org.mockito.Mockito.times(2)).send(requestCaptor.capture(), any());
+    JsonObject firstRequest = requestBody(requestCaptor.getAllValues().get(0));
+    JsonObject secondRequest = requestBody(requestCaptor.getAllValues().get(1));
+    assertFalse(firstRequest.has("nextToken"));
+    assertEquals("next-page-token", secondRequest.get("nextToken").getAsString());
+    assertEquals(firstRequest.get("nodes"), secondRequest.get("nodes"));
+    assertEquals("->typeOf", secondRequest.get("property").getAsString());
+
+    JsonArray nodeA = result.getAsJsonObject("nodeA").getAsJsonArray("out");
+    JsonArray nodeB = result.getAsJsonObject("nodeB").getAsJsonArray("out");
+    assertEquals(2, nodeA.size());
+    assertEquals("Place", nodeA.get(0).getAsJsonObject().get("dcid").getAsString());
+    assertEquals("City", nodeA.get(1).getAsJsonObject().get("dcid").getAsString());
+    assertEquals(1, nodeB.size());
+    assertEquals("Place", nodeB.get(0).getAsJsonObject().get("dcid").getAsString());
+  }
+
+  @Test
+  public void fetchPropertyValuesDoesNotReturnPartialData() throws Exception {
+    HttpClient mockHttp = mock(HttpClient.class);
+    HttpResponse<String> firstResponse = mock(HttpResponse.class);
+    HttpResponse<String> invalidResponse = mock(HttpResponse.class);
+    when(firstResponse.body())
+        .thenReturn(
+            "{\"data\":{\"nodeA\":{\"arcs\":{\"typeOf\":{\"nodes\":[{\"dcid\":\"Place\"}]}}}},"
+                + "\"nextToken\":\"next-page-token\"}");
+    when(invalidResponse.body()).thenReturn("{}");
+    doReturn(firstResponse, invalidResponse).when(mockHttp).send(any(), any());
+
+    JsonObject result = ApiHelper.fetchPropertyValues(mockHttp, List.of("nodeA"), "typeOf");
+
+    assertNull(result);
+    verify(mockHttp, org.mockito.Mockito.times(2)).send(any(), any());
+  }
+
+  @Test
+  public void convertsNodesWithDcid() throws Exception {
+    Map<String, List<V2NodeResponse.NodeInfo>> propertyValuesByNode =
+        Map.of("geoId/06", List.of(nodeWithDcid("Class")));
+
+    JsonObject legacy = ApiHelper.convertToLegacyFormat(propertyValuesByNode, List.of("geoId/06"));
 
     JsonArray out = legacy.getAsJsonObject("geoId/06").getAsJsonArray("out");
     assertEquals(1, out.size());
@@ -60,10 +135,10 @@ public class ApiHelperTest {
 
   @Test
   public void convertsNodesWithValue() throws Exception {
-    V2NodeResponse response = new V2NodeResponse();
-    response.data = Map.of("geoId/06", nodeWith("name", List.of(nodeWithValue("California"))));
+    Map<String, List<V2NodeResponse.NodeInfo>> propertyValuesByNode =
+        Map.of("geoId/06", List.of(nodeWithValue("California")));
 
-    JsonObject legacy = ApiHelper.convertToLegacyFormat(response, List.of("geoId/06"), "name");
+    JsonObject legacy = ApiHelper.convertToLegacyFormat(propertyValuesByNode, List.of("geoId/06"));
 
     JsonArray out = legacy.getAsJsonObject("geoId/06").getAsJsonArray("out");
     assertEquals(1, out.size());
@@ -72,40 +147,10 @@ public class ApiHelperTest {
 
   @Test
   public void populatesPlaceholdersWhenNoDataReturned() throws Exception {
-    V2NodeResponse response = new V2NodeResponse();
-    response.data = Map.of();
-
-    JsonObject legacy = ApiHelper.convertToLegacyFormat(response, List.of("geoId/06"), "name");
+    JsonObject legacy = ApiHelper.convertToLegacyFormat(Map.of(), List.of("geoId/06"));
 
     JsonArray out = legacy.getAsJsonObject("geoId/06").getAsJsonArray("out");
     assertTrue(out.isEmpty());
-  }
-
-  @Test
-  public void returnsEmptyWhenPropertyMissing() throws Exception {
-    V2NodeResponse.NodeData nodeWithoutProperty = new V2NodeResponse.NodeData();
-    nodeWithoutProperty.arcs = Map.of();
-
-    V2NodeResponse response = new V2NodeResponse();
-    response.data = Map.of("geoId/06", nodeWithoutProperty);
-
-    JsonObject legacy = ApiHelper.convertToLegacyFormat(response, List.of("geoId/06"), "name");
-
-    JsonArray out = legacy.getAsJsonObject("geoId/06").getAsJsonArray("out");
-    assertTrue(out.isEmpty());
-  }
-
-  private static V2NodeResponse.NodeData nodeWith(
-      String property, List<V2NodeResponse.NodeInfo> nodes) {
-    V2NodeResponse.NodeData nodeData = new V2NodeResponse.NodeData();
-    nodeData.arcs = Map.of(property, arcWith(nodes));
-    return nodeData;
-  }
-
-  private static V2NodeResponse.ArcData arcWith(List<V2NodeResponse.NodeInfo> nodes) {
-    V2NodeResponse.ArcData arcData = new V2NodeResponse.ArcData();
-    arcData.nodes = nodes;
-    return arcData;
   }
 
   private static V2NodeResponse.NodeInfo nodeWithDcid(String dcid) {
@@ -118,5 +163,39 @@ public class ApiHelperTest {
     V2NodeResponse.NodeInfo nodeInfo = new V2NodeResponse.NodeInfo();
     nodeInfo.value = value;
     return nodeInfo;
+  }
+
+  private static JsonObject requestBody(HttpRequest request) throws Exception {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    CompletableFuture<JsonObject> body = new CompletableFuture<>();
+    request
+        .bodyPublisher()
+        .orElseThrow()
+        .subscribe(
+            new Flow.Subscriber<>() {
+              @Override
+              public void onSubscribe(Flow.Subscription subscription) {
+                subscription.request(Long.MAX_VALUE);
+              }
+
+              @Override
+              public void onNext(ByteBuffer bytes) {
+                byte[] chunk = new byte[bytes.remaining()];
+                bytes.get(chunk);
+                output.write(chunk, 0, chunk.length);
+              }
+
+              @Override
+              public void onError(Throwable error) {
+                body.completeExceptionally(error);
+              }
+
+              @Override
+              public void onComplete() {
+                body.complete(
+                    new Gson().fromJson(output.toString(StandardCharsets.UTF_8), JsonObject.class));
+              }
+            });
+    return body.get();
   }
 }

--- a/util/src/test/java/org/datacommons/util/StatVarStateTest.java
+++ b/util/src/test/java/org/datacommons/util/StatVarStateTest.java
@@ -15,6 +15,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import org.datacommons.proto.Debug;
 import org.datacommons.proto.Mcf.McfGraph;
 import org.junit.Test;
@@ -102,10 +103,12 @@ public class StatVarStateTest {
     // Test that the payload contained in TEST_SV_MEASRES_HTTP_RESP
     // is correctly parsed and Vocabulary.MEASUREMENT_RESULT is returned.
     V2NodeResponse response = new Gson().fromJson(TEST_SV_MEASRES_HTTP_RESP, V2NodeResponse.class);
+    List<V2NodeResponse.NodeInfo> statTypes =
+        response.data.get(TEST_SV_MEASRES_DCID).arcs.get(Vocabulary.STAT_TYPE).nodes;
 
     JsonObject payloadJson =
         ApiHelper.convertToLegacyFormat(
-            response, List.of(TEST_SV_MEASRES_DCID), Vocabulary.STAT_TYPE);
+            Map.of(TEST_SV_MEASRES_DCID, statTypes), List.of(TEST_SV_MEASRES_DCID));
 
     String returnValue = StatVarState.parseApiStatTypeResponse(payloadJson, TEST_SV_MEASRES_DCID);
 


### PR DESCRIPTION
## Summary

The import tool checks whether referenced nodes exist by querying `/v2/node` for their `typeOf` property.

Spanner-backed deployments can paginate large batched responses and return a `nextToken`. The import tool previously ignored this token, causing nodes omitted from the first page to be incorrectly reported as missing references.

This change:

- Adds `nextToken` to the V2 node response model.
- Fetches pages until the server stops returning a token.
- Accumulates property values by node across pages.
- Converts the complete result to the legacy response format once.
- Returns no partial result if any page fails.
- Adds coverage for token propagation, multi-page merging, and later-page failure.

## Testing

- `mvn -pl util -Dtest=ApiHelperTest,StatVarStateTest test`
- `mvn -pl util test`