### PR TITLE
Add Base DC specific common.yaml config for aggregations

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/README.md
+++ b/pipeline/workflow/aggregation-helper/aggregation/README.md
@@ -66,13 +66,14 @@ Aggregates raw statistical variables into a summarized ancestor variable.
     ```
 
 #### 3. Common Aggregations (`LINKED_EDGES`, `PROVENANCE_SUMMARY`, `STAT_VAR_GROUPS`)
-Common graph structure, lineage, and UI group hierarchy rollups defined in `common.yaml`.
+Common graph structure, lineage, and UI group hierarchy rollups defined in `common.yaml` (for DCP where `LINKED_EDGES` applies to `*`) and `base_dc/common.yaml` (for Base Data Commons where `LINKED_EDGES` applies to `Schema` and `Place`).
 *   **Example**:
     ```yaml
     - type: LINKED_EDGES
-      stage: 1
+      stage: 0
       input_imports:
-        - "*"
+        - "Schema"
+        - "Place"
     ```
 
 ---

--- a/pipeline/workflow/aggregation-helper/aggregation/common.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/common.py
@@ -78,9 +78,11 @@ def _escape_sql_literal(val: str) -> str:
 #
 # Tier 2 (20): Global Post-Processing
 #   - EMBEDDING_GENERATION (20): Computes vector embeddings across finalized node properties.
+#
+# Note: The priority values are arbitrary and relative, used only to establish execution order.
 CALCULATION_TYPE_PRIORITY = {
-    "LINKED_EDGES": 0,
-    "STAT_VAR_GROUPS": 1,
+    "STAT_VAR_GROUPS": 0,
+    "LINKED_EDGES": 1,
     "PROVENANCE_SUMMARY": 2,
     "PLACE_AGGREGATION": 10,
     "STAT_VAR_AGGREGATION": 11,

--- a/pipeline/workflow/aggregation-helper/aggregation/configs/base_dc/common.yaml
+++ b/pipeline/workflow/aggregation-helper/aggregation/configs/base_dc/common.yaml
@@ -1,0 +1,26 @@
+# Note: This file is temporary and is added to avoid making changes that are Base DC
+# specific that could impact DCP workflows consuming common.yaml. In Base DC, the
+# workflow will be hardcoded to pass this file path explicitly.
+
+calculations:
+  # Generates linkedContainedInPlace, linkedMemberOf, etc.
+  - name: "Global: ContainedInPlace & MemberOf Graph Linked Edges"
+    type: LINKED_EDGES
+    stage: 0
+    input_imports:
+      - "Schema"
+      - "Place"
+
+  # Generates summary statistics in the KeyValueStore table
+  - name: "Global: KeyValueStore Provenance & Lineage Summary"
+    type: PROVENANCE_SUMMARY
+    stage: 0
+    input_imports:
+      - "*"
+
+  # Generates the Statistical Variable hierarchy/verticals
+  - name: "Global: StatVar Group Hierarchy & Verticals"
+    type: STAT_VAR_GROUPS
+    stage: 0
+    input_imports:
+      - "Schema"

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -206,8 +206,13 @@ class AggregationOrchestrator:
                 continue
 
             if dry_run:
+                active_calcs = [
+                    f"{calc.get('name', calc.get('type', 'Unknown'))} ({calc.get('type', '')})"
+                    for calc in self.calculations
+                    if self._calc_applies_to_import(calc, single_import)
+                ]
                 logging.info(
-                    f"Detected active stage(s) {active_stages} for import '{single_import}'. Skipping execution because dry_run=True."
+                    f"Detected active stage(s) {active_stages} for import '{single_import}'. [Dry Run] Would execute calculation step(s): {active_calcs}. Skipping execution because dry_run=True."
                 )
                 run_result.import_results[single_import] = ImportExecutionResult(
                     import_name=single_import,

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
@@ -498,8 +498,8 @@ class TestOrchestratorOrdering(unittest.TestCase):
         """Verifies calculations are sorted deterministically by (stage, priority)."""
         types_in_order = [calc["type"] for calc in self.orchestrator.calculations]
         expected_order = [
-            "LINKED_EDGES",
             "STAT_VAR_GROUPS",
+            "LINKED_EDGES",
             "PROVENANCE_SUMMARY",
             "PLACE_AGGREGATION"
         ]

--- a/pipeline/workflow/spanner-ingestion-workflow.yaml
+++ b/pipeline/workflow/spanner-ingestion-workflow.yaml
@@ -183,6 +183,8 @@ run_aggregation_job:
                     - "--import_list"
                     - ${json.encode_to_string(import_list)}
                     - "--no-dry_run"
+                    - "--config_path"
+                    - "aggregation/configs/base_dc/common.yaml"
           connector_params:
             timeout: 21600
         result: aggregation_response


### PR DESCRIPTION
This PR adds a temporary `base_dc/common.yaml` config where `LINKED_EDGES` runs for `Schema` and `Place` imports only, while `PROVENANCE_SUMMARY` runs for `'*'` (any import).

I tested the behaviour through the `--dry-run` flag to see which aggregations would be triggered for the specific list of imports passed:

#### 1. Base DC — `["Schema"]` Import

```bash
uv run python main.py --config_path aggregation/configs/base_dc/common.yaml --import_list '["Schema"]' --dry_run

# output
# [Dry Run] Would execute calculation step(s): ['Global: ContainedInPlace & MemberOf Graph Linked Edges (LINKED_EDGES)', 'Global: StatVar Group Hierarchy & Verticals (STAT_VAR_GROUPS)', 'Global: KeyValueStore Provenance & Lineage Summary (PROVENANCE_SUMMARY)']
```

#### 2. Base DC — `["Place"]` Import

```bash
uv run python main.py --config_path aggregation/configs/base_dc/common.yaml --import_list '["Place"]' --dry_run

# output
# [Dry Run] Would execute calculation step(s): ['Global: ContainedInPlace & MemberOf Graph Linked Edges (LINKED_EDGES)', 'Global: KeyValueStore Provenance & Lineage Summary (PROVENANCE_SUMMARY)']
```

#### 3. Base DC — Standard Data Import (`["CensusACS5YearSurvey"]`)

```bash
uv run python main.py --config_path aggregation/configs/base_dc/common.yaml --import_list '["CensusACS5YearSurvey"]' --dry_run

# output
# [Dry Run] Would execute calculation step(s): ['Global: KeyValueStore Provenance & Lineage Summary (PROVENANCE_SUMMARY)']
```

#### 4. DCP / Default Directory Scan — Standard Data Import (`["CensusACS5YearSurvey"]`, without `--config_path`)

```bash
uv run python main.py --import_list '["CensusACS5YearSurvey"]' --dry_run

# output
# [Dry Run] Would execute calculation step(s): ['Global: ContainedInPlace & MemberOf Graph Linked Edges (LINKED_EDGES)', 'Global: KeyValueStore Provenance & Lineage Summary (PROVENANCE_SUMMARY)']
```
