### PR TITLE
Disable all non-core aggregations in aggregation-helper configs

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/configs/embedding.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/embedding.yaml
@@ -2,6 +2,7 @@ calculations:
   # Generates node embeddings in Spanner
   - name: "Global: Node Embeddings Generation"
     type: EMBEDDING_GENERATION
+    disabled: true
     stage: 1
     embedding_table: "NodeEmbedding"
     embedding_generation:

--- a/pipeline/workflow/aggregation-helper/aggregation/configs/entity.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/entity.yaml
@@ -3,6 +3,7 @@ calculations:
   # Earthquakes
   - name: "EarthquakeUSGS: Earthquake Event Aggregation"
     type: ENTITY_AGGREGATION
+    disabled: true
     input_imports:
       - EarthquakeUSGS
     output_import: EarthquakeUSGS_Agg
@@ -65,6 +66,7 @@ calculations:
   # Fires
   - name: "FireFAMWEB: Wildland Fire Event Aggregation"
     type: ENTITY_AGGREGATION
+    disabled: true
     input_imports:
       - FireFAMWEB
     output_import: FireFAMWEB_Agg
@@ -79,6 +81,7 @@ calculations:
 
   - name: "FireWFIGS: Fire Incident Event Aggregation"
     type: ENTITY_AGGREGATION
+    disabled: true
     input_imports:
       - FireWFIGS
     output_import: FireWFIGS_Agg
@@ -96,6 +99,7 @@ calculations:
 
   - name: "NASA_VIIRSActiveFiresEvents: Fire Event S2 Cell Aggregation"
     type: ENTITY_AGGREGATION
+    disabled: true
     # Aggregate event counts for S2-cells of level 13
     input_imports:
       - NASA_VIIRSActiveFiresEvents
@@ -113,6 +117,7 @@ calculations:
   # Storms
   - name: "StormNOAA: Storm & Extreme Weather Event Aggregation"
     type: ENTITY_AGGREGATION
+    disabled: true
     input_imports:
       - StormNOAA
     output_import: StormNOAA_Agg
@@ -190,6 +195,7 @@ calculations:
   # Floods
   - name: "DynamicWorld_FloodEvents: Flood Event S2 Cell Aggregation"
     type: ENTITY_AGGREGATION
+    disabled: true
     # Aggregate event counts for S2-cells of level 13
     input_imports:
       - DynamicWorld_FloodEvents
@@ -207,6 +213,7 @@ calculations:
   # Heat/Cold Temperature Events counts
   - name: "TemperatureEvents: Heat & Cold Event Aggregation"
     type: ENTITY_AGGREGATION
+    disabled: true
     input_imports:
       - TemperatureEvents
     output_import: TemperatureEvents_Agg

--- a/pipeline/workflow/aggregation-helper/aggregation/configs/place.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/place.yaml
@@ -1,6 +1,7 @@
 calculations:
   - name: "CensusACS5YearSurvey: State -> Country Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - CensusACS5YearSurvey
@@ -11,6 +12,7 @@ calculations:
 
   - name: "CensusSAHIE: State -> Country Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - CensusSAHIE
@@ -21,6 +23,7 @@ calculations:
 
   - name: "CDCMortality: County -> State Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - CDCMortality
@@ -31,6 +34,7 @@ calculations:
 
   - name: "CDCMortality: State -> Country Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 2
     input_imports:
       - CDCMortality_AggState
@@ -41,6 +45,7 @@ calculations:
 
   - name: "DEA_ARCOS: County -> State Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - DEA_ARCOS
@@ -51,6 +56,7 @@ calculations:
 
   - name: "DEA_ARCOS: State -> Country Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 2
     input_imports:
       - DEA_ARCOS_AggState
@@ -61,6 +67,7 @@ calculations:
 
   - name: "EPA_EJSCREEN: CensusBlockGroup -> CensusTract Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - EPA_EJSCREEN
@@ -71,6 +78,7 @@ calculations:
 
   - name: "EPA_EJSCREEN: CensusTract -> County Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 2
     input_imports:
       - EPA_EJSCREEN_AggCensusTract
@@ -81,6 +89,7 @@ calculations:
 
   - name: "DeepSolar: CensusBlockGroup -> CensusTract Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - DeepSolar
@@ -91,6 +100,7 @@ calculations:
 
   - name: "DeepSolar: CensusTract -> County Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 2
     input_imports:
       - DeepSolar_AggCensusTract
@@ -101,6 +111,7 @@ calculations:
 
   - name: "EPA_GHGRP: EpaReportingFacility -> County Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - EPA_GHGRP
@@ -111,6 +122,7 @@ calculations:
 
   - name: "EPA_GHGRP: EpaReportingFacility -> CensusZipCodeTabulationArea Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - EPA_GHGRP
@@ -121,6 +133,7 @@ calculations:
 
   - name: "EPA_GHGRP: County -> State Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 2
     input_imports:
       - EPA_GHGRP_AggCounty
@@ -131,6 +144,7 @@ calculations:
 
   - name: "RFF_USGridGeo: GeoGrid -> County Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - RFF_USGridGeo_WeatherVariabilityForecast
@@ -142,6 +156,7 @@ calculations:
 
   - name: "India_RBIStateDomesticProduct: State -> Country Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - India_RBIStateDomesticProduct
@@ -153,6 +168,7 @@ calculations:
 
   - name: "India_RBIStateDomesticProduct: StatVarAgg State -> Country Place Rollup"
     type: PLACE_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - India_RBIStateDomesticProduct_StatVarAgg

--- a/pipeline/workflow/aggregation-helper/aggregation/configs/statvar.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/statvar.yaml
@@ -3,6 +3,7 @@ calculations:
   # Health Insurance Coverage
   - name: "CensusACS5YearSurvey: Health Insurance SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey
       - CensusACS5YearSurvey_AggCountry
@@ -271,6 +272,7 @@ calculations:
   #
   - name: "CensusACS5YearSurvey: Ability To Speak English SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey
       - CensusACS5YearSurvey_AggCountry
@@ -319,6 +321,7 @@ calculations:
   #
   - name: "CensusACS5YearSurvey: In Armed Forces SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey
       - CensusACS5YearSurvey_AggCountry
@@ -380,6 +383,7 @@ calculations:
   # Education - CensusACS5YearSurvey
   - name: "CensusACS5YearSurvey: Education SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey
       - CensusACS5YearSurvey_AggCountry
@@ -596,6 +600,7 @@ calculations:
   # Education - ACSED5YrSurvey
   - name: "CensusSAHIE_AggCountry: Health Insurance SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - ACSED5YrSurvey
     output_import: CensusSAHIE_AggCountry_StatVarAgg
@@ -625,6 +630,7 @@ calculations:
   # Demographics
   - name: "CensusACS5YearSurvey: Demographics SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey
       - CensusACS5YearSurvey_AggCountry
@@ -643,6 +649,7 @@ calculations:
   # Agriculture
   - name: "USDA_AgricultureCensus: Agriculture Producer SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - USDA_AgricultureCensus
     output_import: USDA_AgricultureCensus_Agriculture_StatVarAgg
@@ -665,6 +672,7 @@ calculations:
 
   - name: "CensusACS5YearSurvey: Employment & Industry SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey
       - CensusACS5YearSurvey_AggCountry
@@ -856,6 +864,7 @@ calculations:
   # Crime
   - name: "USNationalPrisonerStatistics: Crime & Correctional Facility SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - USNationalPrisonerStatistics
     output_import: USNationalPrisonerStatistics_Crime_StatVarAgg
@@ -869,6 +878,7 @@ calculations:
   # WithOwnChildrenUnder18.
   - name: "CensusACS5YearSurvey_SubjectTables_S1251: Children & Household SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey_SubjectTables_S1251
     output_import: CensusACS5YearSurvey_SubjectTables_S1251_StatVarAgg
@@ -890,6 +900,7 @@ calculations:
   # Marriage
   - name: "CensusACS5YearSurvey_SubjectTables_S1201: Marital Status SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey_SubjectTables_S1201
     output_import: CensusACS5YearSurvey_SubjectTables_S1201_StatVarAgg
@@ -915,6 +926,7 @@ calculations:
   # Employment by business ownership type.
   - name: "CensusACS5YearSurvey_SubjectTables_S2408: Business Ownership Employment SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey_SubjectTables_S2408
     output_import: CensusACS5YearSurvey_SubjectTables_S2408_StatVarAgg
@@ -932,6 +944,7 @@ calculations:
   # US Citizen by Naturalization
   - name: "CensusACS5YearSurvey_SubjectTables_S0504: Naturalized Citizenship SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey_SubjectTables_S0504
     output_import: CensusACS5YearSurvey_SubjectTables_S0504_StatVarAgg
@@ -1063,6 +1076,7 @@ calculations:
   # HousingUnit HomeValue.
   - name: "CensusACS5YearSurvey: Home Value SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey
       - CensusACS5YearSurvey_AggCountry
@@ -1114,6 +1128,7 @@ calculations:
 
   - name: "CensusACS5YearSurvey: Person Age Groups SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey
       - CensusACS5YearSurvey_AggCountry
@@ -1130,6 +1145,7 @@ calculations:
 
   - name: "CensusACS5YearSurvey: Individual Income SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey
       - CensusACS5YearSurvey_AggCountry
@@ -1322,6 +1338,7 @@ calculations:
 
   - name: "DEA_ARCOS: Opioid Prescription SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - IndiaNSS_HealthAilments
     output_import: IndiaNSS_HealthAilments_StatVarAgg
@@ -1634,6 +1651,7 @@ calculations:
 
   - name: "OECDRegionalDemography: Person Age Groups SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - OECDRegionalDemography_Population
     output_import: OECDRegionalDemography_Person_Age_StatVarAgg
@@ -1720,6 +1738,7 @@ calculations:
 
   - name: "CensusACS5YearSurvey_SubjectTables_S0801: Work Commute SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey_SubjectTables_S0801
     output_import: CensusACS5YearSurvey_SubjectTables_S0801_StatVarAgg
@@ -1837,6 +1856,7 @@ calculations:
             - Count_Person_Years16Onwards_60OrMoreMinute_WorkCommute_Employed_Female_WorkedOutsideOfHome
   - name: "CensusACS5YearSurvey_SubjectTables_S0804: Means of Transportation Work Commute SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey_SubjectTables_S0804
     output_import: CensusACS5YearSurvey_SubjectTables_S0804_StatVarAgg
@@ -1877,6 +1897,7 @@ calculations:
             - Count_Person_Years16Onwards_CarTruckOrVanCarpooled_60OrMoreMinute_WorkCommute_Employed_WorkedOutsideOfHome
   - name: "India_RBIStateDomesticProduct: Gross Value Added SV Aggregation"
     type: STAT_VAR_AGGREGATION
+    disabled: true
     input_imports:
       - India_RBIStateDomesticProduct
     output_import: India_RBIStateDomesticProduct_StatVarAgg

--- a/pipeline/workflow/aggregation-helper/aggregation/configs/statvar_calculation.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/statvar_calculation.yaml
@@ -3,6 +3,7 @@ calculations:
   # Energy.
   - name: "EIA_Electricity: Annual Emissions Per Capita StatVar Calculation"
     type: STAT_VAR_CALCULATION
+    disabled: true
     input_imports:
       - EPA_GHGRP_AggCounty
       - EPA_GHGRP_AggCensusZipCodeTabulationArea
@@ -42,6 +43,7 @@ calculations:
   # output, they are preferred. Otherwise, the *_prefix is used.
   - name: "Climate: NASA CMIP6 Temperature Modeling Diffs Calculation"
     type: STAT_VAR_CALCULATION
+    disabled: true
     input_imports:
       - NASA_NEXGDDP_CMIP6_Subnational
       - NASA_NEXGDDP_CMIP6_IpccPlaces50

--- a/pipeline/workflow/aggregation-helper/aggregation/configs/statvar_series.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/statvar_series.yaml
@@ -1,6 +1,7 @@
 calculations:
   - name: "NASA_NEXDCP30: Measurement Methods & Base Date Diff Series Aggregation"
     type: STAT_VAR_SERIES_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - NASA_NEXDCP30
@@ -16,6 +17,7 @@ calculations:
 
   - name: "NASA_NEXGDDP_Subnational: Measurement Methods & Base Date Diff Series Aggregation"
     type: STAT_VAR_SERIES_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - NASA_NEXGDDP_Subnational
@@ -33,6 +35,7 @@ calculations:
 
   - name: "NASA_NEXGDDP_Country: Measurement Methods & Base Date Diff Series Aggregation"
     type: STAT_VAR_SERIES_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - NASA_NEXGDDP_Country
@@ -48,6 +51,7 @@ calculations:
 
   - name: "NASA_NEXGDDP_CMIP6_Subnational: Measurement Methods & Base Date Diff Series Aggregation"
     type: STAT_VAR_SERIES_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - NASA_NEXGDDP_CMIP6_Subnational
@@ -65,6 +69,7 @@ calculations:
 
   - name: "NASA_NEXGDDP_CMIP6_IpccPlaces50: Measurement Methods & Base Date Diff Series Aggregation"
     type: STAT_VAR_SERIES_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - NASA_NEXGDDP_CMIP6_IpccPlaces50
@@ -82,6 +87,7 @@ calculations:
 
   - name: "NASA_NEXGDDP_CMIP6_Subnational: Stats Across Models Series Aggregation"
     type: STAT_VAR_SERIES_AGGREGATION
+    disabled: true
     stage: 2
     input_imports:
       - NASA_NEXGDDP_CMIP6_Subnational
@@ -97,6 +103,7 @@ calculations:
 
   - name: "NASA_NEXGDDP_CMIP6_IpccPlaces50: Stats Across Models Series Aggregation"
     type: STAT_VAR_SERIES_AGGREGATION
+    disabled: true
     stage: 2
     input_imports:
       - NASA_NEXGDDP_CMIP6_IpccPlaces50
@@ -112,6 +119,7 @@ calculations:
 
   - name: "NASA_NEXGDDP_CMIP6_Subnational: Over Time Stats Across Models Series Aggregation"
     type: STAT_VAR_SERIES_AGGREGATION
+    disabled: true
     stage: 3
     input_imports:
       - NASA_NEXGDDP_CMIP6_Subnational_AggrStatsAcrossModels
@@ -216,6 +224,7 @@ calculations:
 
   - name: "NASA_NEXGDDP_CMIP6_IpccPlaces50: Over Time Stats Across Models Series Aggregation"
     type: STAT_VAR_SERIES_AGGREGATION
+    disabled: true
     stage: 3
     input_imports:
       - NASA_NEXGDDP_CMIP6_IpccPlaces50_AggrStatsAcrossModels
@@ -320,6 +329,7 @@ calculations:
 
   - name: "NASA_NEXGDDP_IpccPlaces50: Measurement Methods & Base Date Diff Series Aggregation"
     type: STAT_VAR_SERIES_AGGREGATION
+    disabled: true
     stage: 1
     input_imports:
       - NASA_NEXGDDP_IpccPlaces50

--- a/pipeline/workflow/aggregation-helper/aggregation/configs/super_enum.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/super_enum.yaml
@@ -1,30 +1,35 @@
 calculations:
   - name: "CensusACS5YearSurvey: Super Enum Mapping Aggregation"
     type: SUPER_ENUM_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey
     output_import: CensusACS5YearSurvey_SuperEnum
 
   - name: "CensusACS5YearSurvey_AggCountry: Super Enum Mapping Aggregation"
     type: SUPER_ENUM_AGGREGATION
+    disabled: true
     input_imports:
       - CensusACS5YearSurvey_AggCountry
     output_import: CensusACS5YearSurvey_AggCountry_SuperEnum
 
   - name: "NCES_PrivateSchoolStats: Super Enum Mapping Aggregation"
     type: SUPER_ENUM_AGGREGATION
+    disabled: true
     input_imports:
       - NCES_PrivateSchoolStats
     output_import: NCES_PrivateSchoolStats_SuperEnum
 
   - name: "NCES_PublicSchoolStats: Super Enum Mapping Aggregation"
     type: SUPER_ENUM_AGGREGATION
+    disabled: true
     input_imports:
       - NCES_PublicSchoolStats
     output_import: NCES_PublicSchoolStats_SuperEnum
 
   - name: "NCES_SchoolDistrictStats: Super Enum Mapping Aggregation"
     type: SUPER_ENUM_AGGREGATION
+    disabled: true
     input_imports:
       - NCES_SchoolDistrictStats
     output_import: NCES_SchoolDistrictStats_SuperEnum


### PR DESCRIPTION
Everything except the ones in `configs/common.yaml` are marked as disabled for now. We'll gradually enable them and bring them into auto-refresh.