### PR TITLE
Avoid logging the DC API key value

### DIFF
--- a/simple/util/dc_client.py
+++ b/simple/util/dc_client.py
@@ -73,7 +73,7 @@ def get_api_root():
 
 if _DEBUG:
   logging.info("DC API Root: %s", get_api_root())
-  logging.info("DC API Key: %s", get_api_key())
+  logging.info("DC API Key: %s", "<set>" if get_api_key() else "<not set>")
   os.makedirs(_DEBUG_FOLDER, exist_ok=True)
 
 


### PR DESCRIPTION
### What

`simple/util/dc_client.py` logs the value of the Data Commons API key:

```python
if _DEBUG:
  logging.info("DC API Root: %s", get_api_root())
  logging.info("DC API Key: %s", get_api_key())   # <-- logs the credential itself
```

This change logs whether the key is set rather than what it is, keeping the
diagnostic signal without writing the credential to the log sink.

### Why it matters beyond local debugging

`_DEBUG` is hardcoded to `True` (line 38), not driven by an environment variable, so
this runs on every invocation in every deployment — not only when someone is debugging
locally.

In a Cloud Run deployment the line lands in Cloud Logging, where it is readable by
anyone with `roles/logging.viewer` on the project. That is a much broader audience than
the principals granted `roles/secretmanager.secretAccessor` on the secret the key is
mounted from, so the key effectively escapes the access model it was set up with. Log
sinks and exports widen it further.

We hit this on a Data Commons Platform deployment: the key appears in full in the
preprocessing job logs on every ingestion run.

### Note on disclosure

We would have raised this privately, but this repository has no `SECURITY.md` and
private vulnerability reporting is not enabled, so there was no non-public channel to
use. Opening a separate issue to suggest adding one.
