### PR TITLE
Remove nesting in array of imports passed to aggregation job

### DIFF
--- a/pipeline/workflow/spanner-ingestion-workflow.yaml
+++ b/pipeline/workflow/spanner-ingestion-workflow.yaml
@@ -182,7 +182,7 @@ run_aggregation_job:
           steps:
             - extract_import_name:
                 assign:
-                  - import_names: ${list.concat(import_names, [item.importName])}
+                  - import_names: ${list.concat(import_names, item.importName)}
     - run_aggregation:
         call: googleapis.run.v2.projects.locations.jobs.run
         args:


### PR DESCRIPTION
In my previous PR #705, there was a typo, and I accidentally created a nested array of strings that are passed to aggregation job. This PR fixes it.