### PR TITLE
Support SPANNER_PROJECT_ID in aggregation-helper for production executions

### DIFF
--- a/pipeline/workflow/aggregation-helper/aggregation/aggregation_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/aggregation_test.py
@@ -83,6 +83,20 @@ class TestBigQueryExecutor(unittest.TestCase):
         self.assertFalse(executor.enable_embeddings)
         self.assertEqual(executor.bq_dataset_id, "datacommons")
 
+    def test_init_with_spanner_project_id(self, mock_bq_client):
+        executor = BigQueryExecutor(connection_id="conn",
+                                    project_id="bq_proj",
+                                    spanner_project_id="spanner_proj",
+                                    instance_id="inst",
+                                    database_id="db",
+                                    location="loc")
+        _ = executor.client
+        mock_bq_client.assert_called_once_with(project="bq_proj", location="loc")
+        self.assertEqual(
+            executor.get_spanner_destination_uri(),
+            "https://spanner.googleapis.com/projects/spanner_proj/instances/inst/databases/db"
+        )
+
     def test_init_failure(self, mock_bq_client):
         mock_bq_client.side_effect = Exception("Auth error")
         with self.assertRaises(Exception):

--- a/pipeline/workflow/aggregation-helper/aggregation/bq_executor.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/bq_executor.py
@@ -30,10 +30,12 @@ class BigQueryExecutor:
                  location: Optional[str] = None,
                  run_sequential: bool = True,
                  enable_embeddings: bool = False,
-                 bq_dataset_id: Optional[str] = None) -> None:
+                 bq_dataset_id: Optional[str] = None,
+                 spanner_project_id: Optional[str] = None) -> None:
         """Initializes the BigQueryExecutor with connection and destination details."""
         self.connection_id = connection_id
         self.project_id = project_id
+        self.spanner_project_id = spanner_project_id or project_id
         self.instance_id = instance_id
         self.database_id = database_id
         self.location = location
@@ -52,7 +54,7 @@ class BigQueryExecutor:
 
     def get_spanner_destination_uri(self) -> str:
         """Returns the Spanner destination URI for EXPORT DATA."""
-        return f"https://spanner.googleapis.com/projects/{self.project_id}/instances/{self.instance_id}/databases/{self.database_id}"
+        return f"https://spanner.googleapis.com/projects/{self.spanner_project_id}/instances/{self.instance_id}/databases/{self.database_id}"
 
     def execute(
         self,

--- a/pipeline/workflow/aggregation-helper/aggregation/embedding_generator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/embedding_generator.py
@@ -110,7 +110,7 @@ class EmbeddingGenerator:
     def spanner_database(self):
         """Lazily initializes and returns the Spanner Database client."""
         if self._spanner_database is None:
-            spanner_client = spanner.Client(project=self.executor.project_id)
+            spanner_client = spanner.Client(project=self.executor.spanner_project_id)
             instance = spanner_client.instance(self.executor.instance_id)
             self._spanner_database = instance.database(self.executor.database_id)
             logging.info(f"Initialized Spanner client for EmbeddingGenerator: {self._spanner_database.name}")
@@ -226,6 +226,7 @@ class EmbeddingGenerator:
         dest = self.executor.get_spanner_destination_uri()
         conn_id = self.executor.connection_id
         project_id = self.executor.project_id
+        model_project_id = self.executor.spanner_project_id
         bq_dataset_id = self.executor.bq_dataset_id
         location = self.executor.location
 
@@ -336,7 +337,7 @@ class EmbeddingGenerator:
           node_types, 
           ml_generate_embedding_result AS embeddings
         FROM ML.GENERATE_EMBEDDING(
-          MODEL `{project_id}.{bq_dataset_id}.{model_name}`,
+          MODEL `{model_project_id}.{bq_dataset_id}.{model_name}`,
           ({select_nodes_sql}),
           STRUCT("{task_type}" AS task_type)
         );

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator.py
@@ -96,6 +96,7 @@ class OrchestratorConfig:
     project_id: str
     instance_id: str
     database_id: str
+    spanner_project_id: Optional[str] = None
     location: Optional[str] = None
     is_base_dc: bool = True
     config_dir: Optional[str] = None
@@ -117,6 +118,7 @@ class AggregationOrchestrator:
             config: OrchestratorConfig dataclass instance containing connection and execution parameters.
         """
         self.config = config
+        spanner_proj = self.config.spanner_project_id or self.config.project_id
 
         self.executor = BigQueryExecutor(
             connection_id=self.config.connection_id,
@@ -126,12 +128,13 @@ class AggregationOrchestrator:
             location=self.config.location,
             run_sequential=self.config.run_sequential,
             enable_embeddings=self.config.enable_embeddings,
-            bq_dataset_id=self.config.bq_dataset_id
+            bq_dataset_id=self.config.bq_dataset_id,
+            spanner_project_id=spanner_proj,
         )
         self.is_base_dc = self.config.is_base_dc
         self.poll_interval = self.config.poll_interval
         self.deleter = AggregationDeleter(
-            project_id=self.config.project_id,
+            project_id=spanner_proj,
             instance_id=self.config.instance_id,
             database_id=self.config.database_id,
             is_base_dc=self.config.is_base_dc

--- a/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
+++ b/pipeline/workflow/aggregation-helper/aggregation/orchestrator_test.py
@@ -423,7 +423,8 @@ class TestOrchestratorGlobalCalculations(unittest.TestCase):
             location=None,
             run_sequential=False,
             enable_embeddings=True,
-            bq_dataset_id="test-dataset"
+            bq_dataset_id="test-dataset",
+            spanner_project_id="proj"
         )
 
     def test_run_global_calcs_failure(self, mock_embedding_gen, mock_executor_cls):

--- a/pipeline/workflow/aggregation-helper/main.py
+++ b/pipeline/workflow/aggregation-helper/main.py
@@ -44,6 +44,7 @@ def create_orchestrator_config(
     """Creates an OrchestratorConfig from CLI arguments and environment variables."""
     connection_id = env.get("BQ_SPANNER_CONN_ID")
     project_id = env.get("PROJECT_ID")
+    spanner_project_id = env.get("SPANNER_PROJECT_ID", project_id)
     instance_id = env.get("SPANNER_INSTANCE_ID")
     database_id = env.get("SPANNER_DATABASE_ID")
     location = env.get("LOCATION")
@@ -61,6 +62,7 @@ def create_orchestrator_config(
     return OrchestratorConfig(
         connection_id=connection_id,
         project_id=project_id,
+        spanner_project_id=spanner_project_id,
         instance_id=instance_id,
         database_id=database_id,
         location=location,


### PR DESCRIPTION
Fix for a failing [CI issue](https://pantheon.corp.google.com/workflows/workflow/us-central1/spanner-ingestion-workflow/execution/72098d0b-dddc-41a3-9fe6-684fc7207671/summary?e=13803378&mods=-monitoring_api_staging&project=datcom-import-automation-prod).