### PR TITLE
Fix statvar aggregator bugs

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/configs/statvar.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/statvar.yaml
@@ -594,11 +594,11 @@ calculations:
             - dc/dc9v9h3q8l8n7
 
   # Education - ACSED5YrSurvey
-  - name: "CensusSAHIE_AggCountry: Health Insurance SV Aggregation"
+  - name: "ACSED5YrSurvey: Education SV Aggregation"
     type: STAT_VAR_AGGREGATION
     input_imports:
       - ACSED5YrSurvey
-    output_import: CensusSAHIE_AggCountry_StatVarAgg
+    output_import: ACSED5YrSurvey_StatVarAgg
     stat_var_aggregation:
       aggregations:
         - ancestor_sv_id: Count_Parent_Occupation_Management_Business_Science_Arts

--- a/pipeline/workflow/aggregation-helper/aggregation/configs/statvar.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/statvar.yaml
@@ -831,6 +831,7 @@ calculations:
           source_sv_ids:
             - Count_Person_WithOwnChildrenUnder18_Female
             - Count_Person_WithOwnChildrenUnder18_Male
+          skip_all_sources_present_check: true
 
   # Marriage
   - name: "CensusACS5YearSurvey_SubjectTables_S1201: Marital Status SV Aggregation"
@@ -1035,6 +1036,7 @@ calculations:
             - Count_Person_USCitizenByNaturalization_DateOfEntry1990To1999_ForeignBorn
             - Count_Person_USCitizenByNaturalization_DateOfEntry2000OrLater_ForeignBorn
             - Count_Person_USCitizenByNaturalization_DateOfEntry2010OrLater_ForeignBorn
+          skip_all_sources_present_check: true
 
   # HousingUnit HomeValue.
   - name: "CensusACS5YearSurvey: Home Value SV Aggregation"

--- a/pipeline/workflow/aggregation-helper/aggregation/configs/statvar.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/statvar.yaml
@@ -1254,7 +1254,7 @@ calculations:
             # Population: Male, 10,000 - 12,499 USD, White Alone Not Hispanic or Latino, Worked Full Time
             - dc/5jp07brw3g26h
 
-  - name: "DEA_ARCOS: Opioid Prescription SV Aggregation"
+  - name: "IndiaNSS_HealthAilments: Health Ailments SV Aggregation"
     type: STAT_VAR_AGGREGATION
     input_imports:
       - IndiaNSS_HealthAilments

--- a/pipeline/workflow/aggregation-helper/aggregation/configs/statvar.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/statvar.yaml
@@ -406,90 +406,52 @@ calculations:
         # Level 3
         - ancestor_sv_id: Count_Person_EducationalAttainment_9ThTo12ThGradeNoDiploma
           source_sv_ids:
-            # Population: 18 - 24 Years, 9th To 12th Grade No Diploma, Female
-            - dc/g0y4zefyr10n7
-            # Population: 18 - 24 Years, 9th To 12th Grade No Diploma, Male
-            - dc/0kptwgt2r2j97
-            # Population: 25 - 34 Years, 9th To 12th Grade No Diploma, Female
-            - dc/4f3r13e4gkhq6
-            # Population: 25 - 34 Years, 9th To 12th Grade No Diploma, Male
-            - dc/tcv30t9ydkldc
-            # Population: 35 - 44 Years, 9th To 12th Grade No Diploma, Female
-            - dc/7k5lylyz4l2th
-            # Population: 35 - 44 Years, 9th To 12th Grade No Diploma, Male
-            - dc/nrmj89cggsfg6
-            # Population: 45 - 64 Years, 9th To 12th Grade No Diploma, Female
-            - dc/m3g8esl121v73
-            # Population: 45 - 64 Years, 9th To 12th Grade No Diploma, Male
-            - dc/3hfl00nblgvg5
-            # Population: 65 Years or More, 9th To 12th Grade No Diploma, Female
-            - dc/5sps7rmylm73b
-            # Population: 65 Years or More, 9th To 12th Grade No Diploma, Male
-            - dc/07hctc6f9e2k9
+            - Count_Person_18To24Years_EducationalAttainment9ThTo12ThGradeNoDiploma_Female
+            - Count_Person_18To24Years_EducationalAttainment9ThTo12ThGradeNoDiploma_Male
+            - Count_Person_25To34Years_EducationalAttainment9ThTo12ThGradeNoDiploma_Female
+            - Count_Person_25To34Years_EducationalAttainment9ThTo12ThGradeNoDiploma_Male
+            - Count_Person_35To44Years_EducationalAttainment9ThTo12ThGradeNoDiploma_Female
+            - Count_Person_35To44Years_EducationalAttainment9ThTo12ThGradeNoDiploma_Male
+            - Count_Person_45To64Years_EducationalAttainment9ThTo12ThGradeNoDiploma_Female
+            - Count_Person_45To64Years_EducationalAttainment9ThTo12ThGradeNoDiploma_Male
+            - Count_Person_65OrMoreYears_EducationalAttainment9ThTo12ThGradeNoDiploma_Female
+            - Count_Person_65OrMoreYears_EducationalAttainment9ThTo12ThGradeNoDiploma_Male
         # dc/g/Person_EducationalAttainment-LessThan9ThGrade
         # Level 3
         - ancestor_sv_id: Count_Person_EducationalAttainment_LessThan9ThGrade
           source_sv_ids:
-            # Population: 18 - 24 Years, Less Than 9th Grade, Female
-            - dc/935ftchsz31b1
-            # Population: 18 - 24 Years, Less Than 9th Grade, Male
-            - dc/n6v6b8vh8jnd5
-            # Population: 25 - 34 Years, Less Than 9th Grade, Female
-            - dc/dr8wcfnpxyrj7
-            # Population: 25 - 34 Years, Less Than 9th Grade, Male
-            - dc/k8g20v452g617
-            # Population: 35 - 44 Years, Less Than 9th Grade, Female
-            - dc/y051838618t9c
-            # Population: 35 - 44 Years, Less Than 9th Grade, Male
-            - dc/cpx5ll8vth2n7
-            # Population: 45 - 64 Years, Less Than 9th Grade, Female
-            - dc/b841qxd3smpt
-            # Population: 45 - 64 Years, Less Than 9th Grade, Male
-            - dc/5vhc0r8m4x5g9
-            # Population: 65 Years or More, Less Than 9th Grade, Female
-            - dc/292723k92k5tb
-            # Population: 65 Years or More, Less Than 9th Grade, Male
-            - dc/68pblb53csteb
+            - Count_Person_18To24Years_EducationalAttainmentLessThan9ThGrade_Female
+            - Count_Person_18To24Years_EducationalAttainmentLessThan9ThGrade_Male
+            - Count_Person_25To34Years_EducationalAttainmentLessThan9ThGrade_Female
+            - Count_Person_25To34Years_EducationalAttainmentLessThan9ThGrade_Male
+            - Count_Person_35To44Years_EducationalAttainmentLessThan9ThGrade_Female
+            - Count_Person_35To44Years_EducationalAttainmentLessThan9ThGrade_Male
+            - Count_Person_45To64Years_EducationalAttainmentLessThan9ThGrade_Female
+            - Count_Person_45To64Years_EducationalAttainmentLessThan9ThGrade_Male
+            - Count_Person_65OrMoreYears_EducationalAttainmentLessThan9ThGrade_Female
+            - Count_Person_65OrMoreYears_EducationalAttainmentLessThan9ThGrade_Male
         # dc/g/Person_EducationalAttainment-LessThanHighSchoolDiploma
         # Level 3
         - ancestor_sv_id: Count_Person_EducationalAttainment_LessThanHighSchoolDiploma
           source_sv_ids:
-            # Population: Less Than High School Diploma, Male, Two or More Races
-            - dc/3g5g2k9n19l45
-            # Population: Less Than High School Diploma, Male, Asian Alone
-            - dc/z3z44q7edbyp7
-            # Population: Less Than High School Diploma, Female, Hispanic or Latino
-            - dc/0p89e7q72edr1
-            # Population: Less Than High School Diploma, Male, White Alone
-            - dc/70kcr1l5jldsb
-            # Population: Less Than High School Diploma, Female, Asian Alone
-            - dc/nbfp13v6t9v87
-            # Population: Less Than High School Diploma, Male, Hispanic or Latino
-            - dc/szpdtvh1v6p49
-            # Population: Less Than High School Diploma, Male, Some Other Race Alone
-            - dc/pyflt85w79j35
-            # Population: Less Than High School Diploma, Female, White Alone Not Hispanic or Latino
-            - dc/vhxsz5bplmef4
-            # Population: Less Than High School Diploma, Male, Black or African American Alone
-            - dc/k51n39gvd22t5
-            # Population: Less Than High School Diploma, Female, Black or African American Alone
-            - dc/m1trmbvh8sygd
-            # Population: Less Than High School Diploma, Male, Native Hawaiian or Other Pacific Islander Alone
-            - dc/7n0468s56spt8
-            # Population: Less Than High School Diploma, Male, American Indian or Alaska Native Alone
-            - dc/5e4qydg4slyvd
-            # Population: Less Than High School Diploma, Female, Native Hawaiian or Other Pacific Islander Alone
-            - dc/y95cbfgtlqrmb
-            # Population: Less Than High School Diploma, Female, Some Other Race Alone
-            - dc/p7978m8tbsns6
-            # Population: Less Than High School Diploma, Female, American Indian or Alaska Native Alone
-            - dc/lyzcfc37eet64
-            # Population: Less Than High School Diploma, Female, White Alone
-            - dc/m4q40nln3qms
-            # Population: Less Than High School Diploma, Male, White Alone Not Hispanic or Latino
-            - dc/yfrrvevrmyr74
-            # Population: Less Than High School Diploma, Female, Two or More Races
-            - dc/29l3m1z7d3n7c
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_AmericanIndianOrAlaskaNativeAlone_Female
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_AmericanIndianOrAlaskaNativeAlone_Male
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_AsianAlone_Female
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_AsianAlone_Male
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_BlackOrAfricanAmericanAlone_Female
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_BlackOrAfricanAmericanAlone_Male
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_HispanicOrLatino_Female
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_HispanicOrLatino_Male
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_NativeHawaiianOrOtherPacificIslanderAlone_Female
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_NativeHawaiianOrOtherPacificIslanderAlone_Male
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_SomeOtherRaceAlone_Female
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_SomeOtherRaceAlone_Male
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_TwoOrMoreRaces_Female
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_TwoOrMoreRaces_Male
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_WhiteAlone_Female
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_WhiteAlone_Male
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_WhiteAloneNotHispanicOrLatino_Female
+            - Count_Person_25OrMoreYears_EducationalAttainmentLessThanHighSchoolDiploma_WhiteAloneNotHispanicOrLatino_Male
         # dc/g/Person_EducationalAttainment-NurseryTo4ThGrade
         # Level 1
         - ancestor_sv_id: Count_Person_Years25Onwards_EducationalAttainment_NurseryTo4ThGrade
@@ -502,26 +464,16 @@ calculations:
         # Level 3
         - ancestor_sv_id: Count_Person_EducationalAttainment_SomeCollegeNoDegree
           source_sv_ids:
-            # Population: 18 - 24 Years, Some College No Degree, Female
-            - dc/x8sydp80d61v9
-            # Population: 18 - 24 Years, Some College No Degree, Male
-            - dc/bxs5x91p5jbf
-            # Population: 25 - 34 Years, Some College No Degree, Female
-            - dc/z8j7q9303cpx8
-            # Population: 25 - 34 Years, Some College No Degree, Male
-            - dc/d4p0m2p51v7d3
-            # Population: 35 - 44 Years, Some College No Degree, Female
-            - dc/66nscflhly519
-            # Population: 35 - 44 Years, Some College No Degree, Male
-            - dc/q4eclxrhd5mrd
-            # Population: 45 - 64 Years, Some College No Degree, Female
-            - dc/dsmks2epl3ve
-            # Population: 45 - 64 Years, Some College No Degree, Male
-            - dc/6ms49l0q9tq44
-            # Population: 65 Years or More, Some College No Degree, Female
-            - dc/c0vyt03x0h0v4
-            # Population: 65 Years or More, Some College No Degree, Male
-            - dc/5s08n6kdt26db
+            - Count_Person_18To24Years_EducationalAttainmentSomeCollegeNoDegree_Female
+            - Count_Person_18To24Years_EducationalAttainmentSomeCollegeNoDegree_Male
+            - Count_Person_25To34Years_EducationalAttainmentSomeCollegeNoDegree_Female
+            - Count_Person_25To34Years_EducationalAttainmentSomeCollegeNoDegree_Male
+            - Count_Person_35To44Years_EducationalAttainmentSomeCollegeNoDegree_Female
+            - Count_Person_35To44Years_EducationalAttainmentSomeCollegeNoDegree_Male
+            - Count_Person_45To64Years_EducationalAttainmentSomeCollegeNoDegree_Female
+            - Count_Person_45To64Years_EducationalAttainmentSomeCollegeNoDegree_Male
+            - Count_Person_65OrMoreYears_EducationalAttainmentSomeCollegeNoDegree_Female
+            - Count_Person_65OrMoreYears_EducationalAttainmentSomeCollegeNoDegree_Male
         - ancestor_sv_id: Count_Person_EducationalAttainment_1StTo12ThGrade
           source_sv_ids:
             - Count_Person_EducationalAttainment1StGrade
@@ -540,58 +492,40 @@ calculations:
         # The following 9 aggregations are: SomeCollegeOrAssociatesDegree, by race.
         - ancestor_sv_id: Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_AmericanIndianOrAlaskaNativeAlone
           source_sv_ids:
-            # Population: Some College or Associates Degree, Female, American Indian or Alaska Native Alone
-            - dc/mqxdr821c7kw3
-            # Population: Some College or Associates Degree, Male, American Indian or Alaska Native Alone
-            - dc/lyt8y97bbrkpc
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_AmericanIndianOrAlaskaNativeAlone_Female
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_AmericanIndianOrAlaskaNativeAlone_Male
         - ancestor_sv_id: Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_AsianAlone
           source_sv_ids:
-            # Population: Some College or Associates Degree, Female, Asian Alone
-            - dc/whn99h1l0xgth
-            # Population: Some College or Associates Degree, Male, Asian Alone
-            - dc/fkvnj4rlrs84f
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_AsianAlone_Female
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_AsianAlone_Male
         - ancestor_sv_id: Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_BlackOrAfricanAmericanAlone
           source_sv_ids:
-            # Population: Some College or Associates Degree, Female, Black or African American Alone
-            - dc/56md3ndhrmvm7
-            # Population: Some College or Associates Degree, Male, Black or African American Alone
-            - dc/e7h67vn5w4g13
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_BlackOrAfricanAmericanAlone_Female
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_BlackOrAfricanAmericanAlone_Male
         - ancestor_sv_id: Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_HispanicOrLatino
           source_sv_ids:
-            # Population: Some College or Associates Degree, Female, Hispanic or Latino
-            - dc/3w039ndqy7qv1
-            # Population: Some College or Associates Degree, Male, Hispanic or Latino
-            - dc/7xf6mm0sg9y18
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_HispanicOrLatino_Female
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_HispanicOrLatino_Male
         - ancestor_sv_id: Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_NativeHawaiianOrOtherPacificIslanderAlone
           source_sv_ids:
-            # Population: Some College or Associates Degree, Female, Native Hawaiian or Other Pacific Islander Alone
-            - dc/kpcfmb6lp3zpd
-            # Population: Some College or Associates Degree, Male, Native Hawaiian or Other Pacific Islander Alone
-            - dc/r3l3rfl1ms85f
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_NativeHawaiianOrOtherPacificIslanderAlone_Female
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_NativeHawaiianOrOtherPacificIslanderAlone_Male
         - ancestor_sv_id: Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_SomeOtherRaceAlone
           source_sv_ids:
-            # Population: Some College or Associates Degree, Female, Some Other Race Alone
-            - dc/epw58ne8mytn5
-            # Population: Some College or Associates Degree, Male, Some Other Race Alone
-            - dc/t0mcpxqgr2lm9
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_SomeOtherRaceAlone_Female
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_SomeOtherRaceAlone_Male
         - ancestor_sv_id: Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_TwoOrMoreRaces
           source_sv_ids:
-            # Population: Some College or Associates Degree, Female, Two or More Races
-            - dc/q98jxycvs422f
-            # Population: Some College or Associates Degree, Male, Two or More Races
-            - dc/zjlfv8d8v14f8
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_TwoOrMoreRaces_Female
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_TwoOrMoreRaces_Male
         - ancestor_sv_id: Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_WhiteAlone
           source_sv_ids:
-            # Population: Some College or Associates Degree, Female, White Alone
-            - dc/9sneyc8lpk8dc
-            # Population: Some College or Associates Degree, Male, White Alone
-            - dc/d2ct8qmvcct81
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_WhiteAlone_Female
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_WhiteAlone_Male
         - ancestor_sv_id: Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_WhiteAloneNotHispanicOrLatino
           source_sv_ids:
-            # Population: Some College or Associates Degree, Female, White Alone Not Hispanic or Latino
-            - dc/bqy52h7y4nq34
-            # Population: Some College or Associates Degree, Male, White Alone Not Hispanic or Latino
-            - dc/dc9v9h3q8l8n7
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_WhiteAloneNotHispanicOrLatino_Female
+            - Count_Person_25OrMoreYears_SomeCollegeOrAssociatesDegree_WhiteAloneNotHispanicOrLatino_Male
 
   # Education - ACSED5YrSurvey
   - name: "ACSED5YrSurvey: Education SV Aggregation"

--- a/pipeline/workflow/aggregation-helper/aggregation/configs/statvar.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/statvar.yaml
@@ -800,12 +800,13 @@ calculations:
             - dc/qgv9d3frn35qc
             - dc/91vy0sf20wlg9
 
-  # WithOwnChildrenUnder18.
-  - name: "CensusACS5YearSurvey_SubjectTables_S1251: Children & Household SV Aggregation"
+  # WithOwnChildrenUnder18 (Stage 1).
+  - name: "CensusACS5YearSurvey_SubjectTables_S1251: Children & Household SV Aggregation (Stage 1)"
     type: STAT_VAR_AGGREGATION
+    stage: 1
     input_imports:
       - CensusACS5YearSurvey_SubjectTables_S1251
-    output_import: CensusACS5YearSurvey_SubjectTables_S1251_StatVarAgg
+    output_import: CensusACS5YearSurvey_SubjectTables_S1251_Stage1
     stat_var_aggregation:
       aggregations:
         - ancestor_sv_id: Count_Person_WithOwnChildrenUnder18_Female
@@ -816,6 +817,16 @@ calculations:
           source_sv_ids:
             - Count_Person_WithOwnChildrenUnder18_Male_FamilyHousehold_MarriedInThePast12Months_ResidesInHousehold
             - Count_Person_WithOwnChildrenUnder18_Male_FamilyHousehold_DivorcedInThePast12Months_ResidesInHousehold
+
+  # WithOwnChildrenUnder18 (Stage 2).
+  - name: "CensusACS5YearSurvey_SubjectTables_S1251: Children & Household SV Aggregation (Stage 2)"
+    type: STAT_VAR_AGGREGATION
+    stage: 2
+    input_imports:
+      - CensusACS5YearSurvey_SubjectTables_S1251_Stage1
+    output_import: CensusACS5YearSurvey_SubjectTables_S1251_StatVarAgg
+    stat_var_aggregation:
+      aggregations:
         - ancestor_sv_id: Count_Person_WithOwnChildrenUnder18
           source_sv_ids:
             - Count_Person_WithOwnChildrenUnder18_Female
@@ -829,24 +840,28 @@ calculations:
     output_import: CensusACS5YearSurvey_SubjectTables_S1201_StatVarAgg
     stat_var_aggregation:
       aggregations:
-        - ancestor_sv_id: Count_Person_InLaborForce_Divorced
+        - ancestor_sv_id: Count_Person_15OrMoreYears_MarriedAndNotSeparated
           source_sv_ids:
-            - Count_Person_InLaborForce_Female_Divorced
-            - Count_Person_InLaborForce_Male_Divorced
-        - ancestor_sv_id: Count_Person_InLaborForce_NeverMarried
+            - Count_Person_15OrMoreYears_Female_MarriedAndNotSeparated
+            - Count_Person_15OrMoreYears_Male_MarriedAndNotSeparated
+        - ancestor_sv_id: Count_Person_15OrMoreYears_Widowed
           source_sv_ids:
-            - Count_Person_InLaborForce_Female_NeverMarried
-            - Count_Person_InLaborForce_Male_NeverMarried
-        - ancestor_sv_id: Count_Person_InLaborForce_MarriedAndNotSeparated
+            - Count_Person_15OrMoreYears_Female_Widowed
+            - Count_Person_15OrMoreYears_Male_Widowed
+        - ancestor_sv_id: Count_Person_15OrMoreYears_Divorced
           source_sv_ids:
-            - Count_Person_InLaborForce_Female_MarriedAndNotSeparated
-            - Count_Person_InLaborForce_Male_MarriedAndNotSeparated
-        - ancestor_sv_id: Count_Person_InLaborForce_Widowed
+            - Count_Person_15OrMoreYears_Female_Divorced
+            - Count_Person_15OrMoreYears_Male_Divorced
+        - ancestor_sv_id: Count_Person_15OrMoreYears_Separated
           source_sv_ids:
-            - Count_Person_InLaborForce_Female_Widowed
-            - Count_Person_InLaborForce_Male_Widowed
+            - Count_Person_15OrMoreYears_Female_Separated
+            - Count_Person_15OrMoreYears_Male_Separated
+        - ancestor_sv_id: Count_Person_15OrMoreYears_NeverMarried
+          source_sv_ids:
+            - Count_Person_15OrMoreYears_Female_NeverMarried
+            - Count_Person_15OrMoreYears_Male_NeverMarried
 
-  # Employment by business ownership type.
+  # Business Ownership Employment
   - name: "CensusACS5YearSurvey_SubjectTables_S2408: Business Ownership Employment SV Aggregation"
     type: STAT_VAR_AGGREGATION
     input_imports:
@@ -854,21 +869,38 @@ calculations:
     output_import: CensusACS5YearSurvey_SubjectTables_S2408_StatVarAgg
     stat_var_aggregation:
       aggregations:
-        - ancestor_sv_id: Count_Person_PrivatelyOwnedNotForProfitEstablishment_PaidWorker
+        - ancestor_sv_id: Count_Person_16OrMoreYears_PrivateForProfitEmployee
           source_sv_ids:
-            - Count_Person_PrivatelyOwnedNotForProfitEstablishment_Male_PaidWorker
-            - Count_Person_PrivatelyOwnedNotForProfitEstablishment_Female_PaidWorker
-        - ancestor_sv_id: Count_Person_PrivatelyOwnedForProfitEstablishment_PaidWorker
+            - Count_Person_16OrMoreYears_Female_PrivateForProfitEmployee
+            - Count_Person_16OrMoreYears_Male_PrivateForProfitEmployee
+        - ancestor_sv_id: Count_Person_16OrMoreYears_SelfEmployedInOwnIncorporatedBusiness
           source_sv_ids:
-            - Count_Person_PrivatelyOwnedForProfitEstablishment_Male_PaidWorker
-            - Count_Person_PrivatelyOwnedForProfitEstablishment_Female_PaidWorker
+            - Count_Person_16OrMoreYears_Female_SelfEmployedInOwnIncorporatedBusiness
+            - Count_Person_16OrMoreYears_Male_SelfEmployedInOwnIncorporatedBusiness
+        - ancestor_sv_id: Count_Person_16OrMoreYears_PrivateNotForProfitEmployee
+          source_sv_ids:
+            - Count_Person_16OrMoreYears_Female_PrivateNotForProfitEmployee
+            - Count_Person_16OrMoreYears_Male_PrivateNotForProfitEmployee
+        - ancestor_sv_id: Count_Person_16OrMoreYears_LocalGovernmentEmployee
+          source_sv_ids:
+            - Count_Person_16OrMoreYears_Female_LocalGovernmentEmployee
+            - Count_Person_16OrMoreYears_Male_LocalGovernmentEmployee
+        - ancestor_sv_id: Count_Person_16OrMoreYears_StateGovernmentEmployee
+          source_sv_ids:
+            - Count_Person_16OrMoreYears_Female_StateGovernmentEmployee
+            - Count_Person_16OrMoreYears_Male_StateGovernmentEmployee
+        - ancestor_sv_id: Count_Person_16OrMoreYears_FederalGovernmentEmployee
+          source_sv_ids:
+            - Count_Person_16OrMoreYears_Female_FederalGovernmentEmployee
+            - Count_Person_16OrMoreYears_Male_FederalGovernmentEmployee
 
-  # US Citizen by Naturalization
-  - name: "CensusACS5YearSurvey_SubjectTables_S0504: Naturalized Citizenship SV Aggregation"
+  # US Citizen by Naturalization (Stage 1).
+  - name: "CensusACS5YearSurvey_SubjectTables_S0504: Naturalized Citizenship SV Aggregation (Stage 1)"
     type: STAT_VAR_AGGREGATION
+    stage: 1
     input_imports:
       - CensusACS5YearSurvey_SubjectTables_S0504
-    output_import: CensusACS5YearSurvey_SubjectTables_S0504_StatVarAgg
+    output_import: CensusACS5YearSurvey_SubjectTables_S0504_Stage1
     stat_var_aggregation:
       aggregations:
         - ancestor_sv_id: Count_Person_USCitizenByNaturalization_DateOfEntry2000OrLater_ForeignBorn
@@ -985,6 +1017,16 @@ calculations:
             - Count_Person_USCitizenByNaturalization_DateOfEntry1990OrEarlier_ForeignBorn_PlaceOfBirthSouthernEasternEurope
             - Count_Person_USCitizenByNaturalization_DateOfEntry1990OrEarlier_ForeignBorn_PlaceOfBirthWesternAsia
           skip_all_sources_present_check: true
+
+  # US Citizen by Naturalization (Stage 2).
+  - name: "CensusACS5YearSurvey_SubjectTables_S0504: Naturalized Citizenship SV Aggregation (Stage 2)"
+    type: STAT_VAR_AGGREGATION
+    stage: 2
+    input_imports:
+      - CensusACS5YearSurvey_SubjectTables_S0504_Stage1
+    output_import: CensusACS5YearSurvey_SubjectTables_S0504_StatVarAgg
+    stat_var_aggregation:
+      aggregations:
         - ancestor_sv_id: Count_Person_USCitizenByNaturalization
           source_sv_ids:
             - Count_Person_USCitizenByNaturalization_DateOfEntry1990OrEarlier_ForeignBorn

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_aggregator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_aggregator_test.py
@@ -461,6 +461,80 @@ class StatVarAggregatorIntegrationTest(AggregationIntegrationTestBase):
             count = list(snapshot.execute_sql(obs_query))[0][0]
             self.assertEqual(count, 0)
 
+    def test_aggregate_stat_vars_multistage(self):
+        """Tests that a 2-stage stat var aggregation correctly computes intermediate SVs in stage 1 and top-level SVs in stage 2."""
+        import_name = 'S1251_Test'
+        stage1_import_name = f'{import_name}_Stage1'
+        output_import_name = f'{import_name}_StatVarAgg'
+
+        # 1. Setup mock data for 4 raw leaf StatVars
+        self.add_timeseries('SV_Female_Married', 'geoId/06', 'CensusACS5yrSurvey', 'P1Y', '1', '1', import_name)
+        self.add_timeseries('SV_Female_Divorced', 'geoId/06', 'CensusACS5yrSurvey', 'P1Y', '1', '1', import_name)
+        self.add_timeseries('SV_Male_Married', 'geoId/06', 'CensusACS5yrSurvey', 'P1Y', '1', '1', import_name)
+        self.add_timeseries('SV_Male_Divorced', 'geoId/06', 'CensusACS5yrSurvey', 'P1Y', '1', '1', import_name)
+
+        self.add_observation('SV_Female_Married', 'geoId/06', '2020', 10.0, method='CensusACS5yrSurvey', import_name=import_name)
+        self.add_observation('SV_Female_Divorced', 'geoId/06', '2020', 5.0, method='CensusACS5yrSurvey', import_name=import_name)
+        self.add_observation('SV_Male_Married', 'geoId/06', '2020', 20.0, method='CensusACS5yrSurvey', import_name=import_name)
+        self.add_observation('SV_Male_Divorced', 'geoId/06', '2020', 15.0, method='CensusACS5yrSurvey', import_name=import_name)
+
+        self.flush_to_spanner()
+
+        calculations = [
+            {
+                "name": "S1251 Stage 1",
+                "type": "STAT_VAR_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": stage1_import_name,
+                "stat_var_aggregation": {
+                    "aggregations": [
+                        {
+                            "ancestor_sv_id": "SV_Female_Total",
+                            "source_sv_ids": ["SV_Female_Married", "SV_Female_Divorced"],
+                            "skip_all_sources_present_check": False
+                        },
+                        {
+                            "ancestor_sv_id": "SV_Male_Total",
+                            "source_sv_ids": ["SV_Male_Married", "SV_Male_Divorced"],
+                            "skip_all_sources_present_check": False
+                        }
+                    ]
+                }
+            },
+            {
+                "name": "S1251 Stage 2",
+                "type": "STAT_VAR_AGGREGATION",
+                "stage": 2,
+                "input_imports": [stage1_import_name],
+                "output_import": output_import_name,
+                "stat_var_aggregation": {
+                    "aggregations": [
+                        {
+                            "ancestor_sv_id": "SV_TopLevel_Total",
+                            "source_sv_ids": ["SV_Female_Total", "SV_Male_Total"],
+                            "skip_all_sources_present_check": False
+                        }
+                    ]
+                }
+            }
+        ]
+
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
+
+        # 3. Verify in Spanner: SV_TopLevel_Total should exist with aggregated value 50.0 (10 + 5 + 20 + 15)
+        with self.database.snapshot() as snapshot:
+            obs_query = """
+                SELECT variable_measured, entity1, date, value
+                FROM Observation
+                WHERE variable_measured = 'SV_TopLevel_Total'
+            """
+            results = list(snapshot.execute_sql(obs_query))
+            self.assertEqual(len(results), 1)
+            self.assertEqual(float(results[0][3]), 50.0)
+
 
 class StatVarAggregatorCustomDcTest(StatVarAggregatorIntegrationTest):
     is_base_dc = False
+

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_aggregator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_aggregator_test.py
@@ -534,7 +534,58 @@ class StatVarAggregatorIntegrationTest(AggregationIntegrationTestBase):
             self.assertEqual(len(results), 1)
             self.assertEqual(float(results[0][3]), 50.0)
 
+    def test_aggregate_stat_vars_no_orphaned_timeseries(self):
+        """Tests that strict mode (skip_all_sources_present_check=False) produces NO orphaned TimeSeries header rows when observations are dropped."""
+        import_name = 'OrphanTest_Import'
+        output_import_name = f'{import_name}_StatVarAgg'
+
+        # 1. Setup mock TimeSeries headers for 3 source StatVars, but only 2 have observations for geoId/06
+        self.add_timeseries('SV_A', 'geoId/06', 'OrphanMethod', 'P1Y', '1', '1', import_name)
+        self.add_timeseries('SV_B', 'geoId/06', 'OrphanMethod', 'P1Y', '1', '1', import_name)
+        self.add_timeseries('SV_C', 'geoId/06', 'OrphanMethod', 'P1Y', '1', '1', import_name)
+
+        # Only add Observations for SV_A and SV_B (SV_C is missing!)
+        self.add_observation('SV_A', 'geoId/06', '2020', 10.0, method='OrphanMethod', import_name=import_name)
+        self.add_observation('SV_B', 'geoId/06', '2020', 20.0, method='OrphanMethod', import_name=import_name)
+
+        self.flush_to_spanner()
+
+        calculations = [
+            {
+                "name": "Orphan Test Strict Aggregation",
+                "type": "STAT_VAR_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_aggregation": {
+                    "aggregations": [
+                        {
+                            "ancestor_sv_id": "SV_Orphan_Parent",
+                            "source_sv_ids": ["SV_A", "SV_B", "SV_C"],
+                            "skip_all_sources_present_check": False
+                        }
+                    ]
+                }
+            }
+        ]
+
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
+
+        # 3. Verify in Spanner: Since SV_C is missing, strict mode drops Observations.
+        # Confirm BOTH Observation count AND TimeSeries header count for SV_Orphan_Parent are 0 (no orphaned TimeSeries headers!).
+        with self.database.snapshot() as snapshot:
+            obs_query = "SELECT COUNT(*) FROM Observation WHERE variable_measured = 'SV_Orphan_Parent'"
+            obs_count = list(snapshot.execute_sql(obs_query))[0][0]
+            self.assertEqual(obs_count, 0)
+
+        with self.database.snapshot() as snapshot:
+            ts_query = "SELECT COUNT(*) FROM TimeSeries WHERE variable_measured = 'SV_Orphan_Parent'"
+            ts_count = list(snapshot.execute_sql(ts_query))[0][0]
+            self.assertEqual(ts_count, 0)
+
 
 class StatVarAggregatorCustomDcTest(StatVarAggregatorIntegrationTest):
     is_base_dc = False
+
 

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_aggregator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_aggregator_test.py
@@ -415,7 +415,52 @@ class StatVarAggregatorIntegrationTest(AggregationIntegrationTestBase):
             self.assertEqual(obs_row[1], ts_row[1]) # facet_id matches!
             self.assertEqual(float(obs_row[2]), 30.0)
 
+    def test_aggregate_stat_vars_mismatched_units_strict(self):
+        """Tests that source SVs with mismatched units are separated into different facets and dropped in strict mode."""
+        import_name = 'CensusACS5YearSurvey_Test'
+        output_import_name = f'{import_name}_StatVarAgg'
+
+        # 1. Setup mock data: SV_A has unit='USD', SV_B has unit='EUR'
+        self.add_timeseries('SV_A', 'geoId/06', 'CensusACS5yrSurvey', 'P1Y', 'USD', '1', import_name, facet_id='facet_usd')
+        self.add_timeseries('SV_B', 'geoId/06', 'CensusACS5yrSurvey', 'P1Y', 'EUR', '1', import_name, facet_id='facet_eur')
+
+        self.add_observation('SV_A', 'geoId/06', '2020', 10.0, unit='USD', import_name=import_name, facet_id='facet_usd')
+        self.add_observation('SV_B', 'geoId/06', '2020', 20.0, unit='EUR', import_name=import_name, facet_id='facet_eur')
+
+        self.flush_to_spanner()
+
+        calculations = [
+            {
+                "name": "StatVar Aggregation Mismatched Units Strict",
+                "type": "STAT_VAR_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_aggregation": {
+                    "aggregations": [
+                        {
+                            "ancestor_sv_id": "SV_Parent",
+                            "source_sv_ids": ["SV_A", "SV_B"],
+                            "skip_all_sources_present_check": False
+                        }
+                    ]
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
+
+        # 3. Verify in Spanner: Since units don't match, contribution_count for each facet is 1 (instead of 2),
+        # so strict mode drops all observations.
+        with self.database.snapshot() as snapshot:
+            obs_query = """
+                SELECT COUNT(*)
+                FROM Observation
+                WHERE variable_measured = 'SV_Parent'
+            """
+            count = list(snapshot.execute_sql(obs_query))[0][0]
+            self.assertEqual(count, 0)
+
 
 class StatVarAggregatorCustomDcTest(StatVarAggregatorIntegrationTest):
     is_base_dc = False
-

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_aggregator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_aggregator_test.py
@@ -353,6 +353,69 @@ class StatVarAggregatorIntegrationTest(AggregationIntegrationTestBase):
             self.assertEqual(obs_row[4], '2020')
             self.assertEqual(float(obs_row[5]), 30.0)
 
+    def test_aggregate_stat_vars_idempotent_method(self):
+        """Tests that an existing dcAggregate/ prefix in measurementMethod is preserved and not duplicated."""
+        import_name = 'CensusACS5YearSurvey_Test'
+        output_import_name = f'{import_name}_StatVarAgg'
+        prefix = "dc/base/" if self.is_base_dc else ""
+        expected_provenance = f"{prefix}{output_import_name}"
+
+        # 1. Setup mock data with existing dcAggregate/ prefix
+        existing_method = 'dcAggregate/CensusACS5yrSurvey'
+        self.add_timeseries('SV_A', 'geoId/06', existing_method, 'P1Y', '1', '1', import_name)
+        self.add_timeseries('SV_B', 'geoId/06', existing_method, 'P1Y', '1', '1', import_name)
+
+        self.add_observation('SV_A', 'geoId/06', '2020', 10.0, method=existing_method, import_name=import_name)
+        self.add_observation('SV_B', 'geoId/06', '2020', 20.0, method=existing_method, import_name=import_name)
+
+        self.flush_to_spanner()
+
+        calculations = [
+            {
+                "name": "StatVar Aggregation Idempotent Method",
+                "type": "STAT_VAR_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import_name,
+                "stat_var_aggregation": {
+                    "aggregations": [
+                        {
+                            "ancestor_sv_id": "SV_Parent",
+                            "source_sv_ids": ["SV_A", "SV_B"],
+                            "skip_all_sources_present_check": False
+                        }
+                    ]
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations, active_imports=[import_name])
+        self.assertTrue(res.success)
+
+        # 3. Verify results in Spanner: measurementMethod should still be 'dcAggregate/CensusACS5yrSurvey'
+        with self.database.snapshot(multi_use=True) as snapshot:
+            ts_query = """
+                SELECT variable_measured, facet_id, facet
+                FROM TimeSeries
+                WHERE variable_measured = 'SV_Parent'
+            """
+            ts_results = list(snapshot.execute_sql(ts_query))
+            self.assertEqual(len(ts_results), 1)
+            ts_row = ts_results[0]
+            facet_json = ts_row[2]
+            self.assertEqual(facet_json['measurementMethod'], 'dcAggregate/CensusACS5yrSurvey')
+
+            obs_query = """
+                SELECT variable_measured, facet_id, value
+                FROM Observation
+                WHERE variable_measured = 'SV_Parent'
+            """
+            obs_results = list(snapshot.execute_sql(obs_query))
+            self.assertEqual(len(obs_results), 1)
+            obs_row = obs_results[0]
+            self.assertEqual(obs_row[1], ts_row[1]) # facet_id matches!
+            self.assertEqual(float(obs_row[2]), 30.0)
+
 
 class StatVarAggregatorCustomDcTest(StatVarAggregatorIntegrationTest):
     is_base_dc = False
+

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_aggregator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_aggregator.py
@@ -127,7 +127,11 @@ class StatVarAggregator:
             IF(
               JSON_VALUE(facet, '$.measurementMethod') IS NULL OR JSON_VALUE(facet, '$.measurementMethod') = '' OR JSON_VALUE(facet, '$.measurementMethod') = 'DataCommonsAggregate',
               'DataCommonsAggregate',
-              CONCAT('dcAggregate/', JSON_VALUE(facet, '$.measurementMethod'))
+              IF(
+                STARTS_WITH(JSON_VALUE(facet, '$.measurementMethod'), 'dcAggregate/'),
+                JSON_VALUE(facet, '$.measurementMethod'),
+                CONCAT('dcAggregate/', JSON_VALUE(facet, '$.measurementMethod'))
+              )
             )
         """
         facet_expr = f"""
@@ -218,6 +222,18 @@ class StatVarAggregator:
         else:
             filter_condition = f"contribution_count = {len(source_svs)}"
 
+        new_method_sql = """
+            IF(
+              JSON_VALUE(facet, '$.measurementMethod') IS NULL OR JSON_VALUE(facet, '$.measurementMethod') = '' OR JSON_VALUE(facet, '$.measurementMethod') = 'DataCommonsAggregate',
+              'DataCommonsAggregate',
+              IF(
+                STARTS_WITH(JSON_VALUE(facet, '$.measurementMethod'), 'dcAggregate/'),
+                JSON_VALUE(facet, '$.measurementMethod'),
+                CONCAT('dcAggregate/', JSON_VALUE(facet, '$.measurementMethod'))
+              )
+            )
+        """
+
         query = f"""  # nosec
         EXPORT DATA
           OPTIONS( uri="{dest}",
@@ -235,11 +251,7 @@ class StatVarAggregator:
               -- New provenance
               '{safe_output_provenance}', '^',
               -- New measurementMethod
-              IF(
-                JSON_VALUE(facet, '$.measurementMethod') IS NULL OR JSON_VALUE(facet, '$.measurementMethod') = '' OR JSON_VALUE(facet, '$.measurementMethod') = 'DataCommonsAggregate',
-                'DataCommonsAggregate',
-                CONCAT('dcAggregate/', JSON_VALUE(facet, '$.measurementMethod'))
-              ), '^',
+              {new_method_sql}, '^',
               -- Preserved fields
               COALESCE(JSON_VALUE(facet, '$.observationPeriod'), ''), '^',
               COALESCE(JSON_VALUE(facet, '$.scalingFactor'), ''), '^',

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_aggregator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_aggregator.py
@@ -88,7 +88,7 @@ class StatVarAggregator:
 
         # 1. Generate TimeSeries parent query
         ts_query = self._get_timeseries_query(
-            ancestor_sv, source_svs, import_names, output_import_name
+            ancestor_sv, source_svs, import_names, output_import_name, skip_all_sources_present_check
         )
         
         # 2. Generate Observation child query
@@ -107,7 +107,8 @@ class StatVarAggregator:
         ancestor_sv: str,
         source_svs: List[str],
         import_names: List[str],
-        output_import_name: str
+        output_import_name: str,
+        skip_all_sources_present_check: bool
     ) -> str:
         """Creates TimeSeries entries for the ancestor StatVar."""
         dest = self.executor.get_spanner_destination_uri()
@@ -122,6 +123,11 @@ class StatVarAggregator:
         
         output_provenance = get_provenance_name(output_import_name, self.is_base_dc)
         safe_output_provenance = _escape_sql_literal(output_provenance)
+
+        if skip_all_sources_present_check:
+            filter_condition = "TRUE"
+        else:
+            filter_condition = f"contribution_count = {len(source_svs)}"
 
         new_method_sql = """
             IF(
@@ -150,24 +156,49 @@ class StatVarAggregator:
           OPTIONS( uri="{dest}",
             format='CLOUD_SPANNER',
             spanner_options = '{{"table": "TimeSeries"}}' ) AS
-        WITH SourceTS AS (
+        WITH MappedObservations AS (
           SELECT
-            extra_entities_id,
-            -- Stringify JSON columns because BigQuery does not support SELECT DISTINCT on JSON
-            TO_JSON_STRING(entities) as entities_str,
+            o.variable_measured,
+            o.entity1,
+            o.extra_entities_id,
+            o.date,
+            TO_JSON_STRING(o.entities) as entities_str,
             TO_JSON_STRING({facet_expr}) as facet_str
           FROM EXTERNAL_QUERY("{connection_id}",
-            '''SELECT extra_entities_id, entities, facet
-               FROM TimeSeries
-               WHERE variable_measured IN ({sources_str})
-                 AND provenance IN ({imports_str})''')
+            '''SELECT o.variable_measured, o.entity1, o.extra_entities_id, o.date, ts.entities AS entities, ts.facet AS facet
+               FROM Observation o
+               JOIN TimeSeries ts ON o.variable_measured = ts.variable_measured
+                 AND o.entity1 = ts.entity1
+                 AND o.extra_entities_id = ts.extra_entities_id
+                 AND o.facet_id = ts.facet_id
+               WHERE o.variable_measured IN ({sources_str})
+                 AND ts.provenance IN ({imports_str})''') AS o
+        ),
+        AggregatedCounts AS (
+          SELECT
+            entity1,
+            extra_entities_id,
+            entities_str,
+            facet_str,
+            date,
+            COUNT(DISTINCT variable_measured) as contribution_count
+          FROM MappedObservations
+          GROUP BY entity1, extra_entities_id, date, entities_str, facet_str
+        ),
+        ValidFacets AS (
+          SELECT
+            extra_entities_id,
+            entities_str,
+            facet_str
+          FROM AggregatedCounts
+          WHERE {filter_condition}
         ),
         UniqueTS AS (
           SELECT DISTINCT
             extra_entities_id,
             entities_str,
             facet_str
-          FROM SourceTS
+          FROM ValidFacets
         ),
         ParsedTS AS (
           SELECT


### PR DESCRIPTION
This PR fixes a few bugs in statvar aggregation. Most of them were typos and mistakes, that I overlooked while porting:

1. Fixed copy-paste error in `ACSED5YrSurvey` calculation block name and `output_import` in `statvar.yaml`.
2. Made `measurementMethod` prefixing idempotent (`STARTS_WITH(..., 'dcAggregate/')`) in `stat_var_aggregator.py`.
3. Replaced 66 corrupted node IDs (`dc/...`) in Education aggregations with correct StatVar DCIDs in `statvar.yaml`.
4. Fixed mislabeled title for `IndiaNSS_HealthAilments` calculation block in `statvar.yaml`.
5.  Split S1251 and S0504 into `stage: 1` and `stage: 2` multi-stage execution blocks in `statvar.yaml`.
6. Filtered `TimeSeries` headers by observation completeness in `stat_var_aggregator.py` to prevent orphaned headers.
7. Restored `skip_all_sources_present_check: true` for S1251 and S0504 Stage 2 calculations in `statvar.yaml`.

