### PR TITLE
SVG pruning fixes

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/aggregation_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/aggregation_test.py
@@ -22,6 +22,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from aggregation import BigQueryExecutor
 from aggregation import LinkedEdgeGenerator, LinkedEdgeConfig
+from aggregation import StatVarGroupGenerator, StatVarGroupConfig
 from aggregation import ProvenanceSummaryGenerator, ProvenanceSummaryConfig
 from aggregation import PlaceAggregationGenerator, PlaceAggregationConfig
 from aggregation import EmbeddingGenerator, EmbeddingGenerationConfig
@@ -415,6 +416,35 @@ class TestEmbeddingGenerator(unittest.TestCase):
         deleted = generator._delete_existing_embeddings(spec, embedding_table="NodeEmbedding")
         self.assertEqual(deleted, 2)
         mock_db.execute_partitioned_dml.assert_called_once()
+
+
+class TestStatVarGroupGenerator(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_executor = MagicMock()
+        self.mock_executor.connection_id = "test-conn"
+        self.mock_executor.get_spanner_destination_uri.return_value = "spanner-uri"
+
+    def test_run_all_empty(self):
+        generator = StatVarGroupGenerator(self.mock_executor)
+        jobs = generator.run_all(StatVarGroupConfig(import_names=[]))
+        self.assertEqual(jobs, [])
+        self.mock_executor.execute.assert_not_called()
+
+    def test_run_stat_var_group(self):
+        generator = StatVarGroupGenerator(self.mock_executor, is_base_dc=True, should_prune_single_child_svgs=True)
+        mock_prep_job = [MagicMock(object_id="gender"), MagicMock(object_id="age")]
+        mock_exec_job = MagicMock()
+        self.mock_executor.execute.side_effect = [mock_prep_job, mock_exec_job]
+
+        jobs = generator.run_all(StatVarGroupConfig(import_names=["import1"]))
+
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(self.mock_executor.execute.call_count, 2)
+        query = self.mock_executor.execute.call_args[0][0]
+        self.assertIn("PrunableSVGs", query)
+        self.assertIn("EffectiveParent", query)
+        self.assertIn("HAVING COUNT(DISTINCT pc.child) <= 1", query)
 
 
 if __name__ == '__main__':

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_group_generator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_group_generator_test.py
@@ -177,14 +177,20 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
             self.assertIn(('Count_Student_Female', 'linkedMemberOf', f'{ns}g/Root', prov), edges)
 
             # Verify basic populationType SV attached to SVG by mprop
-            self.assertIn(('Count_Person', 'memberOf', f'{ns}g/TestVertical', prov), edges)
+            if self.is_base_dc:
+                self.assertIn(('Count_Person', 'memberOf', f'{ns}g/TestVertical', prov), edges)
+            else:
+                self.assertIn(('Count_Person', 'memberOf', f'{ns}g/Person', prov), edges)
 
             # Verify basic populationType SV attached to ancestor SVGs
             self.assertIn(('Count_Person', 'linkedMemberOf', f'{ns}g/TestVertical', prov), edges)
             self.assertIn(('Count_Person', 'linkedMemberOf', f'{ns}g/Root', prov), edges)
 
             # Verify uncategorized basic populationType SV attached to Uncategorized_Variables SVG
-            self.assertIn(('Count_Thing', 'memberOf', f'{ns}g/Uncategorized_Variables', prov), edges)
+            if self.is_base_dc:
+                self.assertIn(('Count_Thing', 'memberOf', f'{ns}g/Uncategorized_Variables', prov), edges)
+            else:
+                self.assertIn(('Count_Thing', 'memberOf', f'{ns}g/Thing', prov), edges)
 
             # Verify uncategorized basic populationType SV attached to ancestor SVGs
             self.assertIn(('Count_Thing', 'linkedMemberOf', f'{ns}g/Uncategorized_Variables', prov), edges)
@@ -348,10 +354,12 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
             self.assertIn(('Count_Student', 'linkedMemberOf', f'{ns}g/Root', prov), edges)
 
             # --- Other SVs unaffected ---
-            # Count_Person (basic popType, attached to TestVertical)
-            self.assertIn(('Count_Person', 'memberOf', f'{ns}g/TestVertical', prov), edges)
-            # Count_Thing (uncategorized)
-            self.assertIn(('Count_Thing', 'memberOf', f'{ns}g/Uncategorized_Variables', prov), edges)
+            if self.is_base_dc:
+                self.assertIn(('Count_Person', 'memberOf', f'{ns}g/TestVertical', prov), edges)
+                self.assertIn(('Count_Thing', 'memberOf', f'{ns}g/Uncategorized_Variables', prov), edges)
+            else:
+                self.assertIn(('Count_Person', 'memberOf', f'{ns}g/Person', prov), edges)
+                self.assertIn(('Count_Thing', 'memberOf', f'{ns}g/Thing', prov), edges)
 
     def test_pruning_dag_fanout(self):
         """
@@ -470,6 +478,65 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
             self.assertEqual(len(over20_member_edges), 1,
                 f'Expected exactly 1 memberOf edge for Median_Income_Person_Over20, '
                 f'got {len(over20_member_edges)}: {over20_member_edges}')
+
+    def test_pruning_distinct_child_count_and_cascading(self):
+        """
+        Tests multi-level cascading pruning and distinct child counting.
+
+        Verifies:
+          1. Multi-level cascading pruning (3+ levels of single-child SVGs are recursively pruned).
+          2. COUNT(DISTINCT pc.child) correctly evaluates unique distinct children when multiple
+             convergent paths roll up duplicate entries of the same StatVar.
+          3. No ghost linkedMemberOf edges remain pointing to pruned SVGs.
+        """
+        ns = 'dc/' if self.is_base_dc else 'c/'
+        prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+
+        self._setup_dpv_mock_data(ns)
+
+        calculations = [
+            {
+                "name": "StatVar Groups Generation with Distinct Pruning",
+                "type": "STAT_VAR_GROUPS",
+                "stage": 1,
+                "input_imports": ["TestImport"],
+                "should_prune_single_child_svgs": True
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=["TestImport"])
+        self.assertTrue(res.success)
+
+        with self.database.snapshot(multi_use=True) as snapshot:
+            edge_query = """
+                SELECT subject_id, predicate, object_id, provenance
+                FROM Edge 
+                WHERE predicate IN ('memberOf', 'specializationOf', 'linkedMemberOf')
+                ORDER BY subject_id, predicate, object_id
+            """
+            edges = [(r[0], r[1], r[2], r[3]) for r in snapshot.execute_sql(edge_query)]
+
+            node_query = """
+                SELECT subject_id 
+                FROM Node 
+                WHERE 'StatVarGroup' IN UNNEST(types)
+                ORDER BY subject_id
+            """
+            nodes = [r[0] for r in snapshot.execute_sql(node_query)]
+
+            # Check that all single-child generated SVGs were pruned (removed from Node)
+            pruned_svg_candidates = [
+                f'{ns}g/Person_ArmedForcesStatus',
+                f'{ns}g/Person_VeteranStatus',
+                f'{ns}g/Person_ArmedForcesStatus_VeteranStatus',
+                f'{ns}g/Person_Age',
+                f'{ns}g/Person_Age-Years20Onwards'
+            ]
+            for svg_id in pruned_svg_candidates:
+                self.assertNotIn(svg_id, nodes)
+                # Verify ZERO linkedMemberOf or memberOf edges point to pruned SVGs (no ghost edges)
+                linked_to_pruned = [e for e in edges if e[2] == svg_id]
+                self.assertEqual(len(linked_to_pruned), 0,
+                    f'Found ghost edges pointing to pruned SVG {svg_id}: {linked_to_pruned}')
 
     def _setup_dpv_mock_data(self, ns):
         """Setup mock data for DPV (dependentPropertyValue) matching tests."""

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_group_generator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_group_generator_test.py
@@ -490,7 +490,6 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
           3. No ghost linkedMemberOf edges remain pointing to pruned SVGs.
         """
         ns = 'dc/' if self.is_base_dc else 'c/'
-        prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
 
         self._setup_dpv_mock_data(ns)
 

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
@@ -764,22 +764,60 @@ class StatVarGroupGenerator:
             FROM Edge WHERE predicate = 'memberOf'
           );
 
-          -- An SVG is prunable if it is generated and has exactly 1 child.
-          CREATE OR REPLACE TEMP TABLE PrunableSVGs AS (
-            SELECT pc.parent AS svg_id
-            FROM ParentChild pc
-            JOIN GeneratedSVGs g ON pc.parent = g.svg_id
-            GROUP BY pc.parent
-            HAVING COUNT(*) = 1
+          -- Iteratively identify all prunable SVGs (generated SVGs with <= 1 child).
+          -- Includes SVGs with 0 children (empty/orphaned groups) and SVGs whose child count
+          -- drops to <= 1 as a result of pruning child SVGs.
+          --DECLARE pruning_iteration INT64 DEFAULT 0;
+          --DECLARE new_prunable_found BOOL DEFAULT TRUE;
+
+          CREATE OR REPLACE TEMP TABLE CurrentParentChild AS (
+            SELECT * FROM ParentChild
           );
 
-          -- Compute effective parent for each child of a pruned SVG.
-          -- Use a recursive CTE to explore ALL paths through the DAG (a pruned SVG
-          -- may have multiple parents via specializationOf from different cprop
-          -- removal orders). Each path stops when it reaches a non-prunable ancestor.
-          -- Then pick the nearest non-prunable ancestor, preferring generated SVGs
-          -- over verticals/root (so we redirect to the closest surviving SVG, not
-          -- a distant vertical like Demographics).
+          CREATE OR REPLACE TEMP TABLE PrunableSVGs (svg_id STRING);
+
+          WHILE new_prunable_found AND pruning_iteration < 50 DO
+            SET pruning_iteration = pruning_iteration + 1;
+            SET new_prunable_found = FALSE;
+
+            CREATE OR REPLACE TEMP TABLE NewPrunable AS (
+              SELECT g.svg_id
+              FROM GeneratedSVGs g
+              LEFT JOIN CurrentParentChild pc ON g.svg_id = pc.parent
+              WHERE g.svg_id NOT IN (SELECT svg_id FROM PrunableSVGs)
+              GROUP BY g.svg_id
+              HAVING COUNT(DISTINCT pc.child) <= 1
+            );
+
+            IF (SELECT COUNT(*) FROM NewPrunable) > 0 THEN
+              SET new_prunable_found = TRUE;
+
+              INSERT INTO PrunableSVGs SELECT svg_id FROM NewPrunable;
+
+              -- Update CurrentParentChild by bypassing PrunableSVGs nodes recursively
+              CREATE OR REPLACE TEMP TABLE CurrentParentChild AS (
+                WITH RECURSIVE Walk AS (
+                  SELECT child, parent, predicate
+                  FROM ParentChild
+
+                  UNION ALL
+
+                  SELECT w.child, pc.parent, w.predicate
+                  FROM Walk w
+                  JOIN PrunableSVGs p ON w.parent = p.svg_id
+                  JOIN ParentChild pc ON p.svg_id = pc.child
+                )
+                SELECT DISTINCT child, parent, predicate
+                FROM Walk
+                WHERE parent NOT IN (SELECT svg_id FROM PrunableSVGs)
+                  AND child NOT IN (SELECT svg_id FROM PrunableSVGs)
+              );
+            END IF;
+          END WHILE;
+
+          -- Compute effective parent for each surviving child of a pruned SVG across ALL DAG paths.
+          -- Use a recursive CTE to explore ALL paths through the DAG. Each path stops when it
+          -- reaches a non-prunable ancestor.
           CREATE OR REPLACE TEMP TABLE EffectiveParent AS (
             WITH RECURSIVE
             WalkUp AS (
@@ -803,58 +841,33 @@ class StatVarGroupGenerator:
               FROM WalkUp w
               JOIN PrunableSVGs p ON w.effective_parent = p.svg_id
               JOIN ParentChild pc ON p.svg_id = pc.child
-            ),
-            -- Filter to only non-prunable ancestors (the walk stops here)
-            NonPrunableAncestors AS (
-              SELECT
-                node_id,
-                effective_parent,
-                predicate,
-                depth
-              FROM WalkUp
-              WHERE effective_parent NOT IN (SELECT svg_id FROM PrunableSVGs)
-            ),
-            -- Pick the nearest non-prunable ancestor per node.
-            -- Tiebreaker: prefer generated SVGs (more specific) over
-            -- verticals/root (which are less specific).
-            Ranked AS (
-              SELECT
-                npa.node_id,
-                npa.effective_parent,
-                npa.predicate,
-                ROW_NUMBER() OVER (
-                  PARTITION BY npa.node_id
-                  ORDER BY npa.depth ASC,
-                    -- Prefer generated SVGs over verticals/root
-                    IF(g.svg_id IS NOT NULL, 0, 1),
-                    npa.effective_parent
-                ) AS rn
-              FROM NonPrunableAncestors npa
-              LEFT JOIN GeneratedSVGs g ON npa.effective_parent = g.svg_id
             )
-            SELECT node_id, effective_parent, predicate FROM Ranked WHERE rn = 1
+            -- Filter to non-prunable ancestors for surviving (non-pruned) children
+            SELECT DISTINCT
+              node_id,
+              effective_parent,
+              predicate
+            FROM WalkUp
+            WHERE effective_parent NOT IN (SELECT svg_id FROM PrunableSVGs)
+              AND node_id NOT IN (SELECT svg_id FROM PrunableSVGs)
           );
 
           -- Build redirected edges for non-pruned children of pruned SVGs.
           -- Pruned SVGs themselves are removed entirely (no redirected edges).
           -- The predicate is preserved: specializationOf for SVG children, memberOf for SV children.
-          -- Skip redirects for nodes that already have a surviving edge with the same
-          -- predicate (e.g., an SV with a memberOf to a non-pruned SVG doesn't need
-          -- another memberOf from a pruned SVG's redirect).
           CREATE OR REPLACE TEMP TABLE RedirectedEdges AS (
-            SELECT
+            SELECT DISTINCT
               ep.node_id AS subject_id,
               ep.predicate,
               ep.effective_parent AS object_id,
               generated_provenance AS provenance
             FROM EffectiveParent ep
-            WHERE ep.node_id NOT IN (SELECT svg_id FROM PrunableSVGs)
-              AND NOT EXISTS (
-                SELECT 1 FROM Edge e
-                WHERE e.subject_id = ep.node_id
-                  AND e.predicate = ep.predicate
-                  AND e.object_id NOT IN (SELECT svg_id FROM PrunableSVGs)
-              )
+            WHERE NOT EXISTS (
+              SELECT 1 FROM Edge e
+              WHERE e.subject_id = ep.node_id
+                AND e.predicate = ep.predicate
+                AND e.object_id = ep.effective_parent
+            )
           );
 
           -- Rebuild Edge: remove all edges involving pruned SVGs, add redirected edges.

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
@@ -118,6 +118,8 @@ class StatVarGroupGenerator:
         DECLARE root_svg STRING DEFAULT CONCAT(namespace, 'g/Root'); -- DCID for root SVG
         DECLARE should_filter_basic_population_type BOOL DEFAULT @should_filter; -- Whether to filter basic population type SVGs. Default to true for base DC
         DECLARE should_prune BOOL DEFAULT @should_prune; -- Whether to prune single-child SVGs from the generated hierarchy
+        DECLARE pruning_iteration INT64 DEFAULT 0; -- Iteration of pruning loop
+        DECLARE new_prunable_found BOOL DEFAULT TRUE; -- Whether new prunable nodes were found in the iteration
 
         -- ============================================================================
         -- UDFs
@@ -767,9 +769,6 @@ class StatVarGroupGenerator:
           -- Iteratively identify all prunable SVGs (generated SVGs with <= 1 child).
           -- Includes SVGs with 0 children (empty/orphaned groups) and SVGs whose child count
           -- drops to <= 1 as a result of pruning child SVGs.
-          --DECLARE pruning_iteration INT64 DEFAULT 0;
-          --DECLARE new_prunable_found BOOL DEFAULT TRUE;
-
           CREATE OR REPLACE TEMP TABLE CurrentParentChild AS (
             SELECT * FROM ParentChild
           );


### PR DESCRIPTION
Fixes issues in StatVarGroupGenerator where single-child generated StatVarGroups (SVGs) survived pruning and left ghost linkedMemberOf / memberOf edges in the generated graph.

Root Causes & Fixes
1. Distinct Child Counting in Pruning Identification

Problem: In the iterative pruning loop (NewPrunable), child counts were computed using HAVING COUNT(pc.child) <= 1. When a single StatVar arrived at an SVG via multiple convergent paths (e.g. from multiple pruned child SVGs), COUNT(pc.child) counted non-distinct rows (evaluating to >1), preventing the SVG from being marked as prunable. Later, SELECT DISTINCT merged these edges, leaving single-child SVGs unpruned in Node and Edge.
Fix: Updated the query in stat_var_group_generator.py to HAVING COUNT(DISTINCT pc.child) <= 1.

2. Recursive Parent Bypassing for Multi-Level Pruning

Problem: Inside the pruning WHILE loop, CurrentParentChild was updated using a single-step join. When single-child SVGs cascaded across multiple levels (3+ levels deep), intermediate pruned parents were not bypassed for higher ancestors in CurrentParentChild, causing the loop to terminate prematurely and leave higher single-child SVGs unpruned.
Fix: Replaced the single-step join with a WITH RECURSIVE Walk CTE inside the WHILE loop (stat_var_group_generator.py). In each iteration, CurrentParentChild is fully refreshed by recursively walking up through all accumulated PrunableSVGs to their nearest unpruned ancestors.


Testing & Validation
Unit Tests:
* Updated query assertions in aggregation_test.py to assert HAVING COUNT(DISTINCT pc.child) <= 1.
* Added test_pruning_distinct_child_count_and_cascading to e2e_tests/stat_var_group_generator_test.py
 to test multi-level recursive pruning and verify zero ghost edges point to pruned SVGs.
Bulk Run Validation: Verified against full BigQuery/Spanner bulk dataset execution—queries confirmed 0 orphan single-child generated SVGs and 0 ghost linkedMemberOf edges remain.

Also regenerated hierarchy for dev (staging db) with latest changes.

NOTE: Unfortunately this does not fully fix all issues with the hierarchy. In particular, there are still a lot of excess vertical matching, and in some cases this pruning might be too aggressive. However, given the timeline, this is the best I could do without a major refactor, and hopefully addresses at least the bad user experience of clicking on a group and having it have no children.