### PR TITLE
Fix bugs in statvar series aggregation

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/configs/statvar_series.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/statvar_series.yaml
@@ -80,16 +80,31 @@ calculations:
                   - "1990"
                   - "2006"
 
+  - name: "NASA_NEXGDDP_Subnational: Stats Across Models Series Aggregation"
+    type: STAT_VAR_SERIES_AGGREGATION
+    stage: 2
+    input_imports:
+      - NASA_NEXGDDP_Subnational_AggrDiffStats
+    output_import: NASA_NEXGDDP_Subnational_AggrStatsAcrossModels
+    stat_var_series_aggregation:
+      aggr_funcs:
+        - stats_across_models:
+            sv_regex: "^DifferenceRelativeToBaseDate.*"
+            aggregation_ops:
+              - OPERATOR_MEDIAN
+              - OPERATOR_PERCENTILE90
+              - OPERATOR_PERCENTILE10
+
   - name: "NASA_NEXGDDP_CMIP6_Subnational: Stats Across Models Series Aggregation"
     type: STAT_VAR_SERIES_AGGREGATION
     stage: 2
     input_imports:
-      - NASA_NEXGDDP_CMIP6_Subnational
+      - NASA_NEXGDDP_CMIP6_Subnational_AggrDiffStats
     output_import: NASA_NEXGDDP_CMIP6_Subnational_AggrStatsAcrossModels
     stat_var_series_aggregation:
       aggr_funcs:
         - stats_across_models:
-            sv_regex: "^DifferenceRelativeToObservationalData_.*"
+            sv_regex: "^DifferenceRelativeToBaseDate.*"
             aggregation_ops:
               - OPERATOR_MEDIAN
               - OPERATOR_PERCENTILE90
@@ -99,12 +114,12 @@ calculations:
     type: STAT_VAR_SERIES_AGGREGATION
     stage: 2
     input_imports:
-      - NASA_NEXGDDP_CMIP6_IpccPlaces50
+      - NASA_NEXGDDP_CMIP6_IpccPlaces50_AggrDiffStats
     output_import: NASA_NEXGDDP_CMIP6_IpccPlaces50_AggrStatsAcrossModels
     stat_var_series_aggregation:
       aggr_funcs:
         - stats_across_models:
-            sv_regex: "^DifferenceRelativeToObservationalData_.*"
+            sv_regex: "^DifferenceRelativeToBaseDate.*"
             aggregation_ops:
               - OPERATOR_MEDIAN
               - OPERATOR_PERCENTILE90

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_series_aggregator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_series_aggregator_test.py
@@ -130,12 +130,12 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
             ts_diff_query = """
                 SELECT facet_id, facet
                 FROM TimeSeries
-                WHERE variable_measured = 'DifferenceAcrossModels_Max_Temperature'
+                WHERE variable_measured = 'MaxDiffAcrossMeasurementMethods_Max_Temperature'
             """
             ts_diff_results = list(snapshot.execute_sql(ts_diff_query))
             self.assertEqual(len(ts_diff_results), 1)
             self.assertEqual(ts_diff_results[0][1]['provenance'], r1_expected_provenance)
-            self.assertEqual(ts_diff_results[0][1]['measurementMethod'], 'dcAggregate/DifferenceAcrossModels')
+            self.assertEqual(ts_diff_results[0][1]['measurementMethod'], 'dcAggregate/MaxDiffAcrossMeasurementMethods')
 
             # Verify TimeSeries for DifferenceRelativeToBaseDate
             ts_rel_query = """
@@ -150,7 +150,7 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
             obs_diff_query = """
                 SELECT value
                 FROM Observation
-                WHERE variable_measured = 'DifferenceAcrossModels_Max_Temperature'
+                WHERE variable_measured = 'MaxDiffAcrossMeasurementMethods_Max_Temperature'
                   AND date = '2050-07'
             """
             obs_diff_results = list(snapshot.execute_sql(obs_diff_query))
@@ -361,6 +361,55 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
         # 2050-07-15 -> year 2050, month 7
         self.assertEqual(row['y4'], 2050)
         self.assertEqual(row['m4'], 7)
+
+    def test_max_diff_across_measurement_methods(self):
+        """Tests max_diff_across_measurement_methods aggregation."""
+        import_name = 'NASA_NEXGDDP_Test_MaxDiff'
+        output_import = f'{import_name}_AggrMaxDiff'
+        place_id = 'geoId/5363000'
+
+        # Two observations for the same date across 2 measurement methods (Model_A = 30.0, Model_B = 35.0) -> max diff = 5.0
+        self.add_observation('Max_Temperature', place_id, '2050-07', 30.0, method='Model_A', import_name=import_name, facet_id='facet_a')
+        self.add_observation('Max_Temperature', place_id, '2050-07', 35.0, method='Model_B', import_name=import_name, facet_id='facet_b')
+
+        self.flush_to_spanner()
+
+        calculations_config = [
+            {
+                "name": "Max Diff Across Measurement Methods Aggregation",
+                "type": "STAT_VAR_SERIES_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import,
+                "stat_var_series_aggregation": {
+                    "aggr_funcs": [
+                        {"max_diff_across_measurement_methods": {}}
+                    ]
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
+
+        with self.database.snapshot(multi_use=True) as snapshot:
+            obs_query = """
+                SELECT value
+                FROM Observation
+                WHERE variable_measured = 'MaxDiffAcrossMeasurementMethods_Max_Temperature'
+                  AND date = '2050-07'
+            """
+            obs_results = list(snapshot.execute_sql(obs_query))
+            self.assertEqual(len(obs_results), 1)
+            self.assertEqual(float(obs_results[0][0]), 5.0)
+
+            ts_query = """
+                SELECT variable_measured, JSON_VALUE(facet, '$.measurementMethod')
+                FROM TimeSeries
+                WHERE variable_measured = 'MaxDiffAcrossMeasurementMethods_Max_Temperature'
+            """
+            ts_results = list(snapshot.execute_sql(ts_query))
+            self.assertEqual(len(ts_results), 1)
+            self.assertEqual(ts_results[0][1], 'dcAggregate/MaxDiffAcrossMeasurementMethods')
 
     def test_temporal_aggregation(self):
         """Tests temporal aggregation (aggr_over_time): daily to monthly/yearly."""

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_series_aggregator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_series_aggregator_test.py
@@ -264,8 +264,69 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
                   AND date = '2050-07'
             """
             obs_results = list(snapshot.execute_sql(obs_query))
-            self.assertEqual(len(obs_results), 1)
+            self.assertEqual(obs_results[0][0], '3.0')
             self.assertEqual(float(obs_results[0][0]), 3.0)
+
+    def test_multiyear_window_date_filtering(self):
+        """Tests aggr_over_time with multi-year period (P10Y) and output_obs_date ('2030').
+
+        Verifies that observations outside the window [2021, 2030] (e.g. 2010) are EXCLUDED.
+        """
+        import_name = 'NASA_NEXGDDP_Test_Window'
+        output_import = f'{import_name}_AggrWindow'
+        place_id = 'geoId/5363000'
+
+        # Outside window (year 2010): value = 100.0 (should be EXCLUDED)
+        self.add_observation('Max_Temperature', place_id, '2010-05', 100.0, method='Model_A', period='P1M', import_name=import_name, facet_id='facet_a')
+
+        # Inside window [2021, 2030]
+        self.add_observation('Max_Temperature', place_id, '2025-05', 50.0, method='Model_A', period='P1M', import_name=import_name, facet_id='facet_a')
+        self.add_observation('Max_Temperature', place_id, '2028-05', 80.0, method='Model_A', period='P1M', import_name=import_name, facet_id='facet_a')
+
+        self.flush_to_spanner()
+
+        calculations_config = [
+            {
+                "name": "P10Y Window Series Aggregation",
+                "type": "STAT_VAR_SERIES_AGGREGATION",
+                "stage": 3,
+                "input_imports": [import_name],
+                "output_import": output_import,
+                "stat_var_series_aggregation": {
+                    "aggr_funcs": [
+                        {
+                            "aggr_over_time": {
+                                "time_range": {
+                                    "input_obs_period": "P1M",
+                                    "output_obs_period": "P10Y",
+                                    "output_obs_date": "2030"
+                                },
+                                "sv_configs": [
+                                    {
+                                        "aggregation_op": "MAX",
+                                        "use_input_sv_for_output": True
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
+
+        with self.database.snapshot(multi_use=True) as snapshot:
+            obs_query = """
+                SELECT value
+                FROM Observation
+                WHERE variable_measured = 'Max_Temperature'
+                  AND date = '2030'
+            """
+            obs_results = list(snapshot.execute_sql(obs_query))
+            self.assertEqual(len(obs_results), 1)
+            # Must be MAX(50.0, 80.0) = 80.0, excluding 100.0 from 2010
+            self.assertEqual(float(obs_results[0][0]), 80.0)
 
     def test_temporal_aggregation(self):
         """Tests temporal aggregation (aggr_over_time): daily to monthly/yearly."""

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_series_aggregator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_series_aggregator_test.py
@@ -221,6 +221,52 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
             self.assertEqual(obs_ensemble_results[2][0], 'Percentile90AcrossModels_DifferenceRelativeToBaseDate201507_Max_Temperature')
             self.assertEqual(float(obs_ensemble_results[2][1]), 4.0)
 
+    def test_4digit_base_year_matching(self):
+        """Tests diff_relative_to_base_date with a 4-digit base year (e.g. '2015') matching monthly dates ('2015-07')."""
+        import_name = 'NASA_NEXGDDP_Test_BaseYear'
+        output_import = f'{import_name}_AggrBaseYear'
+        place_id = 'geoId/5363000'
+
+        # Baseline monthly observation in 2015-07 (base year '2015')
+        self.add_observation('Max_Temperature', place_id, '2015-07', 30.0, method='Model_A', import_name=import_name, facet_id='facet_a')
+
+        # Projection monthly observation in 2050-07 -> 33 - 30 = 3.0
+        self.add_observation('Max_Temperature', place_id, '2050-07', 33.0, method='Model_A', import_name=import_name, facet_id='facet_a')
+
+        self.flush_to_spanner()
+
+        calculations_config = [
+            {
+                "name": "Base Year 4-Digit Series Aggregation",
+                "type": "STAT_VAR_SERIES_AGGREGATION",
+                "stage": 1,
+                "input_imports": [import_name],
+                "output_import": output_import,
+                "stat_var_series_aggregation": {
+                    "aggr_funcs": [
+                        {
+                            "diff_relative_to_base_date": {
+                                "dates": ["2015"]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+        res = self.run_orchestrator(calculations=calculations_config, active_imports=[import_name])
+        self.assertTrue(res.success)
+
+        with self.database.snapshot(multi_use=True) as snapshot:
+            obs_query = """
+                SELECT value
+                FROM Observation
+                WHERE variable_measured = 'DifferenceRelativeToBaseDate2015_Max_Temperature'
+                  AND date = '2050-07'
+            """
+            obs_results = list(snapshot.execute_sql(obs_query))
+            self.assertEqual(len(obs_results), 1)
+            self.assertEqual(float(obs_results[0][0]), 3.0)
+
     def test_temporal_aggregation(self):
         """Tests temporal aggregation (aggr_over_time): daily to monthly/yearly."""
         import_name = 'NASA_NEXGDDP_Test_Temporal'

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_series_aggregator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_series_aggregator_test.py
@@ -264,7 +264,7 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
                   AND date = '2050-07'
             """
             obs_results = list(snapshot.execute_sql(obs_query))
-            self.assertEqual(obs_results[0][0], '3.0')
+            self.assertEqual(len(obs_results), 1)
             self.assertEqual(float(obs_results[0][0]), 3.0)
 
     def test_multiyear_window_date_filtering(self):
@@ -327,6 +327,40 @@ class StatVarSeriesAggregatorIntegrationTest(AggregationIntegrationTestBase):
             self.assertEqual(len(obs_results), 1)
             # Must be MAX(50.0, 80.0) = 80.0, excluding 100.0 from 2010
             self.assertEqual(float(obs_results[0][0]), 80.0)
+
+    def test_temp_functions_runtime(self):
+        """Directly tests ExtractYear and ExtractMonth TEMP functions in BigQuery runtime."""
+        from aggregation.stat_var_series_aggregator import get_extract_year_sql, get_extract_month_sql
+
+        query = f"""
+        {get_extract_year_sql()}
+        {get_extract_month_sql()}
+
+        SELECT
+          ExtractYear('2015') AS y1, ExtractMonth('2015') AS m1,
+          ExtractYear('2015-07') AS y2, ExtractMonth('2015-07') AS m2,
+          ExtractYear('2050-12') AS y3, ExtractMonth('2050-12') AS m3,
+          ExtractYear('2050-07-15') AS y4, ExtractMonth('2050-07-15') AS m4
+        """
+        results = list(self.bq_client.query(query).result())
+        self.assertEqual(len(results), 1)
+        row = results[0]
+
+        # 2015 -> year 2015, month 0
+        self.assertEqual(row['y1'], 2015)
+        self.assertEqual(row['m1'], 0)
+
+        # 2015-07 -> year 2015, month 7
+        self.assertEqual(row['y2'], 2015)
+        self.assertEqual(row['m2'], 7)
+
+        # 2050-12 -> year 2050, month 12
+        self.assertEqual(row['y3'], 2050)
+        self.assertEqual(row['m3'], 12)
+
+        # 2050-07-15 -> year 2050, month 7
+        self.assertEqual(row['y4'], 2050)
+        self.assertEqual(row['m4'], 7)
 
     def test_temporal_aggregation(self):
         """Tests temporal aggregation (aggr_over_time): daily to monthly/yearly."""

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_series_aggregator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_series_aggregator.py
@@ -31,6 +31,30 @@ class StatVarSeriesAggregationConfig:
     calculations: List[Dict[str, Any]]
 
 
+def get_extract_year_sql() -> str:
+    """Returns the SQL definition for the ExtractYear TEMP function."""
+    return """
+CREATE TEMP FUNCTION ExtractYear(d STRING) AS (
+  COALESCE(
+    EXTRACT(YEAR FROM SAFE.PARSE_DATE('%Y-%m-%d', d)),
+    EXTRACT(YEAR FROM SAFE.PARSE_DATE('%Y-%m', d)),
+    EXTRACT(YEAR FROM SAFE.PARSE_DATE('%Y', d))
+  )
+);"""
+
+
+def get_extract_month_sql() -> str:
+    """Returns the SQL definition for the ExtractMonth TEMP function."""
+    return """
+CREATE TEMP FUNCTION ExtractMonth(d STRING) AS (
+  COALESCE(
+    EXTRACT(MONTH FROM SAFE.PARSE_DATE('%Y-%m-%d', d)),
+    EXTRACT(MONTH FROM SAFE.PARSE_DATE('%Y-%m', d))
+  )
+);"""
+
+
+
 class StatVarSeriesAggregator:
     """Orchestrates StatVar Series Aggregations.
 
@@ -212,11 +236,6 @@ class StatVarSeriesAggregator:
                 cte_idx = len(ts_ctes)
                 safe_base_date = _escape_sql_literal(base_date)
                 clean_date_suffix = safe_base_date.replace("-", "")
-                
-                if len(safe_base_date) == 4:
-                    base_filter = f"(date = '{safe_base_date}' OR SUBSTR(date, 1, 4) = '{safe_base_date}')"
-                else:
-                    base_filter = f"date = '{safe_base_date}'"
 
                 ts_cte = f"""
                 DiffRelTS_{cte_idx} AS (
@@ -245,10 +264,10 @@ class StatVarSeriesAggregator:
                     extra_entities_id,
                     model,
                     val_num AS base_val,
-                    SUBSTR(date, 1, 4) AS base_year,
-                    SUBSTR(date, 6, 2) AS base_month
+                    ExtractYear(date) AS base_year,
+                    ExtractMonth(date) AS base_month
                   FROM RawObs
-                  WHERE {base_filter}
+                  WHERE ExtractYear(date) = ExtractYear('{safe_base_date}')
                 ),
                 DiffRelObs_{cte_idx} AS (
                   SELECT
@@ -271,8 +290,8 @@ class StatVarSeriesAggregator:
                     AND r.variable_measured = b.variable_measured 
                     AND r.model = b.model
                     AND r.facet_id = b.facet_id
-                    AND SUBSTR(r.date, 6, 2) = b.base_month
-                    AND SUBSTR(r.date, 1, 4) > b.base_year
+                    AND ExtractMonth(r.date) = b.base_month
+                    AND ExtractYear(r.date) > b.base_year
                 )
                 """
                 obs_ctes.append(obs_cte)
@@ -311,9 +330,9 @@ class StatVarSeriesAggregator:
                     extra_entities_id,
                     model,
                     AVG(val_num) AS base_val,
-                    SUBSTR(date, 6, 2) AS base_month
+                    ExtractMonth(date) AS base_month
                   FROM RawObs
-                  WHERE date BETWEEN '{safe_start}' AND '{safe_end}'
+                  WHERE ExtractYear(date) BETWEEN ExtractYear('{safe_start}') AND ExtractYear('{safe_end}')
                   GROUP BY facet_id, variable_measured, entity1, extra_entities_id, model, base_month
                 ),
                 DiffRelRangeObs_{cte_idx} AS (
@@ -337,8 +356,8 @@ class StatVarSeriesAggregator:
                     AND r.variable_measured = b.variable_measured 
                     AND r.model = b.model
                     AND r.facet_id = b.facet_id
-                    AND SUBSTR(r.date, 6, 2) = b.base_month
-                    AND SUBSTR(r.date, 1, 4) > SUBSTR('{safe_end}', 1, 4)
+                    AND ExtractMonth(r.date) = b.base_month
+                    AND ExtractYear(r.date) > ExtractYear('{safe_end}')
                 )
                 """
                 obs_ctes.append(obs_cte)
@@ -754,33 +773,44 @@ class StatVarSeriesAggregator:
         obs_final_select = "\nUNION ALL\n".join(obs_union_targets)
 
         # Source filtering for Observations (Step 2)
-        obs_exclude_filter = ""
+        obs_exclude_filter_spanner = ""
         if has_stats_models:
-            obs_exclude_filter = "WHERE NOT variable_measured LIKE 'DifferenceAcrossModels_%'"
+            obs_exclude_filter_spanner = "AND NOT o.variable_measured LIKE 'DifferenceAcrossModels_%'"
 
         obs_query = f"""
+{get_extract_year_sql()}
+{get_extract_month_sql()}
+
         EXPORT DATA
           OPTIONS( uri="{dest}",
             format='CLOUD_SPANNER',
             spanner_options = '{{"table": "Observation"}}' ) AS
         WITH RawObs AS (
           SELECT 
-            o.variable_measured, 
-            o.entity1, 
-            o.extra_entities_id, 
-            o.date, 
-            SAFE_CAST(o.value AS FLOAT64) AS val_num,
-            ts.facet,
-            ts.facet_id,
-            COALESCE(JSON_VALUE(ts.facet, '$.measurementMethod'), '') AS model
+            variable_measured, 
+            entity1, 
+            extra_entities_id, 
+            date, 
+            SAFE_CAST(value AS FLOAT64) AS val_num,
+            facet,
+            facet_id,
+            COALESCE(JSON_VALUE(facet, '$.measurementMethod'), '') AS model
           FROM EXTERNAL_QUERY("{connection_id}",
-            '''SELECT variable_measured, entity1, extra_entities_id, facet_id, date, value 
-               FROM Observation {obs_exclude_filter} ''') o
-          JOIN EXTERNAL_QUERY("{connection_id}",
-            '''SELECT variable_measured, entity1, extra_entities_id, facet_id, facet 
-               FROM TimeSeries 
-               WHERE provenance IN ({input_provenance_str})''') ts
-            ON o.variable_measured = ts.variable_measured AND o.entity1 = ts.entity1 AND o.facet_id = ts.facet_id AND o.extra_entities_id = ts.extra_entities_id
+            '''SELECT 
+                 o.variable_measured, 
+                 o.entity1, 
+                 o.extra_entities_id, 
+                 o.facet_id, 
+                 o.date, 
+                 o.value,
+                 ts.facet
+               FROM Observation o
+               JOIN TimeSeries ts
+                 ON o.variable_measured = ts.variable_measured 
+                AND o.entity1 = ts.entity1 
+                AND o.extra_entities_id = ts.extra_entities_id 
+                AND o.facet_id = ts.facet_id
+               WHERE ts.provenance IN ({input_provenance_str}) {obs_exclude_filter_spanner} ''')
         ),
         {obs_ctes_combined}
         {obs_final_select};

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_series_aggregator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_series_aggregator.py
@@ -213,6 +213,11 @@ class StatVarSeriesAggregator:
                 safe_base_date = _escape_sql_literal(base_date)
                 clean_date_suffix = safe_base_date.replace("-", "")
                 
+                if len(safe_base_date) == 4:
+                    base_filter = f"(date = '{safe_base_date}' OR SUBSTR(date, 1, 4) = '{safe_base_date}')"
+                else:
+                    base_filter = f"date = '{safe_base_date}'"
+
                 ts_cte = f"""
                 DiffRelTS_{cte_idx} AS (
                   SELECT DISTINCT
@@ -240,10 +245,10 @@ class StatVarSeriesAggregator:
                     extra_entities_id,
                     model,
                     val_num AS base_val,
-                    date AS base_date,
+                    SUBSTR(date, 1, 4) AS base_year,
                     SUBSTR(date, 6, 2) AS base_month
                   FROM RawObs
-                  WHERE date = '{safe_base_date}'
+                  WHERE {base_filter}
                 ),
                 DiffRelObs_{cte_idx} AS (
                   SELECT
@@ -267,7 +272,7 @@ class StatVarSeriesAggregator:
                     AND r.model = b.model
                     AND r.facet_id = b.facet_id
                     AND SUBSTR(r.date, 6, 2) = b.base_month
-                    AND SUBSTR(r.date, 1, 4) > SUBSTR(b.base_date, 1, 4)
+                    AND SUBSTR(r.date, 1, 4) > b.base_year
                 )
                 """
                 obs_ctes.append(obs_cte)

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_series_aggregator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_series_aggregator.py
@@ -35,11 +35,7 @@ def get_extract_year_sql() -> str:
     """Returns the SQL definition for the ExtractYear TEMP function."""
     return """
 CREATE TEMP FUNCTION ExtractYear(d STRING) AS (
-  COALESCE(
-    EXTRACT(YEAR FROM SAFE.PARSE_DATE('%Y-%m-%d', d)),
-    EXTRACT(YEAR FROM SAFE.PARSE_DATE('%Y-%m', d)),
-    EXTRACT(YEAR FROM SAFE.PARSE_DATE('%Y', d))
-  )
+  SAFE_CAST(SUBSTR(d, 1, 4) AS INT64)
 );"""
 
 
@@ -48,8 +44,8 @@ def get_extract_month_sql() -> str:
     return """
 CREATE TEMP FUNCTION ExtractMonth(d STRING) AS (
   COALESCE(
-    EXTRACT(MONTH FROM SAFE.PARSE_DATE('%Y-%m-%d', d)),
-    EXTRACT(MONTH FROM SAFE.PARSE_DATE('%Y-%m', d))
+    SAFE_CAST(SUBSTR(d, 6, 2) AS INT64),
+    0
   )
 );"""
 
@@ -230,7 +226,10 @@ class StatVarSeriesAggregator:
               'true'
             )) AS STRING) AS facet_id
           FROM RawObs
-          GROUP BY entity1, extra_entities_id, variable_measured, date
+          GROUP BY entity1, extra_entities_id, variable_measured, date,
+                   COALESCE(JSON_VALUE(facet, '$.observationPeriod'), ''),
+                   COALESCE(JSON_VALUE(facet, '$.scalingFactor'), ''),
+                   COALESCE(JSON_VALUE(facet, '$.unit'), '')
           HAVING COUNT(DISTINCT model) >= 2
         )
         """
@@ -620,6 +619,7 @@ class StatVarSeriesAggregator:
             cte_idx = len(ts_ctes)
             regex_filter_ts = f"AND REGEXP_CONTAINS(variable_measured, r'^{sv_regex}$')" if sv_regex else ""
             regex_filter_obs = f"AND REGEXP_CONTAINS(variable_measured, r'^{sv_regex}$')" if sv_regex else ""
+            unit_filter = f"AND COALESCE(JSON_VALUE(facet, '$.unit'), '') = '{_escape_sql_literal(unit)}'" if unit else ""
 
             # TimeSeries Metadata CTE (removes unit, updates period and provenance)
             ts_cte = f"""
@@ -660,7 +660,7 @@ class StatVarSeriesAggregator:
                 )) AS STRING) AS facet_id
               FROM RawObs
               WHERE COALESCE(JSON_VALUE(facet, '$.observationPeriod'), '') = '{input_period}'
-                {regex_filter_obs} {date_window_filter}
+                {unit_filter} {regex_filter_obs} {date_window_filter}
               GROUP BY entity1, extra_entities_id, variable_measured, model {group_by_date}
               HAVING SUM(CASE WHEN val_num {sql_comp} {threshold} THEN 1 ELSE 0 END) > 0
             )
@@ -720,7 +720,14 @@ class StatVarSeriesAggregator:
             extra_entities_id,
             SAFE.PARSE_JSON(facet_str) AS facet
           FROM (
-            {ts_union_select}
+            SELECT DISTINCT
+              variable_measured,
+              entity1,
+              extra_entities_id,
+              facet_str
+            FROM (
+              {ts_union_select}
+            )
           )
         )
         """

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_series_aggregator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_series_aggregator.py
@@ -54,6 +54,24 @@ CREATE TEMP FUNCTION ExtractMonth(d STRING) AS (
 );"""
 
 
+def _get_time_window_filter_sql(output_obs_date: Optional[str], output_obs_period: Optional[str]) -> str:
+    """Computes SQL WHERE clause filter for multi-year output periods (e.g. P10Y, P30Y, P80Y)."""
+    if not output_obs_date or not output_obs_period:
+        return ""
+
+    if len(output_obs_date) == 4 and output_obs_date.isdigit():
+        end_year = int(output_obs_date)
+        if output_obs_period.startswith("P") and output_obs_period.endswith("Y"):
+            period_num_str = output_obs_period[1:-1]
+            if period_num_str.isdigit():
+                num_years = int(period_num_str)
+                start_year = end_year - num_years + 1
+                return f"AND ExtractYear(date) BETWEEN {start_year} AND {end_year}"
+
+    return ""
+
+
+
 
 class StatVarSeriesAggregator:
     """Orchestrates StatVar Series Aggregations.
@@ -471,6 +489,7 @@ class StatVarSeriesAggregator:
                 op_name = "AggregateSum"
 
             # Determine date binning expression based on target period
+            date_window_filter = _get_time_window_filter_sql(output_obs_date, output_period)
             if output_obs_date:
                 date_bin_expr = f"'{_escape_sql_literal(output_obs_date)}'"
                 group_by_date = ""
@@ -533,7 +552,7 @@ class StatVarSeriesAggregator:
                   'true'
                 )) AS STRING) AS facet_id
               FROM RawObs
-              WHERE {period_filter} {regex_filter_obs}
+              WHERE {period_filter} {regex_filter_obs} {date_window_filter}
               GROUP BY entity1, extra_entities_id, variable_measured, model {group_by_date}
             )
             """
@@ -585,6 +604,7 @@ class StatVarSeriesAggregator:
             sql_comp = ">=" if is_ge else "<="
 
             # Determine date binning and output date
+            date_window_filter = _get_time_window_filter_sql(output_obs_date, output_period)
             if output_obs_date:
                 date_expr = f"'{_escape_sql_literal(output_obs_date)}'"
                 group_by_date = ""
@@ -640,7 +660,7 @@ class StatVarSeriesAggregator:
                 )) AS STRING) AS facet_id
               FROM RawObs
               WHERE COALESCE(JSON_VALUE(facet, '$.observationPeriod'), '') = '{input_period}'
-                {regex_filter_obs}
+                {regex_filter_obs} {date_window_filter}
               GROUP BY entity1, extra_entities_id, variable_measured, model {group_by_date}
               HAVING SUM(CASE WHEN val_num {sql_comp} {threshold} THEN 1 ELSE 0 END) > 0
             )

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_series_aggregator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_series_aggregator.py
@@ -194,13 +194,13 @@ class StatVarSeriesAggregator:
         ts_cte = f"""
         DiffAcrossModelsTS AS (
           SELECT DISTINCT
-            CONCAT('DifferenceAcrossModels_', variable_measured) AS variable_measured,
+            CONCAT('MaxDiffAcrossMeasurementMethods_', variable_measured) AS variable_measured,
             entity1,
             extra_entities_id,
             TO_JSON_STRING(JSON_SET(
               JSON_SET(
                 JSON_SET(facet, '$.provenance', '{output_provenance}'),
-                '$.measurementMethod', 'dcAggregate/DifferenceAcrossModels'
+                '$.measurementMethod', 'dcAggregate/MaxDiffAcrossMeasurementMethods'
               ),
               '$.isDcAggregate', true
             )) AS facet_str
@@ -212,14 +212,14 @@ class StatVarSeriesAggregator:
         obs_cte = f"""
         MaxDiffObs AS (
           SELECT
-            CONCAT('DifferenceAcrossModels_', variable_measured) AS variable_measured,
+            CONCAT('MaxDiffAcrossMeasurementMethods_', variable_measured) AS variable_measured,
             entity1,
             extra_entities_id,
             date,
             MAX(val_num) - MIN(val_num) AS val,
             CAST(FARM_FINGERPRINT(CONCAT(
               '{output_provenance}', '^',
-              'dcAggregate/DifferenceAcrossModels', '^',
+              'dcAggregate/MaxDiffAcrossMeasurementMethods', '^',
               COALESCE(JSON_VALUE(ANY_VALUE(facet), '$.observationPeriod'), ''), '^',
               COALESCE(JSON_VALUE(ANY_VALUE(facet), '$.scalingFactor'), ''), '^',
               COALESCE(JSON_VALUE(ANY_VALUE(facet), '$.unit'), ''), '^',
@@ -737,7 +737,7 @@ class StatVarSeriesAggregator:
         if has_stats_models:
             # Stats across models consumes the output of Round 1, but we must ignore
             # DifferenceAcrossModels which doesn't have multiple models to aggregate
-            ts_exclude_filter = "AND NOT variable_measured LIKE 'DifferenceAcrossModels_%'"
+            ts_exclude_filter = "AND NOT variable_measured LIKE 'MaxDiffAcrossMeasurementMethods_%'"
 
         ts_query = f"""
         EXPORT DATA
@@ -802,7 +802,7 @@ class StatVarSeriesAggregator:
         # Source filtering for Observations (Step 2)
         obs_exclude_filter_spanner = ""
         if has_stats_models:
-            obs_exclude_filter_spanner = "AND NOT o.variable_measured LIKE 'DifferenceAcrossModels_%'"
+            obs_exclude_filter_spanner = "AND NOT o.variable_measured LIKE 'MaxDiffAcrossMeasurementMethods_%'"
 
         obs_query = f"""
 {get_extract_year_sql()}

--- a/pipeline/workflow/aggregation-helper/aggregation/validator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/validator_test.py
@@ -320,6 +320,21 @@ class TestValidatorErrorsAndFileSystem(unittest.TestCase):
             validate_config(self.config_path, "non_existent_schema.json")
         self.assertIn("JSON Schema file not found", str(ctx.exception))
 
+    def test_validate_production_configs(self):
+        """Verifies that all production aggregation config YAML files in configs/ pass validation."""
+        configs_dir = os.path.join(os.path.dirname(__file__), "configs")
+        yaml_files = [
+            os.path.join(configs_dir, f)
+            for f in os.listdir(configs_dir)
+            if f.endswith(".yaml") or f.endswith(".yml")
+        ]
+        self.assertGreater(len(yaml_files), 0, "No production config YAML files found to test.")
+        for config_file in yaml_files:
+            with self.subTest(config_file=os.path.basename(config_file)):
+                calculations = validate_config(config_file, self.schema_path)
+                self.assertIsInstance(calculations, list)
+                self.assertGreater(len(calculations), 0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes a few bugs in the statvar series aggregations:

1. **Missing Date Window Filter:** Added ISO duration (`P10Y`/`P30Y`/`P80Y`) time-window filtering to `aggr_over_time` and `count_threshold_exception_over_time` queries.
2. **Single Base Date Equality Matching:** Replaced exact string equality (`date = '2015'`) with `ExtractYear(date)` matching so 4-digit base years correctly match monthly `'YYYY-MM'` observations.
3. **Base Date Range Lexicographical Comparison:** Replaced string range comparison (`date >= '2006' AND date <= '2020'`) with SQL year extraction (`ExtractYear(date) BETWEEN ...`) so end-year months are not omitted.
4. **Configuration Typo in statvar_series.yaml:** Corrected broken `input_imports` and `sv_regex` in a multi-stage aggregation configuration that  previously resulted in zero output rows.
5. **Duplicate TimeSeries Rows:** Added string-level `SELECT DISTINCT` deduplication before JSON parsing to prevent Spanner and BigQuery duplicate metadata errors.
6. **Measurement Method String Mismatch:** Updated variable prefixes and measurement method strings in `max_diff_across_measurement_methods` to match Flume calculation's parity (`MaxDiffAcrossMeasurementMethods`).
7. **Incomplete SQL GROUP BY in MaxDiffObs:** Included `observationPeriod`, `scalingFactor`, and `unit` in the `GROUP BY` clause to prevent incorrect calculations across mixed units or periods.
8. **Missing unit Filter in Threshold Evaluation:** Added optional unit filtering in `count_threshold_exception_over_time` to ensure threshold comparisons only match identical units.
