### PR TITLE
 Add CLI filtering flags to aggregation-helper

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/README.md
+++ b/pipeline/workflow/aggregation-helper/aggregation/README.md
@@ -77,6 +77,33 @@ Common graph structure, lineage, and UI group hierarchy rollups defined in `comm
 
 ---
 
+## CLI & Cloud Run Job Filtering Flags (`--select`, `--reject`, `--include_disabled`)
+
+Instead of manually editing YAML configuration files (`configs/*.yaml`) to enable or disable specific aggregations, you can use command-line flags to dynamically filter calculation steps by **Calculation Type** (`type:`) or **Import Name** (`import:`):
+
+*   `--select` (repeated or comma-separated): Only execute calculation steps matching the specified types or import names. Each value MUST be explicitly prefixed with `type:` or `import:`.
+*   `--reject` (repeated or comma-separated): Skip calculation steps matching the specified types or import names. Rejections take precedence over selections.
+*   `--include_disabled` (`default=False`): Allows calculation steps marked `disabled: true` in YAML files to be dynamically executed when selected.
+
+### Examples
+
+**1. Run only Place and StatVar aggregations for an import (skipping all other types):**
+```bash
+python main.py --import_list '["CensusACS5YearSurvey"]' \
+  --select "type:PLACE_AGGREGATION,type:STAT_VAR_AGGREGATION" \
+  --include_disabled
+```
+
+**2. Reject a chained downstream import from running:**
+```bash
+python main.py --import_list '["CensusACS5YearSurvey"]' \
+  --reject "import:CensusACS5YearSurvey_AggCountry" \
+  --include_disabled
+```
+
+---
+
+
 ## Local Configuration Validation
 
 The orchestrator strictly validates configuration files against `schema.json`. If there is any syntax error, type mismatch, or missing required field, validation will fail.

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -105,6 +105,11 @@ class OrchestratorConfig:
     enable_embeddings: bool = False
     bq_dataset_id: str = "datacommons"
     generate_stat_var_groups: bool = True
+    select_types: Optional[List[str]] = None
+    reject_types: Optional[List[str]] = None
+    select_imports: Optional[List[str]] = None
+    reject_imports: Optional[List[str]] = None
+    include_disabled: bool = False
 
 
 class AggregationOrchestrator:
@@ -190,6 +195,12 @@ class AggregationOrchestrator:
         logging.info(
             f"Starting Aggregation Orchestrator run (dry_run={dry_run}, skip_deletions={skip_deletions}) for active imports: {active_imports} (expanded: {expanded_imports})"
         )
+        if any([self.config.select_types, self.config.reject_types, self.config.select_imports, self.config.reject_imports, self.config.include_disabled]):
+            logging.info(
+                f"Active filtering rules: select_types={self.config.select_types}, reject_types={self.config.reject_types}, "
+                f"select_imports={self.config.select_imports}, reject_imports={self.config.reject_imports}, "
+                f"include_disabled={self.config.include_disabled}"
+            )
         run_result = AggregationRunResult()
 
         for single_import in expanded_imports:
@@ -247,7 +258,7 @@ class AggregationOrchestrator:
         """Runs global, import-independent calculation steps (e.g., EMBEDDING_GENERATION)."""
         global_calcs = [
             calc for calc in self.calculations
-            if calc.get("type") in GLOBAL_CALCULATION_TYPES and not calc.get("disabled", False)
+            if calc.get("type") in GLOBAL_CALCULATION_TYPES and self._calc_matches_filters(calc)
         ]
         if not global_calcs:
             return None
@@ -609,15 +620,46 @@ class AggregationOrchestrator:
         )
         return generator.run_all(config=embed_config)
 
+    def _calc_matches_filters(self, calc: Dict[str, Any], single_import: Optional[str] = None) -> bool:
+        """Evaluates whether a calculation step passes CLI/config selection and rejection filters."""
+        if calc.get("disabled", False) and not self.config.include_disabled:
+            return False
+
+        calc_type = calc.get("type", "")
+        if not self.config.generate_stat_var_groups and calc_type == CalculationType.STAT_VAR_GROUPS:
+            return False
+
+        if self.config.reject_types and calc_type in self.config.reject_types:
+            return False
+
+        if self.config.select_types and calc_type not in self.config.select_types:
+            return False
+
+        configured_imports = set(calc.get("input_imports") or calc.get("imports", []))
+        output_import = calc.get("output_import")
+        if output_import:
+            configured_imports.add(output_import)
+
+        if self.config.reject_imports:
+            if (single_import and single_import in self.config.reject_imports) or any(
+                imp in self.config.reject_imports for imp in configured_imports if imp != "*"
+            ):
+                return False
+
+        if self.config.select_imports:
+            if not ((single_import and single_import in self.config.select_imports) or any(
+                imp in self.config.select_imports for imp in configured_imports if imp != "*"
+            )):
+                return False
+
+        return True
+
     def _calc_applies_to_import(self, calc: Dict[str, Any], single_import: str) -> bool:
         """Determines if a calculation step applies to a single import."""
-        if calc.get("disabled", False):
-            return False
-
-        if not self.config.generate_stat_var_groups and calc.get("type") == CalculationType.STAT_VAR_GROUPS:
-            return False
-
         if calc.get("type") in GLOBAL_CALCULATION_TYPES:
+            return False
+
+        if not self._calc_matches_filters(calc, single_import=single_import):
             return False
 
         configured_imports = calc.get("input_imports") or calc.get("imports", [])

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -635,6 +635,9 @@ class AggregationOrchestrator:
         if self.config.select_types and calc_type not in self.config.select_types:
             return False
 
+        if calc_type in GLOBAL_CALCULATION_TYPES:
+            return True
+
         configured_imports = set(calc.get("input_imports") or calc.get("imports", []))
         output_import = calc.get("output_import")
         if output_import:

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
@@ -531,6 +531,116 @@ class TestOrchestratorOrdering(unittest.TestCase):
         self.assertTrue(orchestrator_enabled._calc_applies_to_import(svg_calc, "schema"))
 
 
+DISABLED_CONFIG_YAML = textwrap.dedent("""\
+    calculations:
+      - type: PLACE_AGGREGATION
+        disabled: true
+        input_imports: ["USFed_Census"]
+        output_import: "USFed_Census_AggState"
+        stage: 1
+        place_aggregation:
+          from_place_types: County
+          to_place_types: State
+""")
+
+
+@patch('aggregation.orchestrator.BigQueryExecutor')
+class TestOrchestratorFiltering(unittest.TestCase):
+    """Tests for selection/rejection filtering by calculation type and import, plus include_disabled."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+        self.config_path = os.path.join(self.tmpdir.name, "config.yaml")
+        with open(self.config_path, "w") as f:
+            f.write(VALID_CONFIG_YAML)
+
+        self.disabled_path = os.path.join(self.tmpdir.name, "disabled.yaml")
+        with open(self.disabled_path, "w") as f:
+            f.write(DISABLED_CONFIG_YAML)
+
+    def test_filter_select_type(self, mock_executor):
+        """Verifies only selected calculation types are active."""
+        orchestrator = AggregationOrchestrator(OrchestratorConfig(
+            connection_id="conn",
+            project_id="proj",
+            instance_id="inst",
+            database_id="db",
+            config_file_path=self.config_path,
+            select_types=["PLACE_AGGREGATION"]
+        ))
+        active_stages = orchestrator._get_active_stages_for_import("USFed_Census")
+        self.assertEqual(active_stages, [1])
+
+    def test_filter_reject_type(self, mock_executor):
+        """Verifies rejected calculation types are excluded."""
+        orchestrator = AggregationOrchestrator(OrchestratorConfig(
+            connection_id="conn",
+            project_id="proj",
+            instance_id="inst",
+            database_id="db",
+            config_file_path=self.config_path,
+            reject_types=["PLACE_AGGREGATION"]
+        ))
+        active_stages = orchestrator._get_active_stages_for_import("USFed_Census")
+        self.assertEqual(active_stages, [2])
+
+    def test_reject_wins_over_select(self, mock_executor):
+        """Verifies reject rules take precedence over select rules."""
+        orchestrator = AggregationOrchestrator(OrchestratorConfig(
+            connection_id="conn",
+            project_id="proj",
+            instance_id="inst",
+            database_id="db",
+            config_file_path=self.config_path,
+            select_types=["PLACE_AGGREGATION", "STAT_VAR_AGGREGATION"],
+            reject_types=["STAT_VAR_AGGREGATION"]
+        ))
+        active_stages = orchestrator._get_active_stages_for_import("USFed_Census")
+        self.assertEqual(active_stages, [1])
+
+    def test_filter_reject_import(self, mock_executor):
+        """Verifies calculations associated with rejected imports are skipped."""
+        chained_path = os.path.join(self.tmpdir.name, "chained.yaml")
+        with open(chained_path, "w") as f:
+            f.write(CHAINED_CONFIG_YAML)
+
+        orchestrator = AggregationOrchestrator(OrchestratorConfig(
+            connection_id="conn",
+            project_id="proj",
+            instance_id="inst",
+            database_id="db",
+            config_file_path=chained_path,
+            reject_imports=["USFed_Census_AggState"]
+        ))
+        # Stage 1 generates USFed_Census_AggState, so it should be rejected
+        active_stages = orchestrator._get_active_stages_for_import("USFed_Census")
+        self.assertEqual(active_stages, [])
+
+    def test_include_disabled(self, mock_executor):
+        """Verifies include_disabled allows executing disabled: true steps from YAML."""
+        orchestrator_default = AggregationOrchestrator(OrchestratorConfig(
+            connection_id="conn",
+            project_id="proj",
+            instance_id="inst",
+            database_id="db",
+            config_file_path=self.disabled_path,
+            include_disabled=False
+        ))
+        self.assertEqual(orchestrator_default._get_active_stages_for_import("USFed_Census"), [])
+
+        orchestrator_enabled = AggregationOrchestrator(OrchestratorConfig(
+            connection_id="conn",
+            project_id="proj",
+            instance_id="inst",
+            database_id="db",
+            config_file_path=self.disabled_path,
+            include_disabled=True
+        ))
+        self.assertEqual(orchestrator_enabled._get_active_stages_for_import("USFed_Census"), [1])
+
+
 class TestConfigSanity(unittest.TestCase):
     """Sanity checks for calculation configurations and metadata."""
 

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
@@ -640,6 +640,26 @@ class TestOrchestratorFiltering(unittest.TestCase):
         ))
         self.assertEqual(orchestrator_enabled._get_active_stages_for_import("USFed_Census"), [1])
 
+    def test_global_calculations_ignore_import_filter(self, mock_executor):
+        """Verifies global calculations are not filtered out by import-level select filters."""
+        global_path = os.path.join(self.tmpdir.name, "global.yaml")
+        with open(global_path, "w") as f:
+            f.write(GLOBAL_CALCS_CONFIG_YAML)
+
+        orchestrator = AggregationOrchestrator(OrchestratorConfig(
+            connection_id="conn",
+            project_id="proj",
+            instance_id="inst",
+            database_id="db",
+            config_file_path=global_path,
+            select_imports=["SomeImport"]
+        ))
+        global_calcs = [
+            calc for calc in orchestrator.calculations
+            if calc.get("type") in {"EMBEDDING_GENERATION"} and orchestrator._calc_matches_filters(calc)
+        ]
+        self.assertEqual(len(global_calcs), 1)
+
 
 class TestConfigSanity(unittest.TestCase):
     """Sanity checks for calculation configurations and metadata."""

--- a/pipeline/workflow/aggregation-helper/main.py
+++ b/pipeline/workflow/aggregation-helper/main.py
@@ -38,6 +38,34 @@ def parse_import_list(import_list_str: Optional[str]) -> List[str]:
     return parsed
 
 
+def parse_filter_flag(arg_values: Optional[List[str]], flag_name: str) -> dict:
+    """Parses --select or --reject flags requiring explicit 'type:' or 'import:' prefixes."""
+    result = {"types": [], "imports": []}
+    if not arg_values:
+        return result
+    for item_str in arg_values:
+        for token in item_str.split(","):
+            token = token.strip()
+            if not token:
+                continue
+            lower_token = token.lower()
+            if lower_token.startswith("type:"):
+                val = token.split(":", 1)[1].strip().upper()
+                if val:
+                    result["types"].append(val)
+            elif lower_token.startswith("import:"):
+                val = token.split(":", 1)[1].strip()
+                if val:
+                    result["imports"].append(val)
+            else:
+                raise ValueError(
+                    f"Value '{token}' in --{flag_name} must start with 'type:' or 'import:' prefix "
+                    f"(e.g., '--{flag_name} type:PLACE_AGGREGATION' or '--{flag_name} import:CensusACS5YearSurvey')."
+                )
+    logging.info(f"Parsed flag --{flag_name}: {result}")
+    return result
+
+
 def create_orchestrator_config(
     args: argparse.Namespace, env: os._Environ = os.environ
 ) -> OrchestratorConfig:
@@ -58,6 +86,9 @@ def create_orchestrator_config(
     enable_embeddings = env.get("ENABLE_EMBEDDINGS", "false").lower() == "true"
     bq_dataset_id = env.get("BQ_DATASET_ID", "datacommons")
 
+    select_filters = parse_filter_flag(args.select, "select")
+    reject_filters = parse_filter_flag(args.reject, "reject")
+
     return OrchestratorConfig(
         connection_id=connection_id,
         project_id=project_id,
@@ -69,6 +100,11 @@ def create_orchestrator_config(
         enable_embeddings=enable_embeddings,
         bq_dataset_id=bq_dataset_id,
         generate_stat_var_groups=args.generate_stat_var_groups,
+        select_types=select_filters["types"] or None,
+        reject_types=reject_filters["types"] or None,
+        select_imports=select_filters["imports"] or None,
+        reject_imports=reject_filters["imports"] or None,
+        include_disabled=args.include_disabled,
     )
 
 
@@ -108,6 +144,22 @@ def main():
         action=argparse.BooleanOptionalAction,
         default=True,
         help="Whether running in base Data Commons environment (default: True, use --no-is_base_dc for DCP)."
+    )
+    parser.add_argument(
+        "--select",
+        action="append",
+        help="Select calculation types or import names (requires 'type:' or 'import:' prefix, e.g., 'type:PLACE_AGGREGATION,import:CensusACS5YearSurvey')."
+    )
+    parser.add_argument(
+        "--reject",
+        action="append",
+        help="Reject calculation types or import names (requires 'type:' or 'import:' prefix, e.g., 'type:LINKED_EDGES,import:CensusACS5YearSurvey_AggCountry')."
+    )
+    parser.add_argument(
+        "--include_disabled",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Whether to include calculations marked disabled: true in YAML configs when evaluating filters (default: False)."
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
This PR adds the following filtering flags to aggregation-helper:

- `select`
- `reject`
- `include_disabled`

The `select`/`reject` filters are used to filter calculation steps by calculation enum type or import name using explicit prefixes (`type:` or `import:`).

The `--include_disabled` flag (defaults to `false`), when set to true, allows calculation steps marked `disabled: true` to be executed if they match active selection filters. This is added as a quick override during runtime without having to update config files.


### Usage Examples

#### 1\. Run only Place Aggregations for an import (even if `disabled: true` in YAML)

```shell
python main.py --import_list '["CensusACS5YearSurvey"]' \
  --select "type:PLACE_AGGREGATION" \
  --include_disabled
```

#### 2\. Run Place & StatVar Aggregations, but skip a specific import

```shell
python main.py --import_list '["CensusACS5YearSurvey"]' \
  --select "type:PLACE_AGGREGATION,type:STAT_VAR_AGGREGATION" \
  --reject "import:CensusACS5YearSurvey_AggCountry" \
  --include_disabled
```

#### 3\. Run all enabled aggregations except Linked Edges and Provenance Summary

```shell
python main.py --import_list '["CensusACS5YearSurvey"]' \
  --reject "type:LINKED_EDGES,type:PROVENANCE_SUMMARY"
```

#### 4\. Test filter combinations safely using `--dry_run`

Logs the selected and rejected calculation stages without submitting BigQuery jobs:

```shell
python main.py --import_list '["CensusACS5YearSurvey"]' \
  --select "type:PLACE_AGGREGATION" \
  --include_disabled \
  --dry_run
```
