### PR TITLE
Update workflow to support import list overrides

### DIFF
--- a/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
+++ b/pipeline/ingestion/src/main/java/org/datacommons/ingestion/pipeline/GraphIngestionPipeline.java
@@ -91,7 +91,10 @@ public class GraphIngestionPipeline {
     // Iterate through each import configuration and process it.
     for (JsonElement element : jsonArray) {
       JsonElement importElement = element.getAsJsonObject().get("importName");
-      JsonElement pathElement = element.getAsJsonObject().get("graphPath");
+      JsonElement pathElement =
+          element.getAsJsonObject().has("graphPath")
+              ? element.getAsJsonObject().get("graphPath")
+              : element.getAsJsonObject().get("latestVersion");
       if (isJsonNullOrEmpty(importElement)) {
         LOGGER.error("Invalid import input json, missing importName: {}", element.toString());
         continue;
@@ -100,7 +103,7 @@ public class GraphIngestionPipeline {
       String graphPath = isJsonNullOrEmpty(pathElement) ? null : pathElement.getAsString();
 
       if (graphPath == null) {
-        LOGGER.error("Invalid import input json, missing graphPath: {}", element.toString());
+        LOGGER.error("Invalid import input json, missing latestVersion: {}", element.toString());
         continue;
       }
 

--- a/pipeline/workflow/import-automation-workflow.yaml
+++ b/pipeline/workflow/import-automation-workflow.yaml
@@ -23,7 +23,7 @@ main:
           - runIngestion: ${default(map.get(args, "runIngestion"), false)}
           - ingestionArgs:
               importList:
-                - ${text.split(importName, ":")[1]}
+                - importName: ${text.split(importName, ":")[1]}
     - runImportJob:
         try:
           call: googleapis.batch.v1.projects.locations.jobs.create

--- a/pipeline/workflow/import-helper/import_helper.py
+++ b/pipeline/workflow/import-helper/import_helper.py
@@ -41,7 +41,7 @@ def invoke_spanner_ingestion_workflow(import_name: str):
     Args:
         import_name: The name of the import.
     """
-    workflow_args = {"importList": [import_name.split(':')[-1]]}
+    workflow_args = {"importList": [{"importName": import_name.split(':')[-1]}]}
 
     logging.info(f"Invoking {SPANNER_INGESTION_WORKFLOW_ID} for {import_name}")
     execution_client = executions_v1.ExecutionsClient()

--- a/pipeline/workflow/ingestion-helper/app_test.py
+++ b/pipeline/workflow/ingestion-helper/app_test.py
@@ -293,8 +293,9 @@ class TestMain(unittest.TestCase):
 
     def test_revert_single_import(self):
         mock_spanner_client = MagicMock()
-        mock_spanner_client.get_import_version_history.return_value = ["v2", "v1"]
-        mock_spanner_client.get_import_latest_version.return_value = "gs://bucket/path/v2"
+        mock_spanner_client.get_import_version_history.return_value = [
+            "gs://bucket/path/v2/*/*.mcf", "gs://bucket/path/v1/*/*.mcf"
+        ]
         mock_spanner_client.revert_import_state.return_value = True
         app.dependency_overrides[get_spanner_client] = lambda: mock_spanner_client
 
@@ -307,25 +308,26 @@ class TestMain(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data["status"], "OK")
-        self.assertEqual(data["message"], "Reverted foo:bar:imp1: v2 -> v1")
+        self.assertEqual(data["message"], "Reverted foo:bar:imp1: gs://bucket/path/v2/*/*.mcf -> gs://bucket/path/v1/*/*.mcf")
         self.assertTrue(data["reverted"])
         self.assertEqual(len(data["revertedImports"]), 1)
         self.assertEqual(data["revertedImports"][0]["importName"], "foo:bar:imp1")
-        self.assertEqual(data["revertedImports"][0]["failedVersion"], "v2")
-        self.assertEqual(data["revertedImports"][0]["restoredVersion"], "v1")
+        self.assertEqual(data["revertedImports"][0]["failedVersion"], "gs://bucket/path/v2/*/*.mcf")
+        self.assertEqual(data["revertedImports"][0]["restoredVersion"], "gs://bucket/path/v1/*/*.mcf")
         mock_spanner_client.get_import_version_history.assert_called_once_with("imp1")
         mock_spanner_client.revert_import_state.assert_called_once_with(
             import_name="imp1",
-            new_latest_version_path="gs://bucket/path/v1",
-            previous_version="v1",
+            new_latest_version_path="gs://bucket/path/v1/*/*.mcf",
+            previous_version="gs://bucket/path/v1/*/*.mcf",
             workflow_id="wf-123",
             comment="Reverted batch workflow (wf-123)"
         )
 
     def test_revert_single_import_without_workflow_id(self):
         mock_spanner_client = MagicMock()
-        mock_spanner_client.get_import_version_history.return_value = ["v2", "v1"]
-        mock_spanner_client.get_import_latest_version.return_value = "gs://bucket/path/v2"
+        mock_spanner_client.get_import_version_history.return_value = [
+            "gs://bucket/path/v2/*/*.mcf", "gs://bucket/path/v1/*/*.mcf"
+        ]
         mock_spanner_client.revert_import_state.return_value = True
         app.dependency_overrides[get_spanner_client] = lambda: mock_spanner_client
 
@@ -337,12 +339,12 @@ class TestMain(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data["status"], "OK")
-        self.assertEqual(data["message"], "Reverted foo:bar:imp1: v2 -> v1")
+        self.assertEqual(data["message"], "Reverted foo:bar:imp1: gs://bucket/path/v2/*/*.mcf -> gs://bucket/path/v1/*/*.mcf")
         self.assertTrue(data["reverted"])
         mock_spanner_client.revert_import_state.assert_called_once_with(
             import_name="imp1",
-            new_latest_version_path="gs://bucket/path/v1",
-            previous_version="v1",
+            new_latest_version_path="gs://bucket/path/v1/*/*.mcf",
+            previous_version="gs://bucket/path/v1/*/*.mcf",
             workflow_id=None,
             comment="Reverted import state"
         )
@@ -350,8 +352,11 @@ class TestMain(unittest.TestCase):
     def test_revert_multiple_imports(self):
         mock_spanner_client = MagicMock()
         mock_spanner_client.get_imports_for_workflow.return_value = ["imp1", "imp2"]
-        mock_spanner_client.get_import_version_history.side_effect = lambda name: ["v2", "v1"] if name == "imp1" else ["v3", "v2"]
-        mock_spanner_client.get_import_latest_version.return_value = "gs://bucket/path/latest"
+        mock_spanner_client.get_import_version_history.side_effect = lambda name: [
+            "gs://bucket/path/v2/*/*.mcf", "gs://bucket/path/v1/*/*.mcf"
+        ] if name == "imp1" else [
+            "gs://bucket/path/v3/*/*.mcf", "gs://bucket/path/v2/*/*.mcf"
+        ]
         mock_spanner_client.revert_import_state.return_value = True
         app.dependency_overrides[get_spanner_client] = lambda: mock_spanner_client
 
@@ -363,15 +368,15 @@ class TestMain(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data["status"], "OK")
-        self.assertEqual(data["message"], "Reverted imp1: v2 -> v1, imp2: v3 -> v2")
+        self.assertEqual(data["message"], "Reverted imp1: gs://bucket/path/v2/*/*.mcf -> gs://bucket/path/v1/*/*.mcf, imp2: gs://bucket/path/v3/*/*.mcf -> gs://bucket/path/v2/*/*.mcf")
         self.assertTrue(data["reverted"])
         self.assertEqual(len(data["revertedImports"]), 2)
         self.assertEqual(data["revertedImports"][0]["importName"], "imp1")
-        self.assertEqual(data["revertedImports"][0]["failedVersion"], "v2")
-        self.assertEqual(data["revertedImports"][0]["restoredVersion"], "v1")
+        self.assertEqual(data["revertedImports"][0]["failedVersion"], "gs://bucket/path/v2/*/*.mcf")
+        self.assertEqual(data["revertedImports"][0]["restoredVersion"], "gs://bucket/path/v1/*/*.mcf")
         self.assertEqual(data["revertedImports"][1]["importName"], "imp2")
-        self.assertEqual(data["revertedImports"][1]["failedVersion"], "v3")
-        self.assertEqual(data["revertedImports"][1]["restoredVersion"], "v2")
+        self.assertEqual(data["revertedImports"][1]["failedVersion"], "gs://bucket/path/v3/*/*.mcf")
+        self.assertEqual(data["revertedImports"][1]["restoredVersion"], "gs://bucket/path/v2/*/*.mcf")
         mock_spanner_client.get_imports_for_workflow.assert_called_once_with("wf-123")
 
     def test_revert_neither_import_name_nor_workflow_id(self):
@@ -558,6 +563,40 @@ class TestMain(unittest.TestCase):
             ingested_imports=["import1"],
             metrics=mock_metrics
         )
+
+    def test_get_import_info_list_of_dicts(self):
+        mock_spanner_client = MagicMock()
+        mock_spanner_client.get_import_info.return_value = [{
+            "importName": "EurostatData",
+            "latestVersion": "gs://bucket/path/*/*.mcf"
+        }]
+        app.dependency_overrides[get_spanner_client] = lambda: mock_spanner_client
+
+        payload = {
+            "importList": [{
+                "importName": "EurostatData",
+                "latestVersion": "gs://bucket/path/*/*.mcf",
+            }]
+        }
+        response = client.post("/imports/info", json=payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+        self.assertEqual(response.json()[0]["importName"], "EurostatData")
+        mock_spanner_client.get_import_info.assert_called_once()
+
+    def test_get_import_info_dict_import_name_only(self):
+        mock_spanner_client = MagicMock()
+        mock_spanner_client.get_import_info.return_value = [{
+            "importName": "import1",
+            "latestVersion": "gs://bucket/import1/*/*.mcf"
+        }]
+        app.dependency_overrides[get_spanner_client] = lambda: mock_spanner_client
+
+        payload = {"importList": [{"importName": "import1"}]}
+        response = client.post("/imports/info", json=payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+        mock_spanner_client.get_import_info.assert_called_once()
 
 if __name__ == '__main__':
     unittest.main()

--- a/pipeline/workflow/ingestion-helper/clients/spanner.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner.py
@@ -228,49 +228,74 @@ class SpannerClient:
             logging.error(f'Error releasing lock for {workflow_id}: {e}')
             raise
 
-    def get_import_info(self, import_list: list) -> list:
+    def get_import_info(self, import_list: list | None) -> list:
         """Get the details of imports to ingest.
 
-        If import_list is empty, return info for ready imports (STAGING).
-        If import_list is not empty, return info for the imports in the list that are in 'STAGING' status.
+        If import_list is empty, return info for ready imports (STAGING) from Spanner DB.
+        Otherwise, import_list is a list of dicts (or ImportItem objects) containing 'importName'
+        and optional 'latestVersion' (which contains the full GCS graph path).
 
         Args:
-            import_list: A list of import names to fetch details for.
+            import_list: A list of dicts or objects containing 'importName' and optional 'latestVersion'.
 
         Returns:
-            A list of dictionaries, where each dictionary contains 'importName', 'latestVersion', and 'graphPath'.
+            A list of dictionaries, where each dictionary contains 'importName' and 'latestVersion' (full GCS graph path).
         """
-        pending_imports = []
-        logging.info(f"Fetching imports from import list {import_list}.")
+        if not import_list:
+            import_list = []
 
+        pending_imports = []
+        imports_to_fetch = []
+
+        for item in import_list:
+            if isinstance(item, dict):
+                import_name = item.get("importName")
+                provided_version = item.get("latestVersion")
+            elif hasattr(item, "importName"):
+                import_name = getattr(item, "importName", None)
+                provided_version = getattr(item, "latestVersion", None)
+            else:
+                continue
+
+            if not import_name:
+                continue
+
+            if provided_version:
+                pending_imports.append({
+                    "importName": import_name,
+                    "latestVersion": provided_version,
+                })
+            else:
+                imports_to_fetch.append(import_name)
+
+        logging.info(f"Fetching import details. Provided directly: {len(pending_imports)}, Needing DB fetch: {len(imports_to_fetch)}, Empty list: {not import_list}")
+
+        sql = None
         params = {}
         param_types = {}
-        if import_list:
-            sql = "SELECT ImportName, LatestVersion, GraphPath FROM ImportStatus WHERE State = 'STAGING' AND ImportName IN UNNEST(@importNames)"
-            params = {"importNames": import_list}
-            param_types = {"importNames": Array(STRING)}
-        else:
+
+        if not import_list:
             sql = "SELECT ImportName, LatestVersion, GraphPath FROM ImportStatus WHERE State = 'STAGING'"
+        elif imports_to_fetch:
+            sql = "SELECT ImportName, LatestVersion, GraphPath FROM ImportStatus WHERE State = 'STAGING' AND ImportName IN UNNEST(@importNames)"
+            params = {"importNames": imports_to_fetch}
+            param_types = {"importNames": Array(STRING)}
 
-        # Use a read-only snapshot for this query
-        try:
-            with self.database.snapshot() as snapshot:
-                results = snapshot.execute_sql(sql,
-                                               params=params,
-                                               param_types=param_types)
-                for row in results:
-                    import_json = {}
-                    import_json['importName'] = row[0]
-                    import_json['latestVersion'] = os.path.basename(row[1])
-                    import_json[
-                        'graphPath'] = f"{row[1].rstrip('/')}/{row[2].lstrip('/')}"
-                    pending_imports.append(import_json)
+        if sql:
+            try:
+                with self.database.snapshot() as snapshot:
+                    results = snapshot.execute_sql(sql, params=params, param_types=param_types)
+                    for row in results:
+                        pending_imports.append({
+                            "importName": row[0],
+                            "latestVersion": f"{row[1].rstrip('/')}/{row[2].lstrip('/')}",
+                        })
+            except Exception as e:
+                logging.error(f'Error getting import list: {e}')
+                raise
 
-            logging.info(f"Found {len(pending_imports)} import jobs.")
-            return pending_imports
-        except Exception as e:
-            logging.error(f'Error getting import list: {e}')
-            raise
+        logging.info(f"Found {len(pending_imports)} import jobs.")
+        return pending_imports
 
     def update_ingestion_status(self, import_names: list, workflow_id: str,
                                 status: str):

--- a/pipeline/workflow/ingestion-helper/clients/spanner_test.py
+++ b/pipeline/workflow/ingestion-helper/clients/spanner_test.py
@@ -820,6 +820,69 @@ class TestSpannerClient(unittest.TestCase):
         imports = client.get_imports_for_workflow("wf-123")
         self.assertEqual(imports, ["imp1", "imp2"])
 
+    @patch('google.cloud.spanner.Client')
+    def test_get_import_info_with_provided_dict(self, mock_spanner_client):
+        mock_instance = MagicMock()
+        mock_db = MagicMock()
+        mock_spanner_client.return_value.instance.return_value = mock_instance
+        mock_instance.database.return_value = mock_db
+
+        client = SpannerClient("project", "instance", "database")
+        import_list = [{
+            "importName": "EurostatData",
+            "latestVersion": "gs://datcom-prod-imports/scripts/eurostat/2026_08_03T19_03_05_074661_07_00/*/*.mcf"
+        }]
+
+        result = client.get_import_info(import_list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["importName"], "EurostatData")
+        self.assertEqual(result[0]["latestVersion"], "gs://datcom-prod-imports/scripts/eurostat/2026_08_03T19_03_05_074661_07_00/*/*.mcf")
+        mock_db.snapshot.assert_not_called()
+
+    @patch('google.cloud.spanner.Client')
+    def test_get_import_info_with_dict_import_name_only(self, mock_spanner_client):
+        mock_instance = MagicMock()
+        mock_db = MagicMock()
+        mock_spanner_client.return_value.instance.return_value = mock_instance
+        mock_instance.database.return_value = mock_db
+
+        mock_snapshot = MagicMock()
+        mock_db.snapshot.return_value.__enter__.return_value = mock_snapshot
+        mock_results = [
+            ["EurostatData", "gs://bucket/version1", "/*/*.mcf"]
+        ]
+        mock_snapshot.execute_sql.return_value = mock_results
+
+        client = SpannerClient("project", "instance", "database")
+        result = client.get_import_info([{"importName": "EurostatData"}])
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["importName"], "EurostatData")
+        self.assertEqual(result[0]["latestVersion"], "gs://bucket/version1/*/*.mcf")
+        mock_snapshot.execute_sql.assert_called_once()
+
+    @patch('google.cloud.spanner.Client')
+    def test_get_import_info_empty_list(self, mock_spanner_client):
+        mock_instance = MagicMock()
+        mock_db = MagicMock()
+        mock_spanner_client.return_value.instance.return_value = mock_instance
+        mock_instance.database.return_value = mock_db
+
+        mock_snapshot = MagicMock()
+        mock_db.snapshot.return_value.__enter__.return_value = mock_snapshot
+        mock_results = [
+            ["ImportA", "gs://bucket/v1", "/*/*.mcf"]
+        ]
+        mock_snapshot.execute_sql.return_value = mock_results
+
+        client = SpannerClient("project", "instance", "database")
+        result = client.get_import_info([])
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["importName"], "ImportA")
+        self.assertEqual(result[0]["latestVersion"], "gs://bucket/v1/*/*.mcf")
+        mock_snapshot.execute_sql.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pipeline/workflow/ingestion-helper/routes/imports.py
+++ b/pipeline/workflow/ingestion-helper/routes/imports.py
@@ -40,7 +40,7 @@ class ImportItem(BaseModel):
 
 
 class ImportInfoRequest(BaseModel):
-    importList: Optional[List[str]] = Field(default_factory=list)
+    importList: Optional[List[ImportItem]] = Field(default_factory=list)
 
 
 class UpdateIngestionStatusRequest(BaseModel):
@@ -86,9 +86,7 @@ class UpdateImportVersionRequest(BaseModel):
 
 class ImportInfoItem(BaseModel):
     importName: str = Field(description="The name of the import")
-    latestVersion: str = Field(description="The latest version GCS filename")
-    graphPath: str = Field(
-        description="The full GCS path to the import graph files")
+    latestVersion: str = Field(description="The latest version full GCS graph path")
 
 
 class RevertImportRequest(BaseModel):

--- a/pipeline/workflow/ingestion-helper/utils/rollback_helper.py
+++ b/pipeline/workflow/ingestion-helper/utils/rollback_helper.py
@@ -14,7 +14,6 @@
 """Rollback helper logic for dataset ingestion."""
 
 import logging
-import posixpath
 from typing import Any
 
 
@@ -55,24 +54,16 @@ def revert_import(spanner_client: Any,
             f"No previous different version found in ImportVersionHistory for '{short_name}'. Cannot revert.")
         return False, latest_version, None
 
-    # 2. Get current LatestVersion path from ImportStatus to preserve GCS parent directory.
-    # TODO: Add Path column to ImportVersionHistory table and fetch path directly from history.
-    current_latest_version_path = spanner_client.get_import_latest_version(short_name) or ""
-
-    if current_latest_version_path:
-        parent_dir = posixpath.dirname(current_latest_version_path)
-        new_latest_version_path = posixpath.join(parent_dir, previous_version)
-    else:
-        new_latest_version_path = previous_version
+    new_latest_version_path = previous_version
 
     if dry_run:
         logging.info(
-            f"[DRY RUN] Would revert '{short_name}' from '{latest_version}' to last known good version: '{previous_version}' (Path: '{new_latest_version_path}')"
+            f"[DRY RUN] Would revert '{short_name}' from '{latest_version}' to last known good version: '{previous_version}'"
         )
         return True, latest_version, previous_version
 
     logging.info(
-        f"Reverting '{short_name}' from '{latest_version}' to last known good version: '{previous_version}' (Path: '{new_latest_version_path}')"
+        f"Reverting '{short_name}' from '{latest_version}' to last known good version: '{previous_version}'"
     )
 
     # 3. Update ImportStatus to point to previous version and set state to STAGING, and record audit history.

--- a/pipeline/workflow/ingestion-helper/utils/rollback_helper_test.py
+++ b/pipeline/workflow/ingestion-helper/utils/rollback_helper_test.py
@@ -21,35 +21,36 @@ class TestRollbackHelper(unittest.TestCase):
 
     def test_revert_import_success(self):
         mock_spanner = MagicMock()
-        mock_spanner.get_import_version_history.return_value = ["v2", "v1"]
-        mock_spanner.get_import_latest_version.return_value = "gs://bucket/path/v2"
+        mock_spanner.get_import_version_history.return_value = [
+            "gs://bucket/path/v2/*/*.mcf", "gs://bucket/path/v1/*/*.mcf"
+        ]
         mock_spanner.revert_import_state.return_value = True
 
         status, cur_ver, prev_ver = revert_import(mock_spanner, "foo:bar:imp1", "wf-123")
 
         self.assertTrue(status)
-        self.assertEqual(cur_ver, "v2")
-        self.assertEqual(prev_ver, "v1")
+        self.assertEqual(cur_ver, "gs://bucket/path/v2/*/*.mcf")
+        self.assertEqual(prev_ver, "gs://bucket/path/v1/*/*.mcf")
         mock_spanner.get_import_version_history.assert_called_once_with("imp1")
-        mock_spanner.get_import_latest_version.assert_called_once_with("imp1")
         mock_spanner.revert_import_state.assert_called_once_with(
             import_name="imp1",
-            new_latest_version_path="gs://bucket/path/v1",
-            previous_version="v1",
+            new_latest_version_path="gs://bucket/path/v1/*/*.mcf",
+            previous_version="gs://bucket/path/v1/*/*.mcf",
             workflow_id="wf-123",
             comment="Reverted batch workflow (wf-123)"
         )
 
     def test_revert_import_dry_run(self):
         mock_spanner = MagicMock()
-        mock_spanner.get_import_version_history.return_value = ["v2", "v1"]
-        mock_spanner.get_import_latest_version.return_value = "gs://bucket/path/v2"
+        mock_spanner.get_import_version_history.return_value = [
+            "gs://bucket/path/v2/*/*.mcf", "gs://bucket/path/v1/*/*.mcf"
+        ]
 
         status, cur_ver, prev_ver = revert_import(mock_spanner, "foo:bar:imp1", "wf-123", dry_run=True)
 
         self.assertTrue(status)
-        self.assertEqual(cur_ver, "v2")
-        self.assertEqual(prev_ver, "v1")
+        self.assertEqual(cur_ver, "gs://bucket/path/v2/*/*.mcf")
+        self.assertEqual(prev_ver, "gs://bucket/path/v1/*/*.mcf")
         mock_spanner.revert_import_state.assert_not_called()
 
     def test_revert_import_no_history(self):
@@ -65,19 +66,20 @@ class TestRollbackHelper(unittest.TestCase):
 
     def test_revert_import_no_previous_version(self):
         mock_spanner = MagicMock()
-        mock_spanner.get_import_version_history.return_value = ["v1"]
+        mock_spanner.get_import_version_history.return_value = ["gs://bucket/path/v1/*/*.mcf"]
 
         status, cur_ver, prev_ver = revert_import(mock_spanner, "foo:bar:imp1", "wf-123")
 
         self.assertFalse(status)
-        self.assertEqual(cur_ver, "v1")
+        self.assertEqual(cur_ver, "gs://bucket/path/v1/*/*.mcf")
         self.assertIsNone(prev_ver)
         mock_spanner.revert_import_state.assert_not_called()
 
     def test_revert_imports_list(self):
         mock_spanner = MagicMock()
-        mock_spanner.get_import_version_history.side_effect = lambda name: ["v2", "v1"] if name == "imp1" else []
-        mock_spanner.get_import_latest_version.return_value = "gs://bucket/path/v2"
+        mock_spanner.get_import_version_history.side_effect = lambda name: [
+            "gs://bucket/path/v2/*/*.mcf", "gs://bucket/path/v1/*/*.mcf"
+        ] if name == "imp1" else []
         mock_spanner.revert_import_state.return_value = True
 
         results = revert_imports(mock_spanner, [{"importName": "imp1"}, "imp2"], "wf-123")
@@ -85,8 +87,8 @@ class TestRollbackHelper(unittest.TestCase):
         self.assertEqual(len(results), 2)
         self.assertTrue(results[0]["reverted"])
         self.assertEqual(results[0]["importName"], "imp1")
-        self.assertEqual(results[0]["failedVersion"], "v2")
-        self.assertEqual(results[0]["restoredVersion"], "v1")
+        self.assertEqual(results[0]["failedVersion"], "gs://bucket/path/v2/*/*.mcf")
+        self.assertEqual(results[0]["restoredVersion"], "gs://bucket/path/v1/*/*.mcf")
 
         self.assertFalse(results[1]["reverted"])
         self.assertEqual(results[1]["importName"], "imp2")

--- a/pipeline/workflow/spanner-ingestion-workflow.yaml
+++ b/pipeline/workflow/spanner-ingestion-workflow.yaml
@@ -172,17 +172,6 @@ run_aggregation_job:
         switch:
           - condition: ${import_list == null or len(import_list) == 0}
             return: 'SKIPPED'
-    - init_import_names:
-        assign:
-          - import_names: []
-    - loop_import_list:
-        for:
-          value: item
-          in: ${import_list}
-          steps:
-            - extract_import_name:
-                assign:
-                  - import_names: ${list.concat(import_names, item.importName)}
     - run_aggregation:
         call: googleapis.run.v2.projects.locations.jobs.run
         args:
@@ -192,7 +181,7 @@ run_aggregation_job:
               containerOverrides:
                 - args:
                     - "--import_list"
-                    - ${json.encode_to_string(import_names)}
+                    - ${json.encode_to_string(import_list)}
                     - "--no-dry_run"
                     - "--config_path"
                     - "aggregation/configs/base_dc/common.yaml"

--- a/pipeline/workflow/spanner_ingestion_test.py
+++ b/pipeline/workflow/spanner_ingestion_test.py
@@ -158,7 +158,7 @@ def main(argv):
                                                  import_workflow_args)
 
         # 2. Trigger Spanner Ingestion Workflow
-        ingestion_workflow_args = {"importList": [short_import_name]}
+        ingestion_workflow_args = {"importList": [{"importName": short_import_name}]}
 
         logging.info("Step 2: Running Spanner Ingestion Workflow...")
         cloud_workflow.trigger_workflow_and_wait(PROJECT_ID, LOCATION,


### PR DESCRIPTION
Currently, ingestion workflow takes a list of import names as an argument. It then fetches the latest version information from the spanner ImportStatus table. This PR allows passing an optional latest version path as an input argument for easy backfilling. For this, we make the import list argument support a JSON body (importName and latestVersion). This input path eliminates the need for a spanner look up via an override. As part of this, code is cleaned up to merge graphPath and latestVersion params into a single latestVersion parameter.  