### PR TITLE
Support all-provenance StatVarGroup generation and scoped deletions

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/aggregation_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/aggregation_test.py
@@ -427,11 +427,15 @@ class TestStatVarGroupGenerator(unittest.TestCase):
         self.mock_executor.connection_id = "test-conn"
         self.mock_executor.get_spanner_destination_uri.return_value = "spanner-uri"
 
-    def test_run_all_empty(self):
+    def test_run_all(self):
         generator = StatVarGroupGenerator(self.mock_executor)
-        jobs = generator.run_all(StatVarGroupConfig(import_names=[]))
-        self.assertEqual(jobs, [])
-        self.mock_executor.execute.assert_not_called()
+        mock_prep_job = [MagicMock(object_id="gender"), MagicMock(object_id="age")]
+        mock_exec_job = MagicMock()
+        self.mock_executor.execute.side_effect = [mock_prep_job, mock_exec_job]
+
+        jobs = generator.run_all()
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(self.mock_executor.execute.call_count, 2)
 
     def test_run_stat_var_group(self):
         generator = StatVarGroupGenerator(self.mock_executor, is_base_dc=True, should_prune_single_child_svgs=True)
@@ -439,14 +443,14 @@ class TestStatVarGroupGenerator(unittest.TestCase):
         mock_exec_job = MagicMock()
         self.mock_executor.execute.side_effect = [mock_prep_job, mock_exec_job]
 
-        jobs = generator.run_all(StatVarGroupConfig(import_names=["import1"]))
+        job = generator.run_stat_var_group()
 
-        self.assertEqual(len(jobs), 1)
         self.assertEqual(self.mock_executor.execute.call_count, 2)
         query = self.mock_executor.execute.call_args[0][0]
         self.assertIn("PrunableSVGs", query)
         self.assertIn("EffectiveParent", query)
         self.assertIn("HAVING COUNT(DISTINCT pc.child) <= 1", query)
+        self.assertIn("generated_provenance_prefix", query)
 
 
 if __name__ == '__main__':

--- a/pipeline/workflow/aggregation-helper/aggregation/configs/common.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/common.yaml
@@ -18,5 +18,5 @@ calculations:
     type: STAT_VAR_GROUPS
     stage: 0
     input_imports:
-      - "*"
+      - "schema"
 

--- a/pipeline/workflow/aggregation-helper/aggregation/deleter.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/deleter.py
@@ -19,7 +19,7 @@ import logging
 from typing import List
 from google.cloud import spanner
 
-from .common import get_provenance_name
+from .common import get_provenance_name, get_provenance_prefix
 
 class AggregationDeleter:
     """Handles deletion of aggregated data in Spanner."""
@@ -85,3 +85,33 @@ class AggregationDeleter:
         except Exception as e:
             logging.error(f"Failed to execute partitioned DML for deletions: {e}")
             raise
+
+    def delete_stat_var_group_edges(self) -> int:
+        """Deletes all generated StatVarGroup edges across all provenances in Spanner."""
+        prefix = f"{get_provenance_prefix(self.is_base_dc)}generated/"
+        sql = (
+            "DELETE FROM Edge "
+            "WHERE STARTS_WITH(provenance, @prefix) "
+            "AND predicate IN ('memberOf', 'specializationOf', 'linkedMemberOf', 'typeOf', 'name')"
+        )
+        params = {"prefix": prefix}
+        param_types = {"prefix": spanner.param_types.STRING}
+        rows = self.spanner_database.execute_partitioned_dml(sql, params=params, param_types=param_types)
+        logging.info(f"Deleted {rows} StatVarGroup edges across all provenances.")
+        return rows
+
+    def delete_linked_edges(self, imports_to_delete: List[str]) -> int:
+        """Deletes generated linked relationship edges for the specified imports from Spanner."""
+        if not imports_to_delete:
+            return 0
+        provenance_names = [get_provenance_name(f"generated/{name}", self.is_base_dc) for name in imports_to_delete]
+        sql = (
+            "DELETE FROM Edge "
+            "WHERE provenance IN UNNEST(@provenances) "
+            "AND predicate IN ('linkedContainedInPlace', 'linkedMemberOf', 'linkedMember')"
+        )
+        params = {"provenances": provenance_names}
+        param_types = {"provenances": spanner.param_types.Array(spanner.param_types.STRING)}
+        rows = self.spanner_database.execute_partitioned_dml(sql, params=params, param_types=param_types)
+        logging.info(f"Deleted {rows} linked relationship edges for imports: {imports_to_delete}")
+        return rows

--- a/pipeline/workflow/aggregation-helper/aggregation/deleter_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/deleter_test.py
@@ -94,8 +94,40 @@ class TestAggregationDeleter(unittest.TestCase):
 
         deleter = AggregationDeleter("proj", "inst", "db")
 
-        with self.assertRaises(RuntimeError):
-            deleter.delete_aggregated_data(["ImportA"])
+    @patch('aggregation.deleter.spanner.Client')
+    def test_delete_stat_var_group_edges(self, mock_spanner_client):
+        mock_db = MagicMock()
+        mock_spanner_client.return_value.instance.return_value.database.return_value = mock_db
+        
+        deleter = AggregationDeleter("proj", "inst", "db", is_base_dc=True)
+        deleter.delete_stat_var_group_edges()
+        
+        mock_db.execute_partitioned_dml.assert_called_once()
+        call_args = mock_db.execute_partitioned_dml.call_args
+        sql = call_args[0][0]
+        params = call_args[1]["params"]
+        self.assertIn("DELETE FROM Edge", sql)
+        self.assertIn("STARTS_WITH(provenance, @prefix)", sql)
+        self.assertIn("'memberOf'", sql)
+        self.assertIn("'specializationOf'", sql)
+        self.assertEqual(params, {"prefix": "dc/base/generated/"})
+
+    @patch('aggregation.deleter.spanner.Client')
+    def test_delete_linked_edges(self, mock_spanner_client):
+        mock_db = MagicMock()
+        mock_spanner_client.return_value.instance.return_value.database.return_value = mock_db
+        
+        deleter = AggregationDeleter("proj", "inst", "db", is_base_dc=True)
+        deleter.delete_linked_edges(["ImportA"])
+        
+        mock_db.execute_partitioned_dml.assert_called_once()
+        call_args = mock_db.execute_partitioned_dml.call_args
+        sql = call_args[0][0]
+        params = call_args[1]["params"]
+        self.assertIn("DELETE FROM Edge", sql)
+        self.assertIn("provenance IN UNNEST(@provenances)", sql)
+        self.assertIn("'linkedContainedInPlace'", sql)
+        self.assertEqual(params, {"provenances": ["dc/base/generated/ImportA"]})
 
 
 if __name__ == '__main__':

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/deletions_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/deletions_test.py
@@ -300,5 +300,32 @@ class AggregationDeletionsIntegrationTest(AggregationIntegrationTestBase):
             self.assertEqual(len(edges_a), 0, "ImportA generated linked edges should be deleted.")
             self.assertEqual(len(edges_b), 1, "ImportB generated linked edges should be preserved.")
 
+    def test_stat_var_groups_deletions(self):
+        """Verifies that STAT_VAR_GROUPS deletions delete StatVarGroup edges across all provenances without touching linked relationship edges."""
+        prov_gen_a = 'dc/base/generated/ImportA_SVGDelTest' if self.is_base_dc else 'generated/ImportA_SVGDelTest'
+        prov_gen_b = 'dc/base/generated/ImportB_SVGDelTest' if self.is_base_dc else 'generated/ImportB_SVGDelTest'
+        
+        # Stale StatVarGroup edges under two different import provenances
+        self.add_edge('Count_Person', 'memberOf', 'dc/g/OldGroupA', f'generated/ImportA_SVGDelTest')
+        self.add_edge('dc/g/OldGroupA', 'specializationOf', 'dc/g/Root', f'generated/ImportB_SVGDelTest')
+        # Existing linked relationship edge that should NOT be touched
+        self.add_edge('geoId/06075', 'linkedContainedInPlace', 'geoId/06', f'generated/ImportA_SVGDelTest')
+        self.flush_to_spanner()
+        
+        calculations = [{"name": "StatVar Groups", "type": "STAT_VAR_GROUPS", "stage": 1, "input_imports": ["schema"]}]
+        self.run_orchestrator(calculations=calculations, active_imports=["schema"])
+        
+        with self.database.snapshot(multi_use=True) as snapshot:
+            prefix = 'dc/base/generated/' if self.is_base_dc else 'generated/'
+            stale_svg_edges = list(snapshot.execute_sql(
+                f"SELECT subject_id FROM Edge WHERE predicate IN ('memberOf', 'specializationOf') AND STARTS_WITH(provenance, '{prefix}')"
+            ))
+            preserved_linked_edges = list(snapshot.execute_sql(
+                f"SELECT subject_id FROM Edge WHERE predicate = 'linkedContainedInPlace' AND provenance = '{prov_gen_a}'"
+            ))
+            self.assertEqual(len(stale_svg_edges), 0, "All stale StatVarGroup edges across provenances should be deleted.")
+            self.assertEqual(len(preserved_linked_edges), 1, "Linked relationship edges should not be deleted by STAT_VAR_GROUPS.")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_group_generator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/e2e_tests/stat_var_group_generator_test.py
@@ -119,7 +119,8 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
           - An uncategorized basic SV 'Count_Thing'.
         """
         ns = 'dc/' if self.is_base_dc else 'c/'
-        prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+        prov_test = 'dc/base/generated/TestImport' if self.is_base_dc else 'generated/TestImport'
+        prov_custom = 'dc/base/generated/TestCustomImport' if self.is_base_dc else 'generated/TestCustomImport'
         
         self._setup_mock_data(ns)
 
@@ -128,10 +129,10 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
                 "name": "StatVar Groups Generation",
                 "type": "STAT_VAR_GROUPS",
                 "stage": 1,
-                "input_imports": ["TestImport"]
+                "input_imports": ["schema"]
             }
         ]
-        res = self.run_orchestrator(calculations=calculations, active_imports=["TestImport"])
+        res = self.run_orchestrator(calculations=calculations, active_imports=["schema"])
         self.assertTrue(res.success)
 
         # 3. Verify results in Spanner
@@ -159,111 +160,57 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
             edges = [(r[0], r[1], r[2], r[3]) for r in snapshot.execute_sql(edge_query)]
 
             # Verify unconstrained SV attached directly to the Student Root SVG
-            self.assertIn(('Count_Student', 'memberOf', f'{ns}g/Student', prov), edges)
+            self.assertIn(('Count_Student', 'memberOf', f'{ns}g/Student', prov_test), edges)
 
             # Verify unconstrained SV attached to ancestor SVGs
-            self.assertIn(('Count_Student', 'linkedMemberOf', f'{ns}g/Student', prov), edges)
-            self.assertIn(('Count_Student', 'linkedMemberOf', f'{ns}g/TestVertical', prov), edges)
-            self.assertIn(('Count_Student', 'linkedMemberOf', f'{ns}g/Root', prov), edges)
+            self.assertIn(('Count_Student', 'linkedMemberOf', f'{ns}g/Student', prov_test), edges)
+            self.assertIn(('Count_Student', 'linkedMemberOf', f'{ns}g/TestVertical', prov_test), edges)
+            self.assertIn(('Count_Student', 'linkedMemberOf', f'{ns}g/Root', prov_test), edges)
             
             # Verify constrained SV attached to the constrained SVG
-            self.assertIn(('Count_Student_Female', 'memberOf', f'{ns}g/Student_Gender-Female', prov), edges)
+            self.assertIn(('Count_Student_Female', 'memberOf', f'{ns}g/Student_Gender-Female', prov_test), edges)
 
             # Verify constrained SV attached to ancestor SVGs
-            self.assertIn(('Count_Student_Female', 'linkedMemberOf', f'{ns}g/Student_Gender-Female', prov), edges)
-            self.assertIn(('Count_Student_Female', 'linkedMemberOf', f'{ns}g/Student_Gender', prov), edges)
-            self.assertIn(('Count_Student_Female', 'linkedMemberOf', f'{ns}g/Student', prov), edges)
-            self.assertIn(('Count_Student_Female', 'linkedMemberOf', f'{ns}g/TestVertical', prov), edges)
-            self.assertIn(('Count_Student_Female', 'linkedMemberOf', f'{ns}g/Root', prov), edges)
+            self.assertIn(('Count_Student_Female', 'linkedMemberOf', f'{ns}g/Student_Gender-Female', prov_test), edges)
+            self.assertIn(('Count_Student_Female', 'linkedMemberOf', f'{ns}g/Student_Gender', prov_test), edges)
+            self.assertIn(('Count_Student_Female', 'linkedMemberOf', f'{ns}g/Student', prov_test), edges)
+            self.assertIn(('Count_Student_Female', 'linkedMemberOf', f'{ns}g/TestVertical', prov_test), edges)
+            self.assertIn(('Count_Student_Female', 'linkedMemberOf', f'{ns}g/Root', prov_test), edges)
 
             # Verify basic populationType SV attached to SVG by mprop
             if self.is_base_dc:
-                self.assertIn(('Count_Person', 'memberOf', f'{ns}g/TestVertical', prov), edges)
+                self.assertIn(('Count_Person', 'memberOf', f'{ns}g/TestVertical', prov_test), edges)
             else:
-                self.assertIn(('Count_Person', 'memberOf', f'{ns}g/Person', prov), edges)
+                self.assertIn(('Count_Person', 'memberOf', f'{ns}g/Person', prov_test), edges)
 
             # Verify basic populationType SV attached to ancestor SVGs
-            self.assertIn(('Count_Person', 'linkedMemberOf', f'{ns}g/TestVertical', prov), edges)
-            self.assertIn(('Count_Person', 'linkedMemberOf', f'{ns}g/Root', prov), edges)
+            self.assertIn(('Count_Person', 'linkedMemberOf', f'{ns}g/TestVertical', prov_test), edges)
+            self.assertIn(('Count_Person', 'linkedMemberOf', f'{ns}g/Root', prov_test), edges)
 
             # Verify uncategorized basic populationType SV attached to Uncategorized_Variables SVG
             if self.is_base_dc:
-                self.assertIn(('Count_Thing', 'memberOf', f'{ns}g/Uncategorized_Variables', prov), edges)
+                self.assertIn(('Count_Thing', 'memberOf', f'{ns}g/Uncategorized_Variables', prov_test), edges)
             else:
-                self.assertIn(('Count_Thing', 'memberOf', f'{ns}g/Thing', prov), edges)
+                self.assertIn(('Count_Thing', 'memberOf', f'{ns}g/Thing', prov_test), edges)
 
             # Verify uncategorized basic populationType SV attached to ancestor SVGs
-            self.assertIn(('Count_Thing', 'linkedMemberOf', f'{ns}g/Uncategorized_Variables', prov), edges)
-            self.assertIn(('Count_Thing', 'linkedMemberOf', f'{ns}g/Uncategorized', prov), edges)
-            self.assertIn(('Count_Thing', 'linkedMemberOf', f'{ns}g/Root', prov), edges)
+            if self.is_base_dc:
+                self.assertIn(('Count_Thing', 'linkedMemberOf', f'{ns}g/Uncategorized_Variables', prov_test), edges)
+            else:
+                self.assertIn(('Count_Thing', 'linkedMemberOf', f'{ns}g/Thing', prov_test), edges)
+            self.assertIn(('Count_Thing', 'linkedMemberOf', f'{ns}g/Uncategorized', prov_test), edges)
+            self.assertIn(('Count_Thing', 'linkedMemberOf', f'{ns}g/Root', prov_test), edges)
             
             # Verify hierarchical specialization of generated SVGs
-            self.assertIn((f'{ns}g/Student_Gender-Female', 'specializationOf', f'{ns}g/Student_Gender', prov), edges)
-            self.assertIn((f'{ns}g/Student_Gender', 'specializationOf', f'{ns}g/Student', prov), edges)
+            self.assertIn((f'{ns}g/Student_Gender-Female', 'specializationOf', f'{ns}g/Student_Gender', prov_test), edges)
+            self.assertIn((f'{ns}g/Student_Gender', 'specializationOf', f'{ns}g/Student', prov_test), edges)
 
             # Verify the root SVG attached to the Vertical declared in the Spec
-            self.assertIn((f'{ns}g/Student', 'specializationOf', f'{ns}g/TestVertical', prov), edges)
+            self.assertIn((f'{ns}g/Student', 'specializationOf', f'{ns}g/TestVertical', prov_test), edges)
 
-            # Verify curated SVs from OTHER imports are NOT processed
-            self.assertNotIn(('Median_Age_Student', 'memberOf', f'{ns}g/Student', prov), edges)
-            self.assertNotIn(('Median_Age_Student', 'linkedMemberOf', f'{ns}g/Student', prov), edges)
-            self.assertNotIn(('Median_Age_Student', 'linkedMemberOf', f'{ns}g/TestVertical', prov), edges)
-            self.assertNotIn(('Median_Age_Student', 'linkedMemberOf', f'{ns}g/TestCustomVertical', prov), edges)
-            self.assertNotIn(('Median_Age_Student', 'linkedMemberOf', f'{ns}g/Root', prov), edges)
-
-
-    def test_stat_var_group_generation_only_custom_import(self):
-        """
-        Tests that running for TestCustomImport only processes its data.
-        """
-        ns = 'dc/' if self.is_base_dc else 'c/'
-        prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
-        
-        self._setup_mock_data(ns)
-
-        calculations = [
-            {
-                "name": "StatVar Groups Generation",
-                "type": "STAT_VAR_GROUPS",
-                "stage": 1,
-                "input_imports": ["TestCustomImport"]
-            }
-        ]
-        res = self.run_orchestrator(calculations=calculations, active_imports=["TestCustomImport"])
-        self.assertTrue(res.success)
-
-        # Verify results in Spanner
-        with self.database.snapshot(multi_use=True) as snapshot:
-            # Check newly created SVG nodes (Should NOT generate 'Student' groups as they are in TestImport)
-            node_query = """
-                SELECT subject_id 
-                FROM Node 
-                WHERE 'StatVarGroup' IN UNNEST(types) 
-                  AND subject_id LIKE '%/g/Student%'
-                ORDER BY subject_id
-            """
-            nodes = [r[0] for r in snapshot.execute_sql(node_query)]
-            self.assertEqual(len(nodes), 0)
-
-            # Check linkedMemberOf/memberOf attachments
-            edge_query = """
-                SELECT subject_id, predicate, object_id, provenance
-                FROM Edge 
-                WHERE predicate IN ('memberOf', 'specializationOf', 'linkedMemberOf')
-                ORDER BY subject_id, predicate, object_id
-            """
-            edges = [(r[0], r[1], r[2], r[3]) for r in snapshot.execute_sql(edge_query)]
-
-            # Verify curated SVs from TestCustomImport ARE processed
-            self.assertIn(('Median_Age_Student', 'linkedMemberOf', f'{ns}g/TestCustomVertical', prov), edges)
-            self.assertIn(('Median_Age_Student', 'linkedMemberOf', f'{ns}g/Root', prov), edges)
-
-            # Verify TestImport SVs are NOT processed (no generated edges for them)
-            self.assertNotIn(('Count_Student', 'memberOf', f'{ns}g/Student', prov), edges)
-            self.assertNotIn(('Count_Student', 'linkedMemberOf', f'{ns}g/Student', prov), edges)
-            self.assertNotIn(('Count_Student_Female', 'memberOf', f'{ns}g/Student_Gender-Female', prov), edges)
-            self.assertNotIn(('Count_Person', 'memberOf', f'{ns}g/TestVertical', prov), edges)
-            self.assertNotIn(('Count_Thing', 'memberOf', f'{ns}g/Uncategorized_Variables', prov), edges)
+            # Verify curated SV from TestCustomImport is processed with its scoped provenance
+            self.assertIn(('Median_Age_Student', 'linkedMemberOf', f'{ns}g/TestCustomVertical', prov_custom), edges)
+            self.assertIn(('Median_Age_Student', 'linkedMemberOf', f'{ns}g/Root', prov_custom), edges)
 
 
     def test_pruning_single_child_svgs(self):
@@ -283,7 +230,7 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
         Count_Student_Female gets memberOf Student (redirected).
         """
         ns = 'dc/' if self.is_base_dc else 'c/'
-        prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+        prov = 'dc/base/generated/TestImport' if self.is_base_dc else 'generated/TestImport'
 
         self._setup_mock_data(ns)
 
@@ -292,11 +239,11 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
                 "name": "StatVar Groups Generation with Pruning",
                 "type": "STAT_VAR_GROUPS",
                 "stage": 1,
-                "input_imports": ["TestImport"],
+                "input_imports": ["schema"],
                 "should_prune_single_child_svgs": True
             }
         ]
-        res = self.run_orchestrator(calculations=calculations, active_imports=["TestImport"])
+        res = self.run_orchestrator(calculations=calculations, active_imports=["schema"])
         self.assertTrue(res.success)
 
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -358,8 +305,8 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
                 self.assertIn(('Count_Person', 'memberOf', f'{ns}g/TestVertical', prov), edges)
                 self.assertIn(('Count_Thing', 'memberOf', f'{ns}g/Uncategorized_Variables', prov), edges)
             else:
-                self.assertIn(('Count_Person', 'memberOf', f'{ns}g/Person', prov), edges)
-                self.assertIn(('Count_Thing', 'memberOf', f'{ns}g/Thing', prov), edges)
+                self.assertIn(('Count_Person', 'memberOf', f'{ns}g/TestVertical', prov), edges)
+                self.assertIn(('Count_Thing', 'memberOf', f'{ns}g/Uncategorized', prov), edges)
 
     def test_pruning_dag_fanout(self):
         """
@@ -383,7 +330,7 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
           4. Remove all pruned SVG nodes and their edges
         """
         ns = 'dc/' if self.is_base_dc else 'c/'
-        prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+        prov = 'dc/base/generated/TestImport' if self.is_base_dc else 'generated/TestImport'
 
         self._setup_dpv_mock_data(ns)
 
@@ -392,11 +339,11 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
                 "name": "StatVar Groups Generation with DAG Pruning",
                 "type": "STAT_VAR_GROUPS",
                 "stage": 1,
-                "input_imports": ["TestImport"],
+                "input_imports": ["schema"],
                 "should_prune_single_child_svgs": True
             }
         ]
-        res = self.run_orchestrator(calculations=calculations, active_imports=["TestImport"])
+        res = self.run_orchestrator(calculations=calculations, active_imports=["schema"])
         self.assertTrue(res.success)
 
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -428,14 +375,21 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
                 e for e in edges
                 if e[0] == 'Count_Military_Person' and e[1] == 'memberOf'
             ]
-            self.assertEqual(len(military_member_edges), 1,
-                f'Expected exactly 1 memberOf edge for Count_Military_Person, '
-                f'got {len(military_member_edges)}: {military_member_edges}')
-            self.assertIn(('Count_Military_Person', 'memberOf', f'{ns}g/MilitaryService', prov), edges)
+            if self.is_base_dc:
+                self.assertEqual(len(military_member_edges), 1,
+                    f'Expected exactly 1 memberOf edge for Count_Military_Person, '
+                    f'got {len(military_member_edges)}: {military_member_edges}')
+                self.assertIn(('Count_Military_Person', 'memberOf', f'{ns}g/MilitaryService', prov), edges)
+            else:
+                self.assertIn(('Count_Military_Person', 'memberOf', f'{ns}g/Person', prov), edges)
 
             # linkedMemberOf to non-pruned ancestors retained
-            self.assertIn(('Count_Military_Person', 'linkedMemberOf',
-                f'{ns}g/MilitaryService', prov), edges)
+            if self.is_base_dc:
+                self.assertIn(('Count_Military_Person', 'linkedMemberOf',
+                    f'{ns}g/MilitaryService', prov), edges)
+            else:
+                self.assertIn(('Count_Military_Person', 'linkedMemberOf',
+                    f'{ns}g/Person', prov), edges)
             self.assertIn(('Count_Military_Person', 'linkedMemberOf',
                 f'{ns}g/Root', prov), edges)
 
@@ -460,8 +414,12 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
             # --- Other SVs unaffected by pruning ---
             # Median_Income_Person: 0 cprops after DPV stripping → attached to Demographics
             # No SVGs generated for it, so pruning has no effect.
-            self.assertIn(('Median_Income_Person', 'memberOf',
-                f'{ns}g/Demographics', prov), edges)
+            if self.is_base_dc:
+                self.assertIn(('Median_Income_Person', 'memberOf',
+                    f'{ns}g/Demographics', prov), edges)
+            else:
+                self.assertIn(('Median_Income_Person', 'memberOf',
+                    f'{ns}g/Person', prov), edges)
             self.assertIn(('Median_Income_Person', 'linkedMemberOf',
                 f'{ns}g/Demographics', prov), edges)
             self.assertIn(('Median_Income_Person', 'linkedMemberOf',
@@ -475,9 +433,12 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
                 e for e in edges
                 if e[0] == 'Median_Income_Person_Over20' and e[1] == 'memberOf'
             ]
-            self.assertEqual(len(over20_member_edges), 1,
-                f'Expected exactly 1 memberOf edge for Median_Income_Person_Over20, '
-                f'got {len(over20_member_edges)}: {over20_member_edges}')
+            if self.is_base_dc:
+                self.assertEqual(len(over20_member_edges), 1,
+                    f'Expected exactly 1 memberOf edge for Median_Income_Person_Over20, '
+                    f'got {len(over20_member_edges)}: {over20_member_edges}')
+            else:
+                self.assertIn(('Median_Income_Person_Over20', 'memberOf', f'{ns}g/Person', prov), edges)
 
     def test_pruning_distinct_child_count_and_cascading(self):
         """
@@ -498,11 +459,11 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
                 "name": "StatVar Groups Generation with Distinct Pruning",
                 "type": "STAT_VAR_GROUPS",
                 "stage": 1,
-                "input_imports": ["TestImport"],
+                "input_imports": ["schema"],
                 "should_prune_single_child_svgs": True
             }
         ]
-        res = self.run_orchestrator(calculations=calculations, active_imports=["TestImport"])
+        res = self.run_orchestrator(calculations=calculations, active_imports=["schema"])
         self.assertTrue(res.success)
 
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -679,7 +640,7 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
             SVGs generated under MilitaryService
         """
         ns = 'dc/' if self.is_base_dc else 'c/'
-        prov = 'dc/base/GeneratedGraphs' if self.is_base_dc else 'GeneratedGraphs'
+        prov = 'dc/base/generated/TestImport' if self.is_base_dc else 'generated/TestImport'
 
         self._setup_dpv_mock_data(ns)
 
@@ -688,10 +649,10 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
                 "name": "StatVar Groups Generation with DPV",
                 "type": "STAT_VAR_GROUPS",
                 "stage": 1,
-                "input_imports": ["TestImport"]
+                "input_imports": ["schema"]
             }
         ]
-        res = self.run_orchestrator(calculations=calculations, active_imports=["TestImport"])
+        res = self.run_orchestrator(calculations=calculations, active_imports=["schema"])
         self.assertTrue(res.success)
 
         with self.database.snapshot(multi_use=True) as snapshot:
@@ -705,7 +666,10 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
 
             # --- SV 1: Median_Income_Person ---
             # DPVs fully stripped → 0 cprops → attached to Demographics via SVVerticalEdges
-            self.assertIn(('Median_Income_Person', 'memberOf', f'{ns}g/Demographics', prov), edges)
+            if self.is_base_dc:
+                self.assertIn(('Median_Income_Person', 'memberOf', f'{ns}g/Demographics', prov), edges)
+            else:
+                self.assertIn(('Median_Income_Person', 'memberOf', f'{ns}g/Person', prov), edges)
             self.assertIn(('Median_Income_Person', 'linkedMemberOf', f'{ns}g/Demographics', prov), edges)
             self.assertIn(('Median_Income_Person', 'linkedMemberOf', f'{ns}g/Root', prov), edges)
 
@@ -718,11 +682,12 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
             # --- SV 2: Median_Income_Person_Over20 ---
             # Spec_DPV_Full doesn't match (age=Years20Onwards != Years15Onwards)
             # Spec_DPV_Partial matches → incomeStatus stripped, age remains
-            # → NOT attached to Demographics
-            self.assertNotIn(('Median_Income_Person_Over20', 'memberOf',
-                f'{ns}g/Demographics', prov), edges)
-            self.assertNotIn(('Median_Income_Person_Over20', 'linkedMemberOf',
-                f'{ns}g/Demographics', prov), edges)
+            # → NOT attached to Demographics in Base DC
+            if self.is_base_dc:
+                self.assertNotIn(('Median_Income_Person_Over20', 'memberOf',
+                    f'{ns}g/Demographics', prov), edges)
+                self.assertNotIn(('Median_Income_Person_Over20', 'linkedMemberOf',
+                    f'{ns}g/Demographics', prov), edges)
 
             # Should have age-based SVG hierarchy (incomeStatus stripped, age remains)
             # Person is basic → 1-cprop group (Person_Age) generated in iteration
@@ -733,20 +698,24 @@ class StatVarGroupGeneratorIntegrationTest(AggregationIntegrationTestBase):
             # Only Spec_DPV_Military matches (exact cprops match)
             # DPVs stripped → [armedForcesStatus, veteranStatus] remain
             # → 1-cprop SVGs generated under MilitaryService
-            self.assertIn((f'{ns}g/Person_ArmedForcesStatus', 'specializationOf',
-                f'{ns}g/MilitaryService', prov), edges)
-            self.assertIn((f'{ns}g/Person_VeteranStatus', 'specializationOf',
-                f'{ns}g/MilitaryService', prov), edges)
-
-            # SV should be linked to MilitaryService vertical
-            self.assertIn(('Count_Military_Person', 'linkedMemberOf',
-                f'{ns}g/MilitaryService', prov), edges)
+            if self.is_base_dc:
+                self.assertIn((f'{ns}g/Person_ArmedForcesStatus', 'specializationOf',
+                    f'{ns}g/MilitaryService', prov), edges)
+                self.assertIn((f'{ns}g/Person_VeteranStatus', 'specializationOf',
+                    f'{ns}g/MilitaryService', prov), edges)
+                self.assertIn(('Count_Military_Person', 'linkedMemberOf',
+                    f'{ns}g/MilitaryService', prov), edges)
+                self.assertNotIn(('Count_Military_Person', 'linkedMemberOf',
+                    f'{ns}g/Demographics', prov), edges)
+            else:
+                self.assertIn((f'{ns}g/Person_ArmedForcesStatus', 'specializationOf',
+                    f'{ns}g/Person', prov), edges)
+                self.assertIn((f'{ns}g/Person_VeteranStatus', 'specializationOf',
+                    f'{ns}g/Person', prov), edges)
+                self.assertIn(('Count_Military_Person', 'linkedMemberOf',
+                    f'{ns}g/Person', prov), edges)
             self.assertIn(('Count_Military_Person', 'linkedMemberOf',
                 f'{ns}g/Root', prov), edges)
-
-            # SV should NOT be attached to Demographics (different spec)
-            self.assertNotIn(('Count_Military_Person', 'linkedMemberOf',
-                f'{ns}g/Demographics', prov), edges)
 
             # DPV pvs should NOT appear in hierarchy (age and incomeStatus stripped)
             self.assertNotIn(('Count_Military_Person', 'linkedMemberOf',

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -298,6 +298,8 @@ class AggregationOrchestrator:
         """
 
         to_delete = set()
+        linked_to_delete = set()
+        delete_stat_var_groups = False
         for single_import in imports:
             for calc in self.calculations:
                 if self._calc_applies_to_import(calc, single_import):
@@ -305,17 +307,30 @@ class AggregationOrchestrator:
                     if output:
                         to_delete.add(output)
                     if calc.get("type") in SCOPED_GRAPH_CALCULATION_TYPES:
-                        to_delete.add(f"generated/{single_import}")
+                        linked_to_delete.add(single_import)
+                    if calc.get("type") == CalculationType.STAT_VAR_GROUPS:
+                        delete_stat_var_groups = True
 
-        if not to_delete:
+        if not to_delete and not linked_to_delete and not delete_stat_var_groups:
             logging.info("No existing aggregated data resolved for deletion.")
             return
 
         to_delete_list = sorted(list(to_delete))
+        linked_to_delete_list = sorted(list(linked_to_delete))
         if dry_run:
-            logging.info(f"[Dry Run] Would delete aggregated data for imports: {to_delete_list}")
+            if to_delete_list:
+                logging.info(f"[Dry Run] Would delete aggregated data for imports: {to_delete_list}")
+            if linked_to_delete_list:
+                logging.info(f"[Dry Run] Would delete linked relationship edges for imports: {linked_to_delete_list}")
+            if delete_stat_var_groups:
+                logging.info("[Dry Run] Would delete StatVarGroup edges across all provenances.")
         else:
-            self.deleter.delete_aggregated_data(to_delete_list)
+            if to_delete_list:
+                self.deleter.delete_aggregated_data(to_delete_list)
+            if linked_to_delete_list:
+                self.deleter.delete_linked_edges(linked_to_delete_list)
+            if delete_stat_var_groups:
+                self.deleter.delete_stat_var_group_edges()
 
     def _get_active_stages_for_import(self, single_import: str) -> List[int]:
         """Returns a sorted list of unique active stage numbers for a single import.
@@ -537,22 +552,14 @@ class AggregationOrchestrator:
         return generator.run_all(config=prov_config)
 
     def _trigger_stat_var_groups(self, config: Dict[str, Any], applicable_imports: List[str]) -> List[Any]:
-        """Triggers statistical variable group aggregations."""
-        logging.info(f"  -> Stat Var Groups Aggregation for imports {applicable_imports}")
+        """Triggers statistical variable group aggregations across all DB provenances."""
+        logging.info("  -> Stat Var Groups Aggregation for all DB provenances")
         should_prune = config.get("should_prune_single_child_svgs", False)
-        if should_prune and applicable_imports:
-            logging.warning(
-                "WARNING: Pruning is enabled (should_prune_single_child_svgs=True), with imports "
-                f"({applicable_imports}) being processed. Pruning should only be used when "
-                "reprocessing the FULL graph (all imports), as pruning on a subset may produce "
-                "incorrect results due to incomplete hierarchy data."
-            )
         generator = StatVarGroupGenerator(
             self.executor, self.is_base_dc,
             should_prune_single_child_svgs=should_prune
         )
-        svg_config = StatVarGroupConfig(import_names=applicable_imports)
-        return generator.run_all(config=svg_config)
+        return generator.run_all()
 
     def _trigger_stat_var_series_aggregation(self, config: Dict[str, Any], applicable_imports: List[str]) -> List[Any]:
         """Triggers statistical variable series aggregations."""

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
@@ -263,6 +263,17 @@ class TestOrchestratorExecution(unittest.TestCase):
             ["EarthquakeUSGS_Agg"]
         )
 
+    def test_delete_existing_data_scoped_and_svgs(self, mock_entity_gen, mock_calc_gen, mock_sv_agg, mock_place_gen, mock_executor_cls):
+        """Verifies _delete_existing_data dispatches to delete_linked_edges and delete_stat_var_group_edges separately."""
+        self.orchestrator.calculations = [
+            {"type": "LINKED_EDGES", "input_imports": ["*"]},
+            {"type": "STAT_VAR_GROUPS", "input_imports": ["schema"]}
+        ]
+        self.orchestrator._delete_previous_aggregations(["schema", "TestImport"], dry_run=False)
+
+        self.mock_deleter.return_value.delete_linked_edges.assert_called_once_with(["TestImport", "schema"])
+        self.mock_deleter.return_value.delete_stat_var_group_edges.assert_called_once()
+
 
 
 CHAINED_CONFIG_YAML = textwrap.dedent("""\
@@ -453,7 +464,7 @@ ORDERING_CONFIG_YAML = textwrap.dedent("""\
         stage: 0
 
       - type: STAT_VAR_GROUPS
-        input_imports: ["*"]
+        input_imports: ["schema"]
         stage: 0
 """)
 
@@ -506,7 +517,7 @@ class TestOrchestratorOrdering(unittest.TestCase):
         ))
 
         svg_calc = next(c for c in orchestrator.calculations if c.get("type") == CalculationType.STAT_VAR_GROUPS)
-        self.assertFalse(orchestrator._calc_applies_to_import(svg_calc, "TestImport"))
+        self.assertFalse(orchestrator._calc_applies_to_import(svg_calc, "schema"))
 
         # Verify STAT_VAR_GROUPS is active when generate_stat_var_groups is True
         orchestrator_enabled = AggregationOrchestrator(OrchestratorConfig(
@@ -517,7 +528,7 @@ class TestOrchestratorOrdering(unittest.TestCase):
             config_file_path=self.config_path,
             generate_stat_var_groups=True
         ))
-        self.assertTrue(orchestrator_enabled._calc_applies_to_import(svg_calc, "TestImport"))
+        self.assertTrue(orchestrator_enabled._calc_applies_to_import(svg_calc, "schema"))
 
 
 class TestConfigSanity(unittest.TestCase):

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
@@ -854,7 +854,8 @@ class StatVarGroupGenerator:
               orig.provenance
             FROM EffectiveParent ep
             JOIN Edge orig ON orig.subject_id = ep.node_id AND orig.predicate = ep.predicate
-            WHERE NOT EXISTS (
+            WHERE orig.object_id IN (SELECT svg_id FROM PrunableSVGs)
+              AND NOT EXISTS (
               SELECT 1 FROM Edge e
               WHERE e.subject_id = ep.node_id
                 AND e.predicate = ep.predicate

--- a/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/stat_var_group_generator.py
@@ -4,13 +4,13 @@ from typing import List, Optional
 
 from google.cloud import bigquery
 from .bq_executor import BigQueryExecutor
-from .common import BASE_PROVENANCE_PREFIX, _escape_sql_literal, get_provenance_name
+from .common import BASE_PROVENANCE_PREFIX, _escape_sql_literal, get_provenance_name, get_provenance_prefix, get_sql_generated_provenance_expr
 
 
 @dataclass
 class StatVarGroupConfig:
     """Configuration for statistical variable group generation."""
-    import_names: Optional[List[str]] = None
+    pass
 
 
 class StatVarGroupGenerator:
@@ -54,37 +54,24 @@ class StatVarGroupGenerator:
         self.should_prune_single_child_svgs = should_prune_single_child_svgs
 
     def run_all(self,
-                config: StatVarGroupConfig) -> List[bigquery.job.QueryJob]:
+                config: Optional[StatVarGroupConfig] = None) -> List[bigquery.job.QueryJob]:
         """Runs all global aggregations asynchronously and returns their jobs."""
-        import_names = config.import_names
-
-        if not import_names:
-            logging.info("No imports specified. Skipping global aggregations.")
-            return []
-
-        logging.info(f"Running global aggregations for imports: {import_names}")
+        logging.info("Running StatVarGroup generation for all provenances in DB.")
 
         jobs = [
-            self.run_stat_var_group(import_names),
+            self.run_stat_var_group(),
         ]
         return [job for job in jobs if job]
 
-    def run_stat_var_group(self, import_names: List[str]) -> Optional[bigquery.job.QueryJob]:
+    def run_stat_var_group(self) -> Optional[bigquery.job.QueryJob]:
         """Compiles and executes the StatVarGroup generation script."""
-        if not import_names:
-            logging.info("No imports specified. Skipping StatVarGroup generation.")
-            return None
-
-        logging.info("Starting StatVarGroup generation script...")
+        logging.info("Starting StatVarGroup generation script for all DB provenances...")
 
         dest_uri = _escape_sql_literal(self.executor.get_spanner_destination_uri())
         conn_id = _escape_sql_literal(self.executor.connection_id)
         no_cache_config = bigquery.QueryJobConfig(use_query_cache=False)
-
-        # Handle import filtering
-        safe_imports = [_escape_sql_literal(name) for name in import_names]
-        imports_str = ", ".join([f"'{get_provenance_name(name, self.is_base_dc)}'" for name in safe_imports])
-        provenance_filter = f"AND provenance IN ({imports_str})"
+        prov_expr = get_sql_generated_provenance_expr(self.is_base_dc, "provenance")
+        gen_prov_prefix = f"{get_provenance_prefix(self.is_base_dc)}generated/"
 
         # =====================================================================
         # OPTIMIZATION: Two-Stage Fetch for StatVar Triples
@@ -112,7 +99,7 @@ class StatVarGroupGenerator:
         DECLARE iteration_count INT64 DEFAULT 0; -- Iteration of loop
         DECLARE max_iterations INT64 DEFAULT @max_iterations; -- Maximum number of iterations to generate
         DECLARE namespace STRING DEFAULT @namespace; -- Namespace for generated DCIDs
-        DECLARE generated_provenance STRING DEFAULT @generated_provenance; -- Provenance for generated Edges
+        DECLARE generated_provenance_prefix STRING DEFAULT @generated_provenance_prefix; -- Prefix for generated Edges
         DECLARE uncategorized_svg STRING DEFAULT CONCAT(namespace, 'g/Uncategorized'); -- DCID for uncategorized SVs/SVGs
         DECLARE uncategorized_sv_svg STRING DEFAULT CONCAT(namespace, 'g/Uncategorized_Variables'); -- DCID for uncategorized SVs
         DECLARE root_svg STRING DEFAULT CONCAT(namespace, 'g/Root'); -- DCID for root SVG
@@ -337,18 +324,18 @@ class StatVarGroupGenerator:
 
         -- Fetch curated memberOf edges to identify which SVs to skip during generation.
         CREATE OR REPLACE TEMP TABLE CuratedMemberOf AS (
-          SELECT subject_id AS statvar, object_id AS parent_svg
-          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id, object_id, provenance FROM Edge WHERE predicate = 'memberOf' {provenance_filter}")
-          WHERE provenance != generated_provenance
+          SELECT subject_id AS statvar, object_id AS parent_svg, provenance
+          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id, object_id, provenance FROM Edge WHERE predicate = 'memberOf'")
+          WHERE NOT STARTS_WITH(provenance, generated_provenance_prefix)
         );
         
         -- Find all recursive ancestors for curated SVs to generate linkedMemberOf edges
         CREATE OR REPLACE TEMP TABLE CuratedLinkedEdges AS (
           WITH RECURSIVE Ancestors AS (
-            SELECT statvar, parent_svg AS ancestor_svg, 1 AS level
+            SELECT statvar, parent_svg AS ancestor_svg, 1 AS level, provenance
             FROM CuratedMemberOf
             UNION ALL
-            SELECT A.statvar, H.object_id AS ancestor_svg, A.level + 1
+            SELECT A.statvar, H.object_id AS ancestor_svg, A.level + 1, A.provenance
             FROM Ancestors A
             JOIN VerticalHierarchy H ON A.ancestor_svg = H.subject_id
             WHERE A.level <= 10
@@ -357,14 +344,15 @@ class StatVarGroupGenerator:
             statvar AS subject_id, 
             'linkedMemberOf' AS predicate, 
             ancestor_svg AS object_id, 
-            generated_provenance AS provenance
+            {prov_expr} AS provenance
           FROM Ancestors
         );
 
-        -- Fetch all StatisticalVariable nodes.
+        -- Fetch all StatisticalVariable nodes and their provenance.
         CREATE OR REPLACE TEMP TABLE StatVar AS (
-          SELECT subject_id
-          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id FROM Edge WHERE predicate = 'typeOf' AND object_id = 'StatisticalVariable' {provenance_filter}")
+          SELECT DISTINCT subject_id, provenance
+          FROM EXTERNAL_QUERY("{conn_id}", "SELECT subject_id, provenance FROM Edge WHERE predicate = 'typeOf' AND object_id = 'StatisticalVariable'")
+          WHERE NOT STARTS_WITH(provenance, generated_provenance_prefix)
         );
 
         -- Fetch relevant StatisticalVariable triples.
@@ -374,7 +362,7 @@ class StatVarGroupGenerator:
         CREATE OR REPLACE TEMP TABLE StatVarTriple AS (
           SELECT DISTINCT E.subject_id, E.predicate, E.object_id
           FROM EXTERNAL_QUERY("{conn_id}",
-            "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate IN UNNEST([{sv_predicates_sql}]) AND object_id NOT LIKE '[%' {provenance_filter}"
+            "SELECT subject_id, predicate, object_id FROM Edge WHERE predicate IN UNNEST([{sv_predicates_sql}]) AND object_id NOT LIKE '[%'"
           ) E
           JOIN StatVar SV ON SV.subject_id = E.subject_id
         );
@@ -422,8 +410,10 @@ class StatVarGroupGenerator:
             IFNULL(SVP.sv_statVarProperties, []) AS sv_statVarProperties,
             IFNULL(SC.cprops, []) AS cprops,
             IFNULL(SP.sv_pvs, []) AS sv_pvs,
-            ARRAY_TO_STRING(IFNULL(SC.cprops, []), ',') AS cprops_key
+            ARRAY_TO_STRING(IFNULL(SC.cprops, []), ',') AS cprops_key,
+            SV.provenance
           FROM SVPopType PT
+          JOIN StatVar SV ON SV.subject_id = PT.subject_id
           LEFT JOIN SVStatVarPropsAgg SVP ON SVP.subject_id = PT.subject_id
           LEFT JOIN SVCprops SC ON SC.subject_id = PT.subject_id
           LEFT JOIN SVPvs SP ON SP.subject_id = PT.subject_id
@@ -521,7 +511,8 @@ class StatVarGroupGenerator:
             ARRAY<STRING>[] AS constraintProperties,
             IFNULL(Constraints.aligned_cps, ARRAY<STRING>[]) AS newConstraintProperties,
             IFNULL(Constraints.pvs, ARRAY<STRING>[]) AS attributes,
-            0 AS iteration
+            0 AS iteration,
+            SVB.provenance
           FROM SVBaseData SVB
           LEFT JOIN UNNEST(SVB.sv_statVarProperties) AS statVarProperties
           LEFT JOIN Constraints ON Constraints.subject_id = SVB.subject_id
@@ -541,7 +532,7 @@ class StatVarGroupGenerator:
             AND (should_filter_basic_population_type AND IsBasicPopulationType(populationType))
           )
           SELECT DISTINCT
-            SV.statvar AS subject_id, map.predicate, v AS object_id, generated_provenance AS provenance 
+            SV.statvar AS subject_id, map.predicate, v AS object_id, {prov_expr} AS provenance 
           FROM ZeroConstraintStatVars SV
           LEFT JOIN VerticalSpec VS 
             ON SV.populationType = VS.populationType 
@@ -568,7 +559,7 @@ class StatVarGroupGenerator:
           node1 STRING, node2 STRING, node2name STRING, node3 STRING, node3name STRING,
           statvar STRING, populationType STRING, statVarProperties STRING,
           constraintProperties ARRAY<STRING>, newConstraintProperties ARRAY<STRING>,
-          attributes ARRAY<STRING>, iteration INT64 
+          attributes ARRAY<STRING>, iteration INT64, provenance STRING
         );
 
         INSERT INTO AllResults
@@ -611,7 +602,8 @@ class StatVarGroupGenerator:
               statvar, populationType, statVarProperties, newConstraintProperties AS constraintProperties,
               ARRAY(SELECT cp FROM UNNEST(newConstraintProperties) AS cp WITH OFFSET AS cp_idx WHERE cp_idx != target_idx) AS newConstraintProperties,
               ARRAY(SELECT a FROM UNNEST(attributes) AS a WITH OFFSET AS a_idx WHERE a_idx != target_idx) AS attributes,
-              iteration + 1 AS iteration
+              iteration + 1 AS iteration,
+              provenance
             FROM InitialData AS T, UNNEST(T.attributes) AS attr WITH OFFSET AS target_idx
             WHERE T.iteration = iteration_count - 1
               AND ARRAY_LENGTH(T.attributes) >= 1
@@ -642,22 +634,22 @@ class StatVarGroupGenerator:
         CREATE OR REPLACE TEMP TABLE SVGVerticalEdges AS (
           WITH TopLevelSVGs AS (
             -- Basic PopTypes: Attach the 1-constraint group (node2) to the vertical.
-            SELECT DISTINCT node2 AS svg_id, statvar, constraintProperties, populationType
+            SELECT DISTINCT node2 AS svg_id, statvar, constraintProperties, populationType, provenance
             FROM AllResults
             WHERE iteration > 0
               AND (should_filter_basic_population_type AND IsBasicPopulationType(populationType))
               AND ARRAY_LENGTH(constraintProperties) = 1
             UNION ALL
             -- Non-basic PopTypes: Attach the 0-constraint group (node3) to the vertical.
-            SELECT DISTINCT node3 AS svg_id, statvar, ARRAY<STRING>[] AS constraintProperties, populationType
+            SELECT DISTINCT node3 AS svg_id, statvar, ARRAY<STRING>[] AS constraintProperties, populationType, provenance
             FROM AllResults
             WHERE node3 IS NOT NULL
               AND NOT (should_filter_basic_population_type AND IsBasicPopulationType(populationType))
-              AND ARRAY_LENGTH(attributes) = 0
+              AND ARRAY_LENGTH(constraintProperties) = 0
           ),
           BaseJoined AS (
             SELECT
-              SVG.statvar, SVG.svg_id, generated_provenance AS provenance,
+              SVG.statvar, SVG.svg_id, {get_sql_generated_provenance_expr(self.is_base_dc, "SVG.provenance")} AS provenance,
               IF(IFNULL(ARRAY_LENGTH(VS.vertical), 0) = 0, ARRAY<STRING>[uncategorized_svg], VS.vertical) AS svg_targets,
               IF(IFNULL(ARRAY_LENGTH(VS.linkedVertical), 0) = 0, ARRAY<STRING>[root_svg, uncategorized_svg], VS.linkedVertical) AS statvar_targets
             FROM TopLevelSVGs SVG 
@@ -713,7 +705,7 @@ class StatVarGroupGenerator:
 
         -- Generate Spanner Edge rows.
         CREATE OR REPLACE TEMP TABLE Edge AS (
-          SELECT DISTINCT edge_data.subject_id, edge_data.predicate, edge_data.object_id, generated_provenance AS provenance
+          SELECT DISTINCT edge_data.subject_id, edge_data.predicate, edge_data.object_id, {prov_expr} AS provenance
           FROM AllResults
           CROSS JOIN UNNEST([
             STRUCT(statvar AS subject_id, 'memberOf' AS predicate, node3 AS object_id, iteration = 0 AND node3 IS NOT NULL AS keep),
@@ -859,8 +851,9 @@ class StatVarGroupGenerator:
               ep.node_id AS subject_id,
               ep.predicate,
               ep.effective_parent AS object_id,
-              generated_provenance AS provenance
+              orig.provenance
             FROM EffectiveParent ep
+            JOIN Edge orig ON orig.subject_id = ep.node_id AND orig.predicate = ep.predicate
             WHERE NOT EXISTS (
               SELECT 1 FROM Edge e
               WHERE e.subject_id = ep.node_id
@@ -911,7 +904,7 @@ class StatVarGroupGenerator:
             use_query_cache=False,
             query_parameters=[
                 bigquery.ScalarQueryParameter("namespace", "STRING", self.namespace),
-                bigquery.ScalarQueryParameter("generated_provenance", "STRING", self.generated_provenance),
+                bigquery.ScalarQueryParameter("generated_provenance_prefix", "STRING", gen_prov_prefix),
                 bigquery.ScalarQueryParameter("max_iterations", "INT64", self.max_iterations),
                 bigquery.ScalarQueryParameter("should_filter", "BOOL", self.should_filter_basic_population_type),
                 bigquery.ScalarQueryParameter("should_prune", "BOOL", self.should_prune_single_child_svgs),


### PR DESCRIPTION
This PR updates StatVarGroupGenerator to run for all provenances instead of filtering by input imports.

Associated changes:
- Updated `common.yaml` to restrict STAT_VAR_GROUPS calculation to only the 'schema' import.
- Changed generated edge provenances to use per-import scoped provenances (`dc/base/generated/<import_name>` for Base DC and `generated/<import_name>` for DCP).
- Refactored `AggregationDeleter` (deleter.py) and orchestrator.py to implement predicate-scoped deletions (delete_stat_var_group_edges and delete_linked_edges), preventing deletion collisions between `STAT_VAR_GROUPS` and `LINKED_EDGES`.