### PR TITLE
Fix failing CI related to aggregations

### DIFF
--- a/pipeline/workflow/spanner-ingestion-workflow.yaml
+++ b/pipeline/workflow/spanner-ingestion-workflow.yaml
@@ -172,6 +172,17 @@ run_aggregation_job:
         switch:
           - condition: ${import_list == null or len(import_list) == 0}
             return: 'SKIPPED'
+    - init_import_names:
+        assign:
+          - import_names: []
+    - loop_import_list:
+        for:
+          value: item
+          in: ${import_list}
+          steps:
+            - extract_import_name:
+                assign:
+                  - import_names: ${list.concat(import_names, [item.importName])}
     - run_aggregation:
         call: googleapis.run.v2.projects.locations.jobs.run
         args:
@@ -181,7 +192,7 @@ run_aggregation_job:
               containerOverrides:
                 - args:
                     - "--import_list"
-                    - ${json.encode_to_string(import_list)}
+                    - ${json.encode_to_string(import_names)}
                     - "--no-dry_run"
                     - "--config_path"
                     - "aggregation/configs/base_dc/common.yaml"


### PR DESCRIPTION
This PR fixes the failing [CI build](https://pantheon.corp.google.com/cloud-build/builds/9d497f49-68d6-48fe-84e1-698518518b20;step=2?e=13803378&project=datcom-ci) related to aggregations.

Presently, the aggregation-helper passes a list of dictionaries, while the cloud run job's `main.py` expects an array of strings. This mismatch is causing an error.

I fixed this by extracting the list of import strings in the workflow and then passing it to the cloud run job.